### PR TITLE
Added stream interceptors for Open Tracing

### DIFF
--- a/controlplane/pkg/nsmd/nsmd_crossconnect_client.go
+++ b/controlplane/pkg/nsmd/nsmd_crossconnect_client.go
@@ -185,7 +185,13 @@ func (client *NsmMonitorCrossConnectClient) dataplaneCrossConnectMonitor(datapla
 
 func (client *NsmMonitorCrossConnectClient) remotePeerConnectionMonitor(remotePeer *registry.NetworkServiceManager, ctx context.Context) {
 	logrus.Infof("Connecting to Remote NSM: %s", remotePeer.Name)
-	conn, err := grpc.Dial(remotePeer.Url, grpc.WithInsecure())
+	tracer := opentracing.GlobalTracer()
+	conn, err := grpc.Dial(remotePeer.Url, grpc.WithInsecure(),
+		grpc.WithUnaryInterceptor(
+			otgrpc.OpenTracingClientInterceptor(tracer)),
+		grpc.WithStreamInterceptor(
+			otgrpc.OpenTracingStreamClientInterceptor(tracer)))
+
 	if err != nil {
 		logrus.Errorf("Failed to dial Network Service Registry %s at %s: %s", remotePeer.GetName(), remotePeer.Url, err)
 		return

--- a/examples/skydive/server/monitor-server.go
+++ b/examples/skydive/server/monitor-server.go
@@ -6,14 +6,18 @@ import (
 	"os/signal"
 	"syscall"
 
+	"github.com/grpc-ecosystem/grpc-opentracing/go/otgrpc"
 	"github.com/ligato/networkservicemesh/controlplane/pkg/apis/crossconnect"
-
 	"github.com/ligato/networkservicemesh/controlplane/pkg/monitor_crossconnect_server"
+	"github.com/ligato/networkservicemesh/pkg/tools"
 	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
 )
 
 func main() {
+	tracer, closer := tools.InitJaeger("skydive-server")
+	defer closer.Close()
+
 	// Capture signals to cleanup before exiting
 	c := make(chan os.Signal, 1)
 	signal.Notify(c,
@@ -29,7 +33,12 @@ func main() {
 	if err != nil {
 		logrus.Fatalf("Error listening on %s: %s", crossConnectAddress, err)
 	}
-	grpcServer := grpc.NewServer()
+	grpcServer := grpc.NewServer(
+		grpc.UnaryInterceptor(
+			otgrpc.OpenTracingServerInterceptor(tracer, otgrpc.LogPayloads())),
+		grpc.StreamInterceptor(
+			otgrpc.OpenTracingStreamServerInterceptor(tracer)))
+
 	crossconnect.RegisterMonitorCrossConnectServer(grpcServer, crossConnectServer)
 	go func() {
 		err := grpcServer.Serve(listener)


### PR DESCRIPTION
This PR adds more stream interceptors for Open Tracing, however, stream interceptors are almost useless:

gRPC stream interceptors control stream lifecycle (e.g. creation), so open tracing stream interceptor creates span on stream creation and finish span on stream close. Since we do not close streams, we see nothing regarding streams in Jaeger UI. 

Stream interceptors do not intercept traffic on the stream, so if we need to trace/log particular messages travelling on the stream we can do it manually with Open Tracing API (I added empty span creation on cross connect event in crossconnect_monitor.go)