### PR TITLE
Adapt kernel_interface_converter to work in envs where /dev/vhost-net is unavailable.

### DIFF
--- a/dataplane/vppagent/pkg/converter/kernel_connection_converter.go
+++ b/dataplane/vppagent/pkg/converter/kernel_connection_converter.go
@@ -2,11 +2,13 @@ package converter
 
 import (
 	"fmt"
-	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/local/connection"
+	"os"
+
 	linux_interfaces "github.com/ligato/vpp-agent/plugins/linux/model/interfaces"
 	"github.com/ligato/vpp-agent/plugins/linux/model/l3"
 	"github.com/ligato/vpp-agent/plugins/vpp/model/interfaces"
 	"github.com/ligato/vpp-agent/plugins/vpp/model/rpc"
+	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/local/connection"
 	"github.com/sirupsen/logrus"
 )
 
@@ -53,48 +55,89 @@ func (c *KernelConnectionConverter) ToDataRequest(rv *rpc.DataRequest, connect b
 
 	logrus.Infof("m.GetParameters()[%s]: %s", connection.InterfaceNameKey, m.GetParameters()[connection.InterfaceNameKey])
 
-	// We append an Interfaces.  Interfaces creates the vpp side of an interface.
-	//   In this case, a Tapv2 interface that has one side in vpp, and the other
-	//   as a Linux kernel interface
-	// Important details:
-	//       Interfaces.HostIfName - This is the linux interface name given
-	//          to the Linux side of the TAP.  If you wish to apply additional
-	//          config like an Ip address, you should make this a random
-	//          tmpIface name, and it *must* match the LinuxIntefaces.Tap.TempIfName
-	//       Interfaces.Tap.Namespace - do not set this, due to a bug in vppagent
-	//          LinuxInterfaces can only be applied if vppagent finds the
-	//          interface in vppagent's netns.  So leave it there in the Interfaces
-	//          The interface name may be no longer than 15 chars (Linux limitation)
-	rv.Interfaces = append(rv.Interfaces, &interfaces.Interfaces_Interface{
-		Name:    c.conversionParameters.Name,
-		Type:    interfaces.InterfaceType_TAP_INTERFACE,
-		Enabled: true,
-		Tap: &interfaces.Interfaces_Interface_Tap{
-			Version:    2,
-			HostIfName: tmpIface,
-		},
-	})
+	// If we have access to /dev/vhost-net, we can use tapv2.  Otherwise fall back to
+	// veth pairs
+	if _, err := os.Stat("/dev/vhost-net"); err == nil {
+		// We append an Interfaces.  Interfaces creates the vpp side of an interface.
+		//   In this case, a Tapv2 interface that has one side in vpp, and the other
+		//   as a Linux kernel interface
+		// Important details:
+		//       Interfaces.HostIfName - This is the linux interface name given
+		//          to the Linux side of the TAP.  If you wish to apply additional
+		//          config like an Ip address, you should make this a random
+		//          tmpIface name, and it *must* match the LinuxIntefaces.Tap.TempIfName
+		//       Interfaces.Tap.Namespace - do not set this, due to a bug in vppagent
+		//          LinuxInterfaces can only be applied if vppagent finds the
+		//          interface in vppagent's netns.  So leave it there in the Interfaces
+		//          The interface name may be no longer than 15 chars (Linux limitation)
+		rv.Interfaces = append(rv.Interfaces, &interfaces.Interfaces_Interface{
+			Name:    c.conversionParameters.Name,
+			Type:    interfaces.InterfaceType_TAP_INTERFACE,
+			Enabled: true,
+			Tap: &interfaces.Interfaces_Interface_Tap{
+				Version:    2,
+				HostIfName: tmpIface,
+			},
+		})
+		logrus.Info("Found /dev/vhost-net - using tapv2")
+		// We apply configuration to LinuxInterfaces
+		// Important details:
+		//    - If you have created a TAP, LinuxInterfaces.Tap.TempIfName must match
+		//      Interfaces.Tap.HostIfName from above
+		//    - LinuxInterfaces.HostIfName - must be no longer than 15 chars (linux limitation)
+		rv.LinuxInterfaces = append(rv.LinuxInterfaces, &linux_interfaces.LinuxInterfaces_Interface{
+			Name:        c.conversionParameters.Name,
+			Type:        linux_interfaces.LinuxInterfaces_AUTO_TAP,
+			Enabled:     true,
+			Description: m.GetParameters()[connection.InterfaceDescriptionKey],
+			IpAddresses: ipAddresses,
+			HostIfName:  m.GetParameters()[connection.InterfaceNameKey],
+			Namespace: &linux_interfaces.LinuxInterfaces_Interface_Namespace{
+				Type:     linux_interfaces.LinuxInterfaces_Interface_Namespace_FILE_REF_NS,
+				Filepath: filepath,
+			},
+			Tap: &linux_interfaces.LinuxInterfaces_Interface_Tap{
+				TempIfName: tmpIface,
+			},
+		})
+	} else {
+		logrus.Info("Did Not Find /dev/vhost-net - using veth pairs")
+		rv.LinuxInterfaces = append(rv.LinuxInterfaces, &linux_interfaces.LinuxInterfaces_Interface{
+			Name:        tmpIface,
+			Type:        linux_interfaces.LinuxInterfaces_VETH,
+			Enabled:     true,
+			Description: m.GetParameters()[connection.InterfaceDescriptionKey],
+			IpAddresses: ipAddresses,
+			HostIfName:  tmpIface,
+			Veth: &linux_interfaces.LinuxInterfaces_Interface_Veth{
+				PeerIfName: m.GetParameters()[connection.InterfaceNameKey],
+			},
+		})
+		rv.LinuxInterfaces = append(rv.LinuxInterfaces, &linux_interfaces.LinuxInterfaces_Interface{
+			Name:        c.conversionParameters.Name,
+			Type:        linux_interfaces.LinuxInterfaces_VETH,
+			Enabled:     true,
+			Description: m.GetParameters()[connection.InterfaceDescriptionKey],
+			IpAddresses: ipAddresses,
+			HostIfName:  m.GetParameters()[connection.InterfaceNameKey],
+			Namespace: &linux_interfaces.LinuxInterfaces_Interface_Namespace{
+				Type:     linux_interfaces.LinuxInterfaces_Interface_Namespace_FILE_REF_NS,
+				Filepath: filepath,
+			},
+			Veth: &linux_interfaces.LinuxInterfaces_Interface_Veth{
+				PeerIfName: tmpIface,
+			},
+		})
+		rv.Interfaces = append(rv.Interfaces, &interfaces.Interfaces_Interface{
+			Name:    c.conversionParameters.Name,
+			Type:    interfaces.InterfaceType_AF_PACKET_INTERFACE,
+			Enabled: true,
+			Afpacket: &interfaces.Interfaces_Interface_Afpacket{
+				HostIfName: tmpIface,
+			},
+		})
 
-	// We apply configuration to LinuxInterfaces
-	// Important details:
-	//    - If you have created a TAP, LinuxInterfaces.Tap.TempIfName must match
-	//      Interfaces.Tap.HostIfName from above
-	//    - LinuxInterfaces.HostIfName - must be no longer than 15 chars (linux limitation)
-	rv.LinuxInterfaces = append(rv.LinuxInterfaces, &linux_interfaces.LinuxInterfaces_Interface{
-		Name:        c.conversionParameters.Name,
-		Type:        linux_interfaces.LinuxInterfaces_AUTO_TAP,
-		Enabled:     true,
-		Description: m.GetParameters()[connection.InterfaceDescriptionKey],
-		IpAddresses: ipAddresses, // TODO - this is wrong... need to use Dst or Src key selectively
-		HostIfName:  m.GetParameters()[connection.InterfaceNameKey],
-		Namespace: &linux_interfaces.LinuxInterfaces_Interface_Namespace{
-			Type:     linux_interfaces.LinuxInterfaces_Interface_Namespace_FILE_REF_NS,
-			Filepath: filepath,
-		},
-		Tap: &linux_interfaces.LinuxInterfaces_Interface_Tap{
-			TempIfName: tmpIface,
-		},
-	})
+	}
 
 	// Process static routes
 	if c.conversionParameters.Side == SOURCE {


### PR DESCRIPTION
GKE does not in its stock images have /dev/vhost-net available.
To get around this, we fall back to the slower veth pairs + AF_PACKET approach.