### PR TITLE
Implement NSMD check for NSE troubles and initial Auto healing operation

### DIFF
--- a/controlplane/cmd/nsmd/nsmd.go
+++ b/controlplane/cmd/nsmd/nsmd.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/nsm"
 	"os"
 	"os/signal"
 	"sync"
@@ -30,12 +31,14 @@ func main() {
 		os.Exit(1)
 	}
 
-	if err := nsmd.StartNSMServer(model, serviceRegistry, apiRegistry); err != nil {
+	manager := nsm.NewNetworkServiceManager(model, serviceRegistry, nsmd.GetExcludedPrefixes())
+
+	if err := nsmd.StartNSMServer(model, manager, serviceRegistry, apiRegistry); err != nil {
 		logrus.Fatalf("Error starting nsmd service: %+v", err)
 		os.Exit(1)
 	}
 
-	if err := nsmd.StartAPIServer(model, apiRegistry, serviceRegistry); err != nil {
+	if err := nsmd.StartAPIServer(model, manager, apiRegistry, serviceRegistry); err != nil {
 		logrus.Fatalf("Error starting nsmd api service: %+v", err)
 		os.Exit(1)
 	}

--- a/controlplane/pkg/apis/local/connection/helpers.go
+++ b/controlplane/pkg/apis/local/connection/helpers.go
@@ -33,6 +33,9 @@ func (c *Connection) UpdateContext(newContext *connectioncontext.ConnectionConte
 	}
 	return c.GetContext().MeetsRequirements(oldCtx)
 }
+func (c *Connection) SetContext(newContext *connectioncontext.ConnectionContext) {
+	c.Context = newContext
+}
 
 func (c *Connection) IsComplete() error {
 	if err := c.IsValid(); err != nil {
@@ -83,4 +86,16 @@ func (m *Mechanism) IsValid() error {
 		}
 	}
 	return nil
+}
+
+func (c *Connection) SetId(id string) {
+	c.Id = id
+}
+func (c *Connection) GetNetworkServiceEndpointName() string {
+	// Local Connection does't have endpoint name.
+	return ""
+}
+
+func (c *Connection) SetNetworkServiceName(networkService string) {
+	c.NetworkService = networkService
 }

--- a/controlplane/pkg/apis/local/networkservice/helpers.go
+++ b/controlplane/pkg/apis/local/networkservice/helpers.go
@@ -1,6 +1,8 @@
 package networkservice
 
-import fmt "fmt"
+import (
+	"fmt"
+)
 
 func (ns *NetworkServiceRequest) IsValid() error {
 	if ns == nil {
@@ -22,4 +24,7 @@ func (ns *NetworkServiceRequest) IsValid() error {
 		return fmt.Errorf("NetworkServiceRequest.MechanismPreferences must have at least one entry: %v", ns)
 	}
 	return nil
+}
+func (ns *NetworkServiceRequest) IsRemote() bool {
+	return false
 }

--- a/controlplane/pkg/apis/nsm/nsm.go
+++ b/controlplane/pkg/apis/nsm/nsm.go
@@ -1,0 +1,46 @@
+package nsm
+
+import (
+	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/connectioncontext"
+	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/model"
+	"golang.org/x/net/context"
+)
+
+type NSMRequest interface {
+	IsValid() error
+	IsRemote() bool
+}
+type NSMConnection interface {
+	IsValid() error
+	SetId(id string)
+	GetNetworkService() string
+	GetContext() *connectioncontext.ConnectionContext
+	UpdateContext(connectionContext *connectioncontext.ConnectionContext) error
+	SetContext(connectionContext *connectioncontext.ConnectionContext)
+	GetId() string
+	IsComplete() error
+	GetLabels() map[string]string
+	GetNetworkServiceEndpointName() string
+	SetNetworkServiceName(service string)
+}
+
+type NetworkServiceClient interface {
+	Request(ctx context.Context, request NSMRequest) (NSMConnection, error)
+	Close(ctx context.Context, connection NSMConnection) error
+
+	Cleanup() error
+}
+
+type HealState int32
+
+const (
+	HealState_DstDown       HealState = 1
+	HealState_SrcDown       HealState = 2
+	HealState_DataplaneDown HealState = 3
+)
+
+type NetworkServiceManager interface {
+	Request(ctx context.Context, request NSMRequest, extra_parameters map[string]string) (NSMConnection, error)
+	Close(ctx context.Context, connection NSMConnection) error
+	Heal(connection *model.ClientConnection, healState HealState)
+}

--- a/controlplane/pkg/apis/nsm/nsm.go
+++ b/controlplane/pkg/apis/nsm/nsm.go
@@ -41,6 +41,6 @@ const (
 
 type NetworkServiceManager interface {
 	Request(ctx context.Context, request NSMRequest, extra_parameters map[string]string) (NSMConnection, error)
-	Close(ctx context.Context, connection NSMConnection) error
+	Close(ctx context.Context, clientConnection *model.ClientConnection) error
 	Heal(connection *model.ClientConnection, healState HealState)
 }

--- a/controlplane/pkg/apis/remote/connection/helpers.go
+++ b/controlplane/pkg/apis/remote/connection/helpers.go
@@ -50,6 +50,10 @@ func (c *Connection) UpdateContext(newContext *connectioncontext.ConnectionConte
 	return c.GetContext().MeetsRequirements(oldCtx)
 }
 
+func (c *Connection) SetContext(newContext *connectioncontext.ConnectionContext) {
+	c.Context = newContext
+}
+
 // IsComplete - Have I been told enough to actually give you what you asked for
 func (c *Connection) IsComplete() error {
 	if err := c.IsValid(); err != nil {
@@ -144,4 +148,12 @@ func (m *Mechanism) VNI() (uint32, error) {
 	}
 
 	return uint32(vni), nil
+}
+
+func (c *Connection) SetId(id string) {
+	c.Id = id
+}
+
+func (c *Connection) SetNetworkServiceName(networkService string) {
+	c.NetworkService = networkService
 }

--- a/controlplane/pkg/apis/remote/networkservice/helpers.go
+++ b/controlplane/pkg/apis/remote/networkservice/helpers.go
@@ -23,3 +23,7 @@ func (ns *NetworkServiceRequest) IsValid() error {
 	}
 	return nil
 }
+
+func (ns *NetworkServiceRequest) IsRemote() bool {
+	return true
+}

--- a/controlplane/pkg/model/model.go
+++ b/controlplane/pkg/model/model.go
@@ -76,7 +76,7 @@ type Model interface {
 	GetClientConnection(connectionId string) *ClientConnection
 	GetAllClientConnections() []*ClientConnection
 	UpdateClientConnection(clientConnection *ClientConnection)
-	DeleteClientConnection(connectionId string) *ClientConnection
+	DeleteClientConnection(connectionId string)
 
 	ConnectionId() string
 
@@ -141,12 +141,11 @@ func (i *impl) UpdateClientConnection(clientConnection *ClientConnection) {
 	}
 }
 
-func (i *impl) DeleteClientConnection(connectionId string) *ClientConnection {
+func (i *impl) DeleteClientConnection(connectionId string) {
 	i.Lock()
 	clientConnection := i.clientConnections[connectionId]
 	if clientConnection == nil {
 		i.Unlock()
-		return nil
 	}
 	delete(i.clientConnections, connectionId)
 	i.Unlock()
@@ -154,7 +153,6 @@ func (i *impl) DeleteClientConnection(connectionId string) *ClientConnection {
 	for _, listener := range i.listeners {
 		listener.ClientConnectionDeleted(clientConnection)
 	}
-	return clientConnection
 }
 
 func (i *impl) AddListener(listener ModelListener) {

--- a/controlplane/pkg/model/model.go
+++ b/controlplane/pkg/model/model.go
@@ -76,7 +76,7 @@ type Model interface {
 	GetClientConnection(connectionId string) *ClientConnection
 	GetAllClientConnections() []*ClientConnection
 	UpdateClientConnection(clientConnection *ClientConnection)
-	DeleteClientConnection(connectionId string)
+	DeleteClientConnection(connectionId string) *ClientConnection
 
 	ConnectionId() string
 
@@ -141,12 +141,12 @@ func (i *impl) UpdateClientConnection(clientConnection *ClientConnection) {
 	}
 }
 
-func (i *impl) DeleteClientConnection(connectionId string) {
+func (i *impl) DeleteClientConnection(connectionId string) *ClientConnection {
 	i.Lock()
 	clientConnection := i.clientConnections[connectionId]
 	if clientConnection == nil {
 		i.Unlock()
-		return
+		return nil
 	}
 	delete(i.clientConnections, connectionId)
 	i.Unlock()
@@ -154,6 +154,7 @@ func (i *impl) DeleteClientConnection(connectionId string) {
 	for _, listener := range i.listeners {
 		listener.ClientConnectionDeleted(clientConnection)
 	}
+	return clientConnection
 }
 
 func (i *impl) AddListener(listener ModelListener) {

--- a/controlplane/pkg/nsm/endpoint_client.go
+++ b/controlplane/pkg/nsm/endpoint_client.go
@@ -30,13 +30,14 @@ func (c *endpointClient) Cleanup() error {
 		err = c.connection.Close()
 	}
 	c.connection = nil
+	c.client = nil
 	return err
 }
 func (c *endpointClient) Close(ctx context.Context, conn nsm.NSMConnection) error {
-	if c.connection == nil {
+	if c.client == nil {
 		return fmt.Errorf("Remote NSM Connection is already cleaned...")
 	}
 	_, err := c.client.Close(ctx, conn.(*connection.Connection))
-	c.connection = nil
+	_ = c.Cleanup()
 	return err
 }

--- a/controlplane/pkg/nsm/endpoint_client.go
+++ b/controlplane/pkg/nsm/endpoint_client.go
@@ -1,0 +1,42 @@
+package nsm
+
+import (
+	"fmt"
+	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/local/connection"
+	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/local/networkservice"
+	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/nsm"
+	"golang.org/x/net/context"
+	"google.golang.org/grpc"
+)
+
+//// Endpoint Connection Client
+type endpointClient struct {
+	client     networkservice.NetworkServiceClient
+	connection *grpc.ClientConn
+}
+
+func (c *endpointClient) Request(ctx context.Context, request nsm.NSMRequest) (nsm.NSMConnection, error) {
+	if c == nil || c.client == nil {
+		return nil, fmt.Errorf("NSE Connection is not initialized...")
+	}
+	return c.client.Request(ctx, request.(*networkservice.NetworkServiceRequest))
+}
+func (c *endpointClient) Cleanup() error {
+	if c == nil || c.client == nil {
+		return fmt.Errorf("NSE Connection is not initialized...")
+	}
+	var err error
+	if c.connection != nil { // Required for testing
+		err = c.connection.Close()
+	}
+	c.connection = nil
+	return err
+}
+func (c *endpointClient) Close(ctx context.Context, conn nsm.NSMConnection) error {
+	if c.connection == nil {
+		return fmt.Errorf("Remote NSM Connection is already cleaned...")
+	}
+	_, err := c.client.Close(ctx, conn.(*connection.Connection))
+	c.connection = nil
+	return err
+}

--- a/controlplane/pkg/nsm/nse_requests.go
+++ b/controlplane/pkg/nsm/nse_requests.go
@@ -1,0 +1,56 @@
+package nsm
+
+import (
+	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/local/connection"
+	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/local/networkservice"
+	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/nsm"
+	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/registry"
+	remote_connection "github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/remote/connection"
+	remote_networkservice "github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/remote/networkservice"
+	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/model"
+)
+
+func (srv *networkServiceManager) createRemoteNSMRequest(endpoint *registry.NSERegistration, requestConnection nsm.NSMConnection, dataplane *model.Dataplane) *remote_networkservice.NetworkServiceRequest {
+	// We need to obtain parameters for remote mechanism
+	remoteM := []*remote_connection.Mechanism{}
+	for _, mechanism := range dataplane.RemoteMechanisms {
+		remoteM = append(remoteM, mechanism)
+	}
+	message := &remote_networkservice.NetworkServiceRequest{
+		Connection: &remote_connection.Connection{
+			// TODO track connection ids
+			Id:                                   srv.createConnectionId(),
+			NetworkService:                       requestConnection.GetNetworkService(),
+			Context:                              requestConnection.GetContext(),
+			Labels:                               requestConnection.GetLabels(),
+			DestinationNetworkServiceManagerName: endpoint.GetNetworkServiceManager().GetName(),
+			SourceNetworkServiceManagerName:      srv.getNetworkServiceManagerName(),
+			NetworkServiceEndpointName:           endpoint.GetNetworkserviceEndpoint().GetEndpointName(),
+		},
+		MechanismPreferences: remoteM,
+	}
+	return message
+}
+
+func (srv *networkServiceManager) createLocalNSERequest(endpoint *registry.NSERegistration, requestConnection nsm.NSMConnection) *networkservice.NetworkServiceRequest {
+
+	message := &networkservice.NetworkServiceRequest{
+		Connection: &connection.Connection{
+			Id:             srv.createConnectionId(),
+			NetworkService: endpoint.GetNetworkService().GetName(),
+			Context:        requestConnection.GetContext(),
+			Labels:         nil,
+		},
+		MechanismPreferences: []*connection.Mechanism{
+			{
+				Type:       connection.MechanismType_MEM_INTERFACE,
+				Parameters: map[string]string{},
+			},
+			{
+				Type:       connection.MechanismType_KERNEL_INTERFACE,
+				Parameters: map[string]string{},
+			},
+		},
+	}
+	return message
+}

--- a/controlplane/pkg/nsm/nsm.go
+++ b/controlplane/pkg/nsm/nsm.go
@@ -1,0 +1,411 @@
+// Copyright (c) 2018 Cisco and/or its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package nsm
+
+import (
+	"fmt"
+	"github.com/golang/protobuf/proto"
+	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/connectioncontext"
+	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/crossconnect"
+	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/local/connection"
+	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/local/networkservice"
+	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/nsm"
+	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/registry"
+	remote_connection "github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/remote/connection"
+	remote_networkservice "github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/remote/networkservice"
+	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/model"
+	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/nsmd"
+	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/serviceregistry"
+	"github.com/sirupsen/logrus"
+	"golang.org/x/net/context"
+)
+
+///// Network service manager to manage both local/remote NSE connections.
+type networkServiceManager struct {
+	serviceRegistry   serviceregistry.ServiceRegistry
+	model             model.Model
+	excluded_prefixes []string
+}
+
+func NewNetworkServiceManager(model model.Model, serviceRegistry serviceregistry.ServiceRegistry, excluded_prefixes []string) nsm.NetworkServiceManager {
+	return &networkServiceManager{
+		serviceRegistry:   serviceRegistry,
+		model:             model,
+		excluded_prefixes: excluded_prefixes,
+	}
+}
+
+func (srv *networkServiceManager) Request(ctx context.Context, request nsm.NSMRequest, extra_parameters map[string]string) (nsm.NSMConnection, error) {
+	// Make sure its a valid request
+	err := request.IsValid()
+	if err != nil {
+		logrus.Error(err)
+		return nil, err
+	}
+
+	var nsmConnection nsm.NSMConnection = nil
+	nsmConnection = srv.cloneConnection(request, nsmConnection)
+
+	// Create a ConnectId for the request.GetConnection(), since connections are managed per NSM
+	nsmConnection.SetId(srv.createConnectionId())
+
+	// get dataplane
+	dp, err := srv.model.SelectDataplane()
+	if err != nil {
+		return nil, err
+	}
+
+	err = srv.updateMechanism(nsmConnection, request, dp, extra_parameters)
+	if err != nil {
+		return nil, err
+	}
+
+	logrus.Infof("Preparing to program dataplane: %v...", dp)
+	dataplaneClient, dataplaneConn, err := srv.serviceRegistry.DataplaneConnection(dp)
+	if err != nil {
+		return nil, err
+	}
+	if dataplaneConn != nil { // Required for testing
+		defer func() {
+			err := dataplaneConn.Close()
+			if err != nil {
+				logrus.Errorf("Error during close Dataplane connection: %v", err)
+			}
+		}()
+	}
+
+	ignore_endpoints := map[string]*registry.NSERegistration{}
+
+	var clientConnection *model.ClientConnection
+	var last_error error
+	var endpoint *registry.NSERegistration
+	for {
+		// Clone Connection to support iteration via EndPoints
+		nseConnection := srv.cloneConnection(request, nsmConnection)
+
+		endpoint, err = srv.getEndpoint(ctx, nseConnection, ignore_endpoints)
+		if err != nil {
+			if last_error != nil {
+				return nil, fmt.Errorf("%v. Last NSE Error: %v", err, last_error)
+			}
+			return nil, err
+		}
+		// Update Request with exclude_prefixes
+		srv.updateExcludePrefixes(nseConnection)
+		clientConnection, err = srv.performNSERequest(request, endpoint, ctx, nseConnection, dp)
+
+		if err != nil {
+			logrus.Errorf("NSE respond with error: %v ", err)
+			last_error = err
+			ignore_endpoints[endpoint.NetworkserviceEndpoint.EndpointName] = endpoint
+			continue
+		}
+		break
+	}
+
+	logrus.Infof("Sending request to dataplane: %v", clientConnection.Xcon)
+	clientConnection.Xcon, err = dataplaneClient.Request(ctx, clientConnection.Xcon)
+	if err != nil {
+		logrus.Errorf("Dataplane request failed: %s", err)
+		return nil, err
+	}
+	srv.model.AddClientConnection(clientConnection)
+	if request.IsRemote() {
+		nsmConnection = clientConnection.Xcon.GetSource().(*crossconnect.CrossConnect_RemoteSource).RemoteSource
+	} else {
+		nsmConnection = clientConnection.Xcon.GetSource().(*crossconnect.CrossConnect_LocalSource).LocalSource
+	}
+	logrus.Info("Dataplane configuration done...")
+	return nsmConnection, nil
+}
+
+func (srv *networkServiceManager) cloneConnection(request nsm.NSMRequest, response nsm.NSMConnection) nsm.NSMConnection {
+	var requestConnection nsm.NSMConnection
+	if request.IsRemote() {
+		if response == nil {
+			requestConnection = proto.Clone(request.(*remote_networkservice.NetworkServiceRequest).Connection).(*remote_connection.Connection)
+		} else {
+			requestConnection = proto.Clone(response.(*remote_connection.Connection)).(*remote_connection.Connection)
+		}
+	} else {
+		if response == nil {
+			requestConnection = proto.Clone(request.(*networkservice.NetworkServiceRequest).Connection).(*connection.Connection)
+		} else {
+			requestConnection = proto.Clone(response.(*connection.Connection)).(*connection.Connection)
+		}
+	}
+	return requestConnection
+}
+
+func (srv *networkServiceManager) Close(ctx context.Context, connection nsm.NSMConnection) error {
+	logrus.Infof("Closing connection %s", connection.GetId())
+	clientConnection := srv.model.DeleteClientConnection(connection.GetId())
+	if clientConnection == nil {
+		return fmt.Errorf("No connection with id: %s, nothing to close", connection.GetId())
+	}
+	var nseClientError error
+	var nseCloseError error
+
+	client, nseClientError := srv.createNSEClient(clientConnection.Endpoint)
+
+	if client != nil {
+		defer func() {
+			err := client.Cleanup()
+			if err != nil {
+				logrus.Errorf("Error during Cleanup: %v", err)
+			}
+		}()
+		ld := clientConnection.Xcon.GetLocalDestination()
+		if ld != nil {
+			nseCloseError = client.Close(ctx, ld)
+		}
+		rd := clientConnection.Xcon.GetRemoteDestination()
+		if rd != nil {
+			nseCloseError = client.Close(ctx, rd)
+		}
+	} else {
+		logrus.Errorf("Failed to create NSE Client %v", nseClientError)
+	}
+
+	dpCloseError := srv.closeDataplane(clientConnection)
+	if nseClientError != nil || nseCloseError != nil || dpCloseError != nil {
+		return fmt.Errorf("Close error: %v", []error{ nseClientError, nseCloseError, dpCloseError})
+	}
+	return nil
+}
+
+func (srv *networkServiceManager) CreateNSERequest(endpoint *registry.NSERegistration, requestConnection nsm.NSMConnection, dataplane *model.Dataplane) nsm.NSMRequest {
+	if srv.isLocalEndpoint(endpoint) {
+		message := srv.createLocalNSERequest(endpoint, requestConnection)
+		return message
+	} else {
+		message := srv.createRemoteNSMRequest(endpoint, requestConnection, dataplane)
+		return message
+	}
+}
+
+func (srv *networkServiceManager) isLocalEndpoint(endpoint *registry.NSERegistration) bool {
+	return srv.getNetworkServiceManagerName() == endpoint.GetNetworkServiceManager().GetName()
+}
+
+func (srv *networkServiceManager) createNSEClient(endpoint *registry.NSERegistration) (nsm.NetworkServiceClient, error) {
+	if srv.isLocalEndpoint(endpoint) {
+		client, conn, err := srv.serviceRegistry.EndpointConnection(endpoint)
+		if err != nil {
+			return nil, err
+		}
+		return &endpointClient{connection: conn, client: client}, nil
+	} else {
+		client, conn, err := srv.serviceRegistry.RemoteNetworkServiceClient(endpoint.GetNetworkServiceManager())
+		if err != nil {
+			return nil, err
+		}
+		return &nsmClient{client: client, connection: conn}, nil
+	}
+}
+
+func (srv *networkServiceManager) performNSERequest(request nsm.NSMRequest, endpoint *registry.NSERegistration, ctx context.Context, requestConnection nsm.NSMConnection, dp *model.Dataplane) (*model.ClientConnection, error) {
+	client, err := srv.createNSEClient(endpoint)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		err := client.Cleanup()
+		if err != nil {
+			logrus.Errorf("Error during Cleanup: %v", err)
+		}
+	}()
+
+	message := srv.CreateNSERequest(endpoint, requestConnection, dp)
+	nseConnection, e := client.Request(ctx, message)
+
+	if e != nil {
+		logrus.Errorf("error requesting networkservice from %+v with message %#v error: %s", endpoint, message, e)
+		return nil, e
+	}
+
+	err = srv.validateNSEConnection(nseConnection)
+	if err != nil {
+		return nil, err
+	}
+
+	err = requestConnection.UpdateContext(nseConnection.GetContext())
+	if err != nil {
+		err = fmt.Errorf("failure Validating NSE Connection: %s", err)
+		return nil, err
+	}
+	srv.updateConnectionParameters(nseConnection, endpoint)
+
+	dpApiConnection := srv.createCrossConnect(requestConnection, endpoint, request, nseConnection)
+	clientConnection := &model.ClientConnection{
+		ConnectionId: requestConnection.GetId(),
+		Xcon:         dpApiConnection,
+		Endpoint:     endpoint,
+		Dataplane:    dp,
+	}
+	return clientConnection, nil
+}
+
+func (srv *networkServiceManager) createCrossConnect(requestConnection nsm.NSMConnection, endpoint *registry.NSERegistration, request nsm.NSMRequest, nseConnection nsm.NSMConnection) *crossconnect.CrossConnect {
+	dpApiConnection := &crossconnect.CrossConnect{
+		Id:      requestConnection.GetId(),
+		Payload: endpoint.GetNetworkService().GetPayload(),
+	}
+
+	// We handling request from remote NSM
+	if request.IsRemote() {
+		dpApiConnection.Source = &crossconnect.CrossConnect_RemoteSource{
+			RemoteSource: requestConnection.(*remote_connection.Connection),
+		}
+	} else {
+		dpApiConnection.Source = &crossconnect.CrossConnect_LocalSource{
+			LocalSource: requestConnection.(*connection.Connection),
+		}
+	}
+
+	// We handling request from local or remote endpoint.
+	//TODO: in case of remote NSE( different cluster case, this method should be changed)
+	if !srv.isLocalEndpoint(endpoint) {
+		dpApiConnection.Destination = &crossconnect.CrossConnect_RemoteDestination{
+			RemoteDestination: nseConnection.(*remote_connection.Connection),
+		}
+	} else {
+		dpApiConnection.Destination = &crossconnect.CrossConnect_LocalDestination{
+			LocalDestination: nseConnection.(*connection.Connection),
+		}
+	}
+	return dpApiConnection
+}
+func (srv *networkServiceManager) validateNSEConnection(nseConnection nsm.NSMConnection) error {
+	err := nseConnection.IsComplete()
+	if err != nil {
+		err = fmt.Errorf("failure Validating NSE Connection: %s", err)
+		return err
+	}
+	return nil
+}
+
+func (srv *networkServiceManager) createConnectionId() string {
+	return srv.model.ConnectionId()
+}
+
+func (srv *networkServiceManager) closeDataplane(clientConnection *model.ClientConnection) error {
+	logrus.Info("Closing cross connection on dataplane...")
+	dataplaneClient, conn, err := srv.serviceRegistry.DataplaneConnection(clientConnection.Dataplane)
+	if err != nil {
+		logrus.Error(err)
+		return err
+	}
+	if conn != nil {
+		defer conn.Close()
+	}
+	if _, err := dataplaneClient.Close(context.Background(), clientConnection.Xcon); err != nil {
+		logrus.Error(err)
+		return err
+	}
+	logrus.Info("Cross connection successfully closed on dataplane")
+	return nil
+}
+
+func (srv *networkServiceManager) getNetworkServiceManagerName() string {
+	return srv.model.GetNsm().GetName()
+}
+
+func (srv *networkServiceManager) updateConnectionParameters(nseConnection nsm.NSMConnection, endpoint *registry.NSERegistration) {
+	if srv.getNetworkServiceManagerName() == endpoint.GetNetworkserviceEndpoint().GetEndpointName() {
+		workspace := nsmd.WorkSpaceRegistry().WorkspaceByEndpoint(endpoint.GetNetworkserviceEndpoint())
+		if workspace != nil { // In case of tests this could be empty
+			nseConnection.(*connection.Connection).GetMechanism().GetParameters()[connection.Workspace] = workspace.Name()
+		}
+	}
+}
+
+func (srv *networkServiceManager) updateExcludePrefixes(requestConnection nsm.NSMConnection) {
+	c := requestConnection.GetContext()
+	if c == nil {
+		c = &connectioncontext.ConnectionContext{}
+	}
+	for _, ep := range srv.excluded_prefixes {
+		c.ExcludedPrefixes = append(c.ExcludedPrefixes, ep)
+	}
+	// Since we do not worry about validation, just
+	requestConnection.SetContext(c)
+}
+
+func (srv *networkServiceManager) getEndpoint(ctx context.Context, requestConnection nsm.NSMConnection, ignore_endpoints map[string]*registry.NSERegistration) (*registry.NSERegistration, error) {
+
+	// Handle case we are remote NSM and asked for particular endpoint to connect to.
+	targetEndpoint := requestConnection.GetNetworkServiceEndpointName()
+	if len(targetEndpoint) > 0 {
+		endpoint := srv.model.GetEndpoint(targetEndpoint)
+		if endpoint != nil && ignore_endpoints[endpoint.NetworkserviceEndpoint.EndpointName] == nil {
+			return endpoint, nil
+		} else {
+			return nil, fmt.Errorf("Could not find endpoint with name: %s at local registry", targetEndpoint)
+		}
+	}
+
+	// Get endpoints, do it every time since we do not know if list are changed or not.
+	discoveryClient, err := srv.serviceRegistry.NetworkServiceDiscovery()
+	if err != nil {
+		logrus.Error(err)
+		return nil, err
+	}
+	nseRequest := &registry.FindNetworkServiceRequest{
+		NetworkServiceName: requestConnection.GetNetworkService(),
+	}
+	endpointResponse, err := discoveryClient.FindNetworkService(ctx, nseRequest)
+	if err != nil {
+		logrus.Error(err)
+		return nil, err
+	}
+	endpoints := srv.filterEndpoints(endpointResponse.GetNetworkServiceEndpoints(), ignore_endpoints)
+
+	if len(endpoints) == 0 {
+		return nil, fmt.Errorf("Failed to find NSE for NetworkService %s. Checked: %d of total NSEs: %d",
+			requestConnection.GetNetworkService(), len(ignore_endpoints), len(endpoints))
+	}
+
+	endpoint := srv.model.GetSelector().SelectEndpoint(requestConnection.(*connection.Connection), endpointResponse.GetNetworkService(), endpoints)
+	if endpoint == nil {
+		return nil, err
+	}
+	return &registry.NSERegistration{
+		NetworkServiceManager:  endpointResponse.GetNetworkServiceManagers()[endpoint.GetNetworkServiceManagerName()],
+		NetworkserviceEndpoint: endpoint,
+		NetworkService:         endpointResponse.GetNetworkService(),
+	}, nil
+}
+
+func (srv *networkServiceManager) filterEndpoints(endpoints []*registry.NetworkServiceEndpoint, ignore_endpoints map[string]*registry.NSERegistration) []*registry.NetworkServiceEndpoint {
+	result := []*registry.NetworkServiceEndpoint{}
+	// Do filter of endpoints
+	for _, candidate := range endpoints {
+		if ignore_endpoints[candidate.GetEndpointName()] == nil {
+			result = append(result, candidate)
+		}
+	}
+	return result
+}
+
+func (srv *networkServiceManager) filterRegEndpoints(endpoints []*registry.NSERegistration, ignore_endpoints map[string]*registry.NSERegistration) []*registry.NSERegistration {
+	result := []*registry.NSERegistration{}
+	// Do filter of endpoints
+	for _, candidate := range endpoints {
+		if ignore_endpoints[candidate.GetNetworkserviceEndpoint().GetEndpointName()] == nil {
+			result = append(result, candidate)
+		}
+	}
+	return result
+}

--- a/controlplane/pkg/nsm/nsm_heal.go
+++ b/controlplane/pkg/nsm/nsm_heal.go
@@ -14,7 +14,6 @@ func (srv *networkServiceManager) Heal(clientConnection *model.ClientConnection,
 		//means that we already invoke closing of remotes, nothing to do here
 		return
 	}
-	clientConnection.IsClosing = true
 
 	switch healState {
 	case nsm.HealState_DstDown:
@@ -24,13 +23,8 @@ func (srv *networkServiceManager) Heal(clientConnection *model.ClientConnection,
 		// Source is down, lets check if this is dataplane down and we could heal.
 	}
 
-	ls := clientConnection.Xcon.GetLocalSource()
-	var err error
-	if ls != nil {
-		err = srv.Close(context.Background(), ls)
-	} else {
-		err = srv.Close(context.Background(), clientConnection.Xcon.GetRemoteSource())
-	}
+	// We could not find new NSE, so just close Dataplane and let Client know.
+	err := srv.Close(context.Background(), clientConnection)
 	if err != nil {
 		logrus.Errorf("Error in Recovery: %v", err)
 	}

--- a/controlplane/pkg/nsm/nsm_heal.go
+++ b/controlplane/pkg/nsm/nsm_heal.go
@@ -1,0 +1,37 @@
+package nsm
+
+import (
+	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/nsm"
+	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/model"
+	"github.com/sirupsen/logrus"
+	"golang.org/x/net/context"
+)
+
+func (srv *networkServiceManager) Heal(clientConnection *model.ClientConnection, healState nsm.HealState) {
+	logrus.Infof("Heal %v", clientConnection)
+
+	if clientConnection.IsClosing {
+		//means that we already invoke closing of remotes, nothing to do here
+		return
+	}
+	clientConnection.IsClosing = true
+
+	switch healState {
+	case nsm.HealState_DstDown:
+		// Destination is down.
+		// Let's Close remote connection and re-create new one.
+	case nsm.HealState_DataplaneDown:
+		// Source is down, lets check if this is dataplane down and we could heal.
+	}
+
+	ls := clientConnection.Xcon.GetLocalSource()
+	var err error
+	if ls != nil {
+		err = srv.Close(context.Background(), ls)
+	} else {
+		err = srv.Close(context.Background(), clientConnection.Xcon.GetRemoteSource())
+	}
+	if err != nil {
+		logrus.Errorf("Error in Recovery: %v", err)
+	}
+}

--- a/controlplane/pkg/nsm/nsm_mechanims.go
+++ b/controlplane/pkg/nsm/nsm_mechanims.go
@@ -1,0 +1,96 @@
+package nsm
+
+import (
+	"fmt"
+	"github.com/golang/protobuf/proto"
+	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/local/connection"
+	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/local/networkservice"
+	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/nsm"
+	remote_connection "github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/remote/connection"
+	remote_networkservice "github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/remote/networkservice"
+	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/model"
+	"strconv"
+)
+
+func (srv *networkServiceManager) updateMechanism(nsmConnection nsm.NSMConnection, request nsm.NSMRequest, dataplane *model.Dataplane, extra_parameters map[string]string) error {
+	if request.IsRemote() {
+		mechanism, err := srv.selectRemoteMechanism(request.(*remote_networkservice.NetworkServiceRequest), dataplane)
+		if err != nil {
+			return err
+		}
+		c := nsmConnection.(*remote_connection.Connection)
+		c.Mechanism = proto.Clone(mechanism).(*remote_connection.Mechanism)
+
+		if c.Mechanism == nil {
+			return fmt.Errorf("Required mechanism are not found... %v ", dataplane.RemoteMechanisms)
+		}
+		if c.Mechanism.Parameters == nil {
+			c.Mechanism.Parameters = map[string]string{}
+		}
+
+		for k, v := range extra_parameters {
+			c.Mechanism.Parameters[k] = v
+		}
+	} else {
+		c := nsmConnection.(*connection.Connection)
+		r := request.(*networkservice.NetworkServiceRequest)
+
+		for _, m := range r.MechanismPreferences {
+			dpMechanism := findLocalMechanism(dataplane.LocalMechanisms, m.Type)
+			if dpMechanism != nil { // We have matching dataplane mechanism
+				c.Mechanism = proto.Clone(m).(*connection.Mechanism)
+				break
+			}
+		}
+		if c.Mechanism == nil {
+			return fmt.Errorf("Required mechanism are not found... %v ", r.MechanismPreferences)
+		}
+		if c.Mechanism.Parameters == nil {
+			c.Mechanism.Parameters = map[string]string{}
+		}
+
+		for k, v := range extra_parameters {
+			c.Mechanism.Parameters[k] = v
+		}
+
+	}
+
+	return nil
+}
+
+func (srv *networkServiceManager) selectRemoteMechanism(request *remote_networkservice.NetworkServiceRequest, dataplane *model.Dataplane) (*remote_connection.Mechanism, error) {
+	for _, mechanism := range request.MechanismPreferences {
+		dp_mechanism := findRemoteMechanism(dataplane.RemoteMechanisms, remote_connection.MechanismType_VXLAN)
+		if dp_mechanism == nil {
+			continue
+		}
+		// TODO: Add other mechanisms support
+		if mechanism.Type == remote_connection.MechanismType_VXLAN {
+			// Update DST IP to be ours
+			remoteSrc := mechanism.Parameters[remote_connection.VXLANSrcIP]
+			mechanism.Parameters[remote_connection.VXLANSrcIP] = remoteSrc
+			mechanism.Parameters[remote_connection.VXLANDstIP] = dp_mechanism.Parameters[remote_connection.VXLANSrcIP]
+			mechanism.Parameters[remote_connection.VXLANVNI] = strconv.FormatUint(srv.serviceRegistry.VniAllocator().Vni(dp_mechanism.Parameters[remote_connection.VXLANSrcIP], remoteSrc), 10)
+		}
+		return mechanism, nil
+	}
+	return nil, fmt.Errorf("Failed to select mechanism. No matched mechanisms found...")
+}
+
+func findRemoteMechanism(MechanismPreferences []*remote_connection.Mechanism, mechanismType remote_connection.MechanismType) *remote_connection.Mechanism {
+	for _, m := range MechanismPreferences {
+		if m.Type == mechanismType {
+			return m
+		}
+	}
+	return nil
+}
+
+func findLocalMechanism(MechanismPreferences []*connection.Mechanism, mechanismType connection.MechanismType) *connection.Mechanism {
+	for _, m := range MechanismPreferences {
+		if m.Type == mechanismType {
+			return m
+		}
+	}
+	return nil
+}

--- a/controlplane/pkg/nsm/remote_nsm_client.go
+++ b/controlplane/pkg/nsm/remote_nsm_client.go
@@ -26,11 +26,12 @@ func (c *nsmClient) Close(ctx context.Context, conn nsm.NSMConnection) error {
 		return fmt.Errorf("Remote NSM Connection is not initialized...")
 	}
 	_, err := c.client.Close(ctx, conn.(*connection.Connection))
+	_= c.Cleanup()
 	return err
 }
 
 func (c *nsmClient) Cleanup() error {
-	if c.connection == nil {
+	if c.client == nil {
 		return fmt.Errorf("Remote NSM Connection is already cleaned...")
 	}
 	var err error
@@ -38,5 +39,6 @@ func (c *nsmClient) Cleanup() error {
 		err = c.connection.Close()
 	}
 	c.connection = nil
+	c.client = nil
 	return err
 }

--- a/controlplane/pkg/nsm/remote_nsm_client.go
+++ b/controlplane/pkg/nsm/remote_nsm_client.go
@@ -1,0 +1,42 @@
+package nsm
+
+import (
+	"fmt"
+	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/nsm"
+	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/remote/connection"
+	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/remote/networkservice"
+	"golang.org/x/net/context"
+	"google.golang.org/grpc"
+)
+
+//// Remote NSM Connection Client
+type nsmClient struct {
+	client     networkservice.NetworkServiceClient
+	connection *grpc.ClientConn
+}
+
+func (c *nsmClient) Request(ctx context.Context, request nsm.NSMRequest) (nsm.NSMConnection, error) {
+	if c == nil || c.client == nil {
+		return nil, fmt.Errorf("Remote NSM Connection is not initialized...")
+	}
+	return c.client.Request(ctx, request.(*networkservice.NetworkServiceRequest))
+}
+func (c *nsmClient) Close(ctx context.Context, conn nsm.NSMConnection) error {
+	if c == nil || c.client == nil {
+		return fmt.Errorf("Remote NSM Connection is not initialized...")
+	}
+	_, err := c.client.Close(ctx, conn.(*connection.Connection))
+	return err
+}
+
+func (c *nsmClient) Cleanup() error {
+	if c.connection == nil {
+		return fmt.Errorf("Remote NSM Connection is already cleaned...")
+	}
+	var err error
+	if c.connection != nil { // Required for testing
+		err = c.connection.Close()
+	}
+	c.connection = nil
+	return err
+}

--- a/controlplane/pkg/nsmd/network_service_server.go
+++ b/controlplane/pkg/nsmd/network_service_server.go
@@ -1,6 +1,7 @@
 package nsmd
 
 import (
+	"fmt"
 	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/local/connection"
 	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/local/networkservice"
@@ -50,7 +51,11 @@ func (srv *networkServiceServer) Request(ctx context.Context, request *networkse
 
 func (srv *networkServiceServer) Close(ctx context.Context, connection *connection.Connection) (*empty.Empty, error) {
 	logrus.Infof("Closing connection: %v", *connection)
-	err := srv.manager.Close(ctx, connection)
+	clientConnection := srv.model.GetClientConnection(connection.GetId())
+	if clientConnection == nil {
+		return nil, fmt.Errorf("There is no such client connection %v", connection)
+	}
+	err := srv.manager.Close(ctx, clientConnection)
 	if err != nil {
 		logrus.Errorf("Error during connection close: %v", err)
 	}

--- a/controlplane/pkg/nsmd/network_service_server.go
+++ b/controlplane/pkg/nsmd/network_service_server.go
@@ -1,24 +1,15 @@
 package nsmd
 
 import (
-	"fmt"
-	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/connectioncontext"
-	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/registry"
-	remote_connection "github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/remote/connection"
-	remote_networkservice "github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/remote/networkservice"
-	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/serviceregistry"
-	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/services"
-
-	"time"
-
 	"github.com/golang/protobuf/ptypes/empty"
-
-	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/crossconnect"
 	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/local/connection"
 	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/local/networkservice"
+	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/nsm"
 	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/model"
+	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/serviceregistry"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
+	"time"
 )
 
 const (
@@ -27,318 +18,42 @@ const (
 )
 
 type networkServiceServer struct {
-	model             model.Model
-	workspace         *Workspace
-	serviceRegistry   serviceregistry.ServiceRegistry
-	excluded_prefixes []string
-	xconManager       *services.ClientConnectionManager
+	model           model.Model
+	workspace       *Workspace
+	serviceRegistry serviceregistry.ServiceRegistry
+	manager         nsm.NetworkServiceManager
 }
 
-func NewNetworkServiceServer(model model.Model, workspace *Workspace, serviceRegistry serviceregistry.ServiceRegistry,
-	excluded_prefixes []string, xconManager *services.ClientConnectionManager) networkservice.NetworkServiceServer {
+func NewNetworkServiceServer(model model.Model, workspace *Workspace, manager nsm.NetworkServiceManager, serviceRegistry serviceregistry.ServiceRegistry) networkservice.NetworkServiceServer {
 	rv := &networkServiceServer{
-		model:             model,
-		workspace:         workspace,
-		serviceRegistry:   serviceRegistry,
-		excluded_prefixes: excluded_prefixes,
-		xconManager:       xconManager,
+		model:           model,
+		workspace:       workspace,
+		serviceRegistry: serviceRegistry,
+		manager:         manager,
 	}
 	return rv
 }
 
-func (srv *networkServiceServer) getEndpointFromRegistry(ctx context.Context, requestConnection *connection.Connection) (*registry.NSERegistration, error) {
-	// Get endpoints
-	discoveryClient, err := srv.serviceRegistry.NetworkServiceDiscovery()
-	if err != nil {
-		logrus.Error(err)
-		return nil, err
-	}
-	nseRequest := &registry.FindNetworkServiceRequest{
-		NetworkServiceName: requestConnection.GetNetworkService(),
-	}
-	endpointResponse, err := discoveryClient.FindNetworkService(ctx, nseRequest)
-	if err != nil {
-		logrus.Error(err)
-		return nil, err
-	}
-	endpoint := srv.model.GetSelector().SelectEndpoint(requestConnection, endpointResponse.GetNetworkService(), endpointResponse.GetNetworkServiceEndpoints())
-	if endpoint == nil {
-		return nil, err
-	}
-	return &registry.NSERegistration{
-		NetworkServiceManager:  endpointResponse.GetNetworkServiceManagers()[endpoint.GetNetworkServiceManagerName()],
-		NetworkserviceEndpoint: endpoint,
-		NetworkService:         endpointResponse.GetNetworkService(),
-	}, nil
-}
-
 func (srv *networkServiceServer) Request(ctx context.Context, request *networkservice.NetworkServiceRequest) (*connection.Connection, error) {
-	logrus.Infof("Received request from client to connect to NetworkService: %v", request)
+	// This parameters will go into selected mechanism
+	params := map[string]string{}
+	params[connection.Workspace] = srv.workspace.Name()
 
-	// Make sure its a valid request
-	err := request.IsValid()
-	if err != nil {
-		logrus.Error(err)
-		return nil, err
-	}
-	// Create a ConnectId for the request.GetConnection()
-	request.GetConnection().Id = srv.model.ConnectionId()
-	// TODO: Mechanism selection
-	request.GetConnection().Mechanism = request.MechanismPreferences[0]
-	request.GetConnection().GetMechanism().GetParameters()[connection.Workspace] = srv.workspace.Name()
-
-	// get dataplane
-	dp, err := srv.model.SelectDataplane()
+	conn, err := srv.manager.Request(ctx, request, params)
 	if err != nil {
 		return nil, err
 	}
-
-	logrus.Infof("Preparing to program dataplane: %v...", dp)
-
-	dataplaneClient, dataplaneConn, err := srv.serviceRegistry.DataplaneConnection(dp)
-	if err != nil {
-		return nil, err
-	}
-	if dataplaneConn != nil {
-		defer dataplaneConn.Close()
-	}
-
-	endpoint, err := srv.getEndpointFromRegistry(ctx, request.GetConnection())
-	if err != nil {
-		return nil, err
-	}
-
-	// Update Request with exclude_prefixes
-
-	for _, ep := range srv.excluded_prefixes {
-		c := request.GetConnection()
-		if c.Context == nil {
-			c.Context = &connectioncontext.ConnectionContext{}
-		}
-		c.Context.ExcludedPrefixes = append(c.Context.ExcludedPrefixes, ep)
-	}
-
-	var clientConnection *model.ClientConnection
-	if srv.model.GetNsm().GetName() == endpoint.GetNetworkServiceManager().GetName() {
-		clientConnection, err = srv.performLocalNSERequest(ctx, request, endpoint, dp)
-	} else {
-		clientConnection, err = srv.performRemoteNSERequest(ctx, request, endpoint, dp)
-	}
-
-	if err != nil {
-		logrus.Error(err)
-		return nil, err
-	}
-
-	logrus.Infof("Sending request to dataplane: %v", clientConnection.Xcon)
-
-	srv.model.AddClientConnection(clientConnection)
-	clientConnection.Xcon, err = dataplaneClient.Request(ctx, clientConnection.Xcon)
-	if err != nil {
-		logrus.Errorf("Dataplane request failed: %s", err)
-		srv.model.DeleteClientConnection(clientConnection.ConnectionId)
-		return nil, err
-	}
-	// TODO - be more cautious here about bad return values from Dataplane
-	con := clientConnection.Xcon.GetSource().(*crossconnect.CrossConnect_LocalSource).LocalSource
-	srv.workspace.MonitorConnectionServer().Update(con)
-	logrus.Info("Dataplane configuration done...")
-	return con, nil
-}
-
-func (srv *networkServiceServer) createLocalNSERequest(endpoint *registry.NSERegistration, request *networkservice.NetworkServiceRequest) *networkservice.NetworkServiceRequest {
-	message := &networkservice.NetworkServiceRequest{
-		Connection: &connection.Connection{
-			// TODO track connection ids
-			Id:             srv.model.ConnectionId(),
-			NetworkService: endpoint.GetNetworkService().GetName(),
-			Context:        request.GetConnection().GetContext(),
-			Labels:         nil,
-		},
-		MechanismPreferences: []*connection.Mechanism{
-			{
-				Type:       connection.MechanismType_MEM_INTERFACE,
-				Parameters: map[string]string{},
-			},
-			{
-				Type:       connection.MechanismType_KERNEL_INTERFACE,
-				Parameters: map[string]string{},
-			},
-		},
-	}
-	return message
+	result := conn.(*connection.Connection)
+	srv.workspace.MonitorConnectionServer().Update(result)
+	return result, nil
 }
 
 func (srv *networkServiceServer) Close(ctx context.Context, connection *connection.Connection) (*empty.Empty, error) {
 	logrus.Infof("Closing connection: %v", *connection)
-	clientConnection := srv.model.GetClientConnection(connection.Id)
-	if clientConnection == nil {
-		logrus.Warnf("No connection with id: %s, nothing to close", connection.Id)
-		return &empty.Empty{}, nil
+	err := srv.manager.Close(ctx, connection)
+	if err != nil {
+		logrus.Errorf("Error during connection close: %v", err)
 	}
-	srv.xconManager.DeleteClientConnection(clientConnection, true, true)
+	srv.workspace.MonitorConnectionServer().Delete(connection)
 	return &empty.Empty{}, nil
-}
-
-func (srv *networkServiceServer) validateNSEConnection(nseConnection *connection.Connection) error {
-	err := nseConnection.IsComplete()
-	if err != nil {
-		err = fmt.Errorf("NetworkService.Request() failed with error: %s", err)
-		logrus.Error(err)
-		return err
-	}
-	err = nseConnection.IsComplete()
-	if err != nil {
-		err = fmt.Errorf("failure Validating NSE Connection: %s", err)
-		return err
-	}
-	return nil
-}
-func (srv *networkServiceServer) validateRemoteNSEConnection(nseConnection *remote_connection.Connection) error {
-	err := nseConnection.IsComplete()
-	if err != nil {
-		err = fmt.Errorf("NetworkService.Request() failed with error: %s", err)
-		logrus.Error(err)
-		return err
-	}
-	err = nseConnection.IsComplete()
-	if err != nil {
-		err = fmt.Errorf("failure Validating NSE Connection: %s", err)
-		return err
-	}
-	return nil
-}
-
-func (srv *networkServiceServer) performLocalNSERequest(ctx context.Context, request *networkservice.NetworkServiceRequest, endpoint *registry.NSERegistration, dataplane *model.Dataplane) (*model.ClientConnection, error) {
-	client, nseConn, err := srv.serviceRegistry.EndpointConnection(endpoint)
-	if err != nil {
-		return nil, err
-	}
-	if nseConn != nil {
-		defer nseConn.Close()
-	}
-
-	message := srv.createLocalNSERequest(endpoint, request)
-
-	nseConnection, e := client.Request(ctx, message)
-
-	if e != nil {
-		logrus.Errorf("error requesting networkservice from %+v with message %#v error: %s", endpoint, message, e)
-		return nil, e
-	}
-
-	err = srv.validateNSEConnection(nseConnection)
-	if err != nil {
-		return nil, err
-	}
-
-	err = request.GetConnection().UpdateContext(nseConnection.Context)
-	if err != nil {
-		err = fmt.Errorf("failure Validating NSE Connection: %s", err)
-		return nil, err
-	}
-	workspace := WorkSpaceRegistry().WorkspaceByEndpoint(endpoint.GetNetworkserviceEndpoint())
-	if workspace != nil { // In case of tests this could be empty
-		nseConnection.GetMechanism().GetParameters()[connection.Workspace] = workspace.Name()
-	}
-	dpApiConnection := &crossconnect.CrossConnect{
-		Id:      request.GetConnection().GetId(),
-		Payload: endpoint.GetNetworkService().GetPayload(),
-		Source: &crossconnect.CrossConnect_LocalSource{
-			LocalSource: request.GetConnection(),
-		},
-		Destination: &crossconnect.CrossConnect_LocalDestination{
-			LocalDestination: nseConnection,
-		},
-	}
-
-	clientConnection := &model.ClientConnection{
-		ConnectionId: request.Connection.Id,
-		Xcon:         dpApiConnection,
-		Endpoint:     endpoint,
-		Dataplane:    dataplane,
-	}
-	return clientConnection, nil
-}
-
-func (srv *networkServiceServer) performRemoteNSERequest(ctx context.Context, request *networkservice.NetworkServiceRequest, endpoint *registry.NSERegistration, dataplane *model.Dataplane) (*model.ClientConnection, error) {
-	client, conn, err := srv.serviceRegistry.RemoteNetworkServiceClient(endpoint.GetNetworkServiceManager())
-	if err != nil {
-		logrus.Error(err)
-		return nil, err
-	}
-	if conn != nil {
-		defer conn.Close()
-	}
-
-	message := srv.createRemoteNSERequest(endpoint, request, dataplane)
-	nseConnection, e := client.Request(ctx, message)
-	if e != nil {
-		logrus.Infof("Received Error in Response to '%s'.Request(%v): %s", message.GetConnection().GetDestinationNetworkServiceManagerName(), message, e)
-		return nil, e
-	}
-
-	logrus.Infof("Received Reply to '%s'.Request(%v) %v", message.GetConnection().GetDestinationNetworkServiceManagerName(), message, nseConnection)
-
-	if e != nil {
-		logrus.Errorf("error requesting networkservice from %+v with message %#v error: %s", endpoint, message, e)
-		return nil, e
-	}
-
-	err = srv.validateRemoteNSEConnection(nseConnection)
-	if err != nil {
-		return nil, err
-	}
-
-	request.GetConnection().Context = nseConnection.Context
-	err = request.GetConnection().IsComplete()
-	if err != nil {
-		err = fmt.Errorf("failure Validating NSE Connection: %s", err)
-		return nil, err
-	}
-
-	dpApiConnection := &crossconnect.CrossConnect{
-		Id:      request.GetConnection().GetId(),
-		Payload: endpoint.GetNetworkService().GetPayload(),
-		Source: &crossconnect.CrossConnect_LocalSource{
-			LocalSource: request.GetConnection(),
-		},
-		Destination: &crossconnect.CrossConnect_RemoteDestination{
-			RemoteDestination: nseConnection,
-		},
-	}
-
-	clientConnection := &model.ClientConnection{
-		ConnectionId: request.Connection.Id,
-		Xcon:         dpApiConnection,
-		RemoteNsm:    endpoint.GetNetworkServiceManager(),
-		Endpoint:     endpoint,
-		Dataplane:    dataplane,
-	}
-	return clientConnection, nil
-}
-
-func (srv *networkServiceServer) createRemoteNSERequest(endpoint *registry.NSERegistration, request *networkservice.NetworkServiceRequest, dataplane *model.Dataplane) *remote_networkservice.NetworkServiceRequest {
-
-	// We need to obtain parameters for remote mechanism
-	remoteM := []*remote_connection.Mechanism{}
-
-	for _, mechanism := range dataplane.RemoteMechanisms {
-		remoteM = append(remoteM, mechanism)
-	}
-
-	message := &remote_networkservice.NetworkServiceRequest{
-		Connection: &remote_connection.Connection{
-			// TODO track connection ids
-			Id:                                   srv.model.ConnectionId(),
-			NetworkService:                       request.GetConnection().GetNetworkService(),
-			Context:                              request.GetConnection().GetContext(),
-			Labels:                               request.GetConnection().GetLabels(),
-			DestinationNetworkServiceManagerName: endpoint.GetNetworkServiceManager().GetName(),
-			SourceNetworkServiceManagerName:      srv.model.GetNsm().GetName(),
-			NetworkServiceEndpointName:           endpoint.GetNetworkserviceEndpoint().GetEndpointName(),
-		},
-		MechanismPreferences: remoteM,
-	}
-	return message
 }

--- a/controlplane/pkg/nsmd/nsmd_crossconnect_client.go
+++ b/controlplane/pkg/nsmd/nsmd_crossconnect_client.go
@@ -84,7 +84,7 @@ func (client *NsmMonitorCrossConnectClient) DataplaneAdded(dataplane *model.Data
 func (client *NsmMonitorCrossConnectClient) DataplaneDeleted(dataplane *model.Dataplane) {
 	clientConnections := client.xconManager.GetClientConnectionsByDataplane(dataplane.RegisteredName)
 	for _, clientConnection := range clientConnections {
-		client.xconManager.DeleteClientConnection(clientConnection, false, true)
+		client.xconManager.UpdateClientConnectionDataplaneStateDown(clientConnection)
 	}
 	client.dataplanes[dataplane.RegisteredName]()
 	delete(client.dataplanes, dataplane.RegisteredName)
@@ -176,7 +176,7 @@ func (client *NsmMonitorCrossConnectClient) dataplaneCrossConnectMonitor(datapla
 					client.xconManager.UpdateClientConnection(clientConnection)
 					client.crossConnectMonitor.Update(xcon)
 				case crossconnect.CrossConnectEventType_DELETE:
-					client.xconManager.DeleteClientConnection(clientConnection, false, false)
+					client.crossConnectMonitor.Delete(xcon)
 				case crossconnect.CrossConnectEventType_INITIAL_STATE_TRANSFER:
 					client.crossConnectMonitor.Update(xcon)
 				}
@@ -224,7 +224,8 @@ func (client *NsmMonitorCrossConnectClient) remotePeerConnectionMonitor(remotePe
 				}
 				switch event.GetType() {
 				case connection.ConnectionEventType_DELETE:
-					client.xconManager.DeleteClientConnection(clientConnection, true, false)
+					client.xconManager.UpdateClientConnectionDstState(clientConnection, local_connection.State_DOWN)
+					//TODO: Local Connection should be informed about SRC connection is also down.
 				}
 			}
 		}

--- a/controlplane/pkg/remote/network_service_server/remote_network_service_server.go
+++ b/controlplane/pkg/remote/network_service_server/remote_network_service_server.go
@@ -2,6 +2,7 @@ package network_service_server
 
 import (
 	"context"
+	"fmt"
 	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/nsm"
 	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/monitor/remote_connection_monitor"
 	"time"
@@ -55,7 +56,11 @@ func (srv *remoteNetworkServiceServer) Request(ctx context.Context, request *rem
 
 func (srv *remoteNetworkServiceServer) Close(ctx context.Context, connection *remote_connection.Connection) (*empty.Empty, error) {
 	logrus.Infof("Remote closing connection: %v", *connection)
-	err := srv.manager.Close(ctx, connection)
+	clientConnection := srv.model.GetClientConnection(connection.GetId())
+	if clientConnection == nil {
+		return nil, fmt.Errorf("There is no such client connection %v", connection)
+	}
+	err := srv.manager.Close(ctx, clientConnection)
 	if err != nil {
 		logrus.Errorf("Error during connection close: %v", err)
 	}

--- a/controlplane/pkg/remote/network_service_server/remote_network_service_server.go
+++ b/controlplane/pkg/remote/network_service_server/remote_network_service_server.go
@@ -2,18 +2,11 @@ package network_service_server
 
 import (
 	"context"
-	"errors"
-	"fmt"
+	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/nsm"
 	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/monitor/remote_connection_monitor"
-	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/services"
-	"strconv"
 	"time"
 
 	"github.com/golang/protobuf/ptypes/empty"
-	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/crossconnect"
-	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/local/connection"
-	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/local/networkservice"
-	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/registry"
 	remote_connection "github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/remote/connection"
 	remote_networkservice "github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/remote/networkservice"
 	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/model"
@@ -30,210 +23,42 @@ type remoteNetworkServiceServer struct {
 	model           model.Model
 	serviceRegistry serviceregistry.ServiceRegistry
 	monitor         *remote_connection_monitor.RemoteConnectionMonitor
-	xconManager     *services.ClientConnectionManager
+	manager         nsm.NetworkServiceManager
+}
+
+func NewRemoteNetworkServiceServer(model model.Model, manager nsm.NetworkServiceManager, serviceRegistry serviceregistry.ServiceRegistry, connectionMonitor *remote_connection_monitor.RemoteConnectionMonitor) remote_networkservice.NetworkServiceServer {
+	server := &remoteNetworkServiceServer{
+		model:           model,
+		serviceRegistry: serviceRegistry,
+		monitor:         connectionMonitor,
+		manager:         manager,
+	}
+	return server
 }
 
 func (srv *remoteNetworkServiceServer) Request(ctx context.Context, request *remote_networkservice.NetworkServiceRequest) (*remote_connection.Connection, error) {
 	logrus.Infof("RemoteNSMD: Received request from client to connect to NetworkService: %v", request)
-	// Make sure its a valid request
-	err := request.IsValid()
+	params := map[string]string{}
+
+	conn, err := srv.manager.Request(ctx, request, params)
 	if err != nil {
 		logrus.Error(err)
 		return nil, err
 	}
 
-	// get dataplane
-	dp, err := srv.model.SelectDataplane()
-	if err != nil {
-		return nil, err
-	}
+	result := conn.(*remote_connection.Connection)
+	srv.monitor.Update(result)
 
-	// Create a ConnectId for the request.GetConnection()
-	request.GetConnection().Id = srv.model.ConnectionId()
-
-	mechanism, err := srv.selectMechanism(request, dp)
-
-	request.GetConnection().Mechanism = mechanism
-
-	// We need to select a dataplane Remote address to be good one.
-
-	logrus.Infof("Selected Remote Mechanism: %+v", request.MechanismPreferences[0])
-
-	// Get endpoints
-	endpoint := srv.model.GetEndpoint(request.GetConnection().GetNetworkServiceEndpointName())
-
-	logrus.Infof("RemoteNSMD: Preparing to program dataplane: %v...", dp)
-
-	dataplaneClient, dataplaneConn, err := srv.serviceRegistry.DataplaneConnection(dp)
-	if err != nil {
-		return nil, err
-	}
-	if dataplaneConn != nil {
-		defer dataplaneConn.Close()
-	}
-
-	var dpApiConnection *crossconnect.CrossConnect
-
-	dpApiConnection, err = srv.performLocalNSERequest(ctx, request, endpoint)
-
-	if err != nil {
-		logrus.Error(err)
-		return nil, err
-	}
-
-	logrus.Infof("RemoteNSMD: Sending request to dataplane: %v", dpApiConnection)
-
-	dpCtx, dpCancel := context.WithTimeout(context.Background(), nseConnectionTimeout)
-	defer dpCancel()
-
-	clientConnection := &model.ClientConnection{
-		ConnectionId: request.Connection.Id,
-		Endpoint:     endpoint,
-		Dataplane:    dp,
-	}
-	srv.model.AddClientConnection(clientConnection)
-
-	rv, err := dataplaneClient.Request(dpCtx, dpApiConnection)
-	if err != nil {
-		logrus.Errorf("RemoteNSMD: Dataplane request failed: %s", err)
-		return nil, err
-	}
-	// TODO - be more cautious here about bad return values from Dataplane
-	con := rv.GetSource().(*crossconnect.CrossConnect_RemoteSource).RemoteSource
-	logrus.Infof("Dataplane: Returned connection obj %+v", con)
-	srv.monitor.Update(con)
 	logrus.Info("RemoteNSMD: Dataplane configuration done...")
-	return con, nil
-}
-
-func findMechanism(MechanismPreferences []*remote_connection.Mechanism, mechanismType remote_connection.MechanismType) *remote_connection.Mechanism {
-	for _, m := range MechanismPreferences {
-		if m.Type == mechanismType {
-			return m
-		}
-	}
-	return nil
-}
-func (srv *remoteNetworkServiceServer) selectMechanism(request *remote_networkservice.NetworkServiceRequest, dataplane *model.Dataplane) (*remote_connection.Mechanism, error) {
-	for _, mechanism := range request.MechanismPreferences {
-		dp_mechanism := findMechanism(dataplane.RemoteMechanisms, remote_connection.MechanismType_VXLAN)
-		if dp_mechanism == nil {
-			continue
-		}
-		// TODO: Add other mechanisms support
-		if mechanism.Type == remote_connection.MechanismType_VXLAN {
-			// Update DST IP to be ours
-			remoteSrc := mechanism.Parameters[remote_connection.VXLANSrcIP]
-			mechanism.Parameters[remote_connection.VXLANSrcIP] = remoteSrc
-			mechanism.Parameters[remote_connection.VXLANDstIP] = dp_mechanism.Parameters[remote_connection.VXLANSrcIP]
-			mechanism.Parameters[remote_connection.VXLANVNI] = strconv.FormatUint(srv.serviceRegistry.VniAllocator().Vni(dp_mechanism.Parameters[remote_connection.VXLANSrcIP], remoteSrc), 10)
-		}
-		return mechanism, nil
-	}
-	return nil, errors.New(fmt.Sprintf("Failed to select mechanism. No matched mechanisms found..."))
-}
-
-func (srv *remoteNetworkServiceServer) createLocalNSERequest(endpoint *registry.NSERegistration, request *remote_networkservice.NetworkServiceRequest) *networkservice.NetworkServiceRequest {
-	message := &networkservice.NetworkServiceRequest{
-		Connection: &connection.Connection{
-			// TODO track connection ids
-			Id:             srv.model.ConnectionId(),
-			NetworkService: request.GetConnection().GetNetworkService(),
-			Context:        request.GetConnection().GetContext(),
-			Labels:         request.GetConnection().GetLabels(),
-		},
-		MechanismPreferences: []*connection.Mechanism{
-			{
-				Type:       connection.MechanismType_MEM_INTERFACE,
-				Parameters: map[string]string{},
-			},
-			{
-				Type:       connection.MechanismType_KERNEL_INTERFACE,
-				Parameters: map[string]string{},
-			},
-		},
-	}
-	return message
-}
-
-func (srv *remoteNetworkServiceServer) performLocalNSERequest(ctx context.Context, request *remote_networkservice.NetworkServiceRequest, endpoint *registry.NSERegistration) (*crossconnect.CrossConnect, error) {
-	client, nseConn, err := srv.serviceRegistry.EndpointConnection(endpoint)
-	if err != nil {
-		return nil, err
-	}
-	if nseConn != nil {
-		defer nseConn.Close()
-	}
-
-	message := srv.createLocalNSERequest(endpoint, request)
-
-	nseConnection, e := client.Request(ctx, message)
-
-	if e != nil {
-		logrus.Errorf("error requesting networkservice from %+v with message %#v error: %s", endpoint, message, e)
-		return nil, e
-	}
-
-	err = srv.validateNSEConnection(nseConnection)
-	if err != nil {
-		return nil, err
-	}
-
-	// TODO - this is a terrible dirty way to do this, needs cleanup
-	nseConnection.GetMechanism().GetParameters()[connection.Workspace] = srv.serviceRegistry.WorkspaceName(endpoint)
-	logrus.Infof("Set ")
-
-	err = request.GetConnection().UpdateContext(nseConnection.Context)
-	if err != nil {
-		err = fmt.Errorf("Failure Validating request.GetConnection(): %s %+v", err, request.GetConnection())
-		return nil, err
-	}
-
-	dpApiConnection := &crossconnect.CrossConnect{
-		Id:      request.GetConnection().GetId(),
-		Payload: endpoint.GetNetworkService().GetPayload(),
-		Source: &crossconnect.CrossConnect_RemoteSource{
-			RemoteSource: request.GetConnection(),
-		},
-		Destination: &crossconnect.CrossConnect_LocalDestination{
-			LocalDestination: nseConnection,
-		},
-	}
-	return dpApiConnection, nil
-}
-
-func (srv *remoteNetworkServiceServer) validateNSEConnection(nseConnection *connection.Connection) error {
-	err := nseConnection.IsComplete()
-	if err != nil {
-		err = fmt.Errorf("NetworkService.Request().LocalNSE failed with error: %s %+v", err, nseConnection)
-		logrus.Error(err)
-		return err
-	}
-	err = nseConnection.IsComplete()
-	if err != nil {
-		err = fmt.Errorf("NetworkService.Request().LocalNSE failed validating NSE Connection: %s %+v", err, nseConnection)
-		return err
-	}
-	return nil
+	return result, nil
 }
 
 func (srv *remoteNetworkServiceServer) Close(ctx context.Context, connection *remote_connection.Connection) (*empty.Empty, error) {
 	logrus.Infof("Remote closing connection: %v", *connection)
-	clientConnection := srv.model.GetClientConnection(connection.Id)
-	if clientConnection == nil {
-		logrus.Warnf("No connection with id: %s, nothing to close", connection.Id)
-		return &empty.Empty{}, nil
+	err := srv.manager.Close(ctx, connection)
+	if err != nil {
+		logrus.Errorf("Error during connection close: %v", err)
 	}
-	srv.xconManager.DeleteClientConnection(clientConnection, true, true)
+	srv.monitor.Delete(connection)
 	return &empty.Empty{}, nil
-}
-
-func NewRemoteNetworkServiceServer(model model.Model, serviceRegistry serviceregistry.ServiceRegistry,
-	xconManager *services.ClientConnectionManager, connectionMonitor *remote_connection_monitor.RemoteConnectionMonitor) remote_networkservice.NetworkServiceServer {
-	return &remoteNetworkServiceServer{
-		model:           model,
-		serviceRegistry: serviceRegistry,
-		monitor:         connectionMonitor,
-		xconManager:     xconManager,
-	}
 }

--- a/controlplane/pkg/tests/nsmd_crossconnect_client_test.go
+++ b/controlplane/pkg/tests/nsmd_crossconnect_client_test.go
@@ -33,7 +33,7 @@ func startAPIServer(model model.Model, nsmdApiAddress string) (error, *grpc.Serv
 	connectionMonitor := remote_connection_monitor.NewRemoteConnectionMonitor()
 	connection.RegisterMonitorConnectionServer(grpcServer, connectionMonitor)
 
-	monitorClient := nsmd.NewMonitorCrossConnectClient(monitor, connectionMonitor, services.NewClientConnectionManager(model, serviceRegistry))
+	monitorClient := nsmd.NewMonitorCrossConnectClient(monitor, connectionMonitor, services.NewClientConnectionManager(model, nil, serviceRegistry))
 	model.AddListener(monitorClient)
 	// TODO: Add more public API services here.
 

--- a/controlplane/pkg/tests/nsmd_local_test.go
+++ b/controlplane/pkg/tests/nsmd_local_test.go
@@ -134,19 +134,19 @@ func TestNSENoSrc(t *testing.T) {
 
 	nsmResponse, err := nsmClient.Request(context.Background(), request)
 	println(err.Error())
-	Expect(err.Error()).To(Equal("rpc error: code = Unknown desc = failure Validating NSE Connection: ConnectionContext.SrcIp is required cannot be empty/nil: dst_ip_addr:\"169083137/30\" "))
+	Expect(err.Error()).To(Equal("rpc error: code = Unknown desc = Failed to find NSE for NetworkService golden_network. Checked: 1 of total NSEs: 0. Last NSE Error: failure Validating NSE Connection: ConnectionContext.SrcIp is required cannot be empty/nil: dst_ip_addr:\"169083137/30\" "))
 	Expect(nsmResponse).To(BeNil())
 }
 
 func TestNSEExcludePrefixes(t *testing.T) {
 	RegisterTestingT(t)
 
+	err := os.Setenv(nsmd.ExcludedPrefixesEnv, "127.0.0.1/24, abc")
+
 	srv := newNSMDFullServer()
 	defer srv.Stop()
 	srv.addFakeDataplane("test_data_plane", "tcp:some_addr")
 	srv.registerFakeEndpoint("golden_network", "test", srv.serviceRegistry.GetPublicAPI())
-
-	err := os.Setenv(nsmd.ExcludedPrefixesEnv, "127.0.0.1/24, abc")
 
 	nsmClient, conn := srv.requestNSMConnection("nsm-1")
 	defer conn.Close()

--- a/controlplane/pkg/tests/nsmd_remote_test.go
+++ b/controlplane/pkg/tests/nsmd_remote_test.go
@@ -24,6 +24,11 @@ func TestNSMDRequestClientRemoteNSMD(t *testing.T) {
 	srv.testModel.AddDataplane(&model.Dataplane{
 		RegisteredName: "test_data_plane",
 		SocketLocation: "tcp:some_addr",
+		LocalMechanisms: []*connection.Mechanism{
+			&connection.Mechanism {
+				Type: connection.MechanismType_KERNEL_INTERFACE,
+			},
+		},
 		RemoteMechanisms: []*connection2.Mechanism{
 			&connection2.Mechanism{
 				Type: connection2.MechanismType_VXLAN,
@@ -38,6 +43,11 @@ func TestNSMDRequestClientRemoteNSMD(t *testing.T) {
 	srv2.testModel.AddDataplane(&model.Dataplane{
 		RegisteredName: "test_data_plane",
 		SocketLocation: "tcp:some_addr",
+		LocalMechanisms: []*connection.Mechanism{
+			&connection.Mechanism {
+				Type: connection.MechanismType_KERNEL_INTERFACE,
+			},
+		},
 		RemoteMechanisms: []*connection2.Mechanism{
 			&connection2.Mechanism{
 				Type: connection2.MechanismType_VXLAN,
@@ -98,6 +108,11 @@ func TestNSMDCloseCrossConnection(t *testing.T) {
 	srv.testModel.AddDataplane(&model.Dataplane{
 		RegisteredName: "test_data_plane",
 		SocketLocation: "tcp:some_addr",
+		LocalMechanisms: []*connection.Mechanism{
+			&connection.Mechanism {
+				Type: connection.MechanismType_KERNEL_INTERFACE,
+			},
+		},
 		RemoteMechanisms: []*connection2.Mechanism{
 			&connection2.Mechanism{
 				Type: connection2.MechanismType_VXLAN,
@@ -160,7 +175,9 @@ func TestNSMDCloseCrossConnection(t *testing.T) {
 	cross_connection := srv.testModel.GetClientConnection(nsmResponse.Id)
 	Expect(cross_connection).ToNot(BeNil())
 
-	cross_connection2 := srv2.testModel.GetClientConnection(nsmResponse.Id)
+	destConnectionId := cross_connection.Xcon.GetRemoteDestination().GetId()
+
+	cross_connection2 := srv2.testModel.GetClientConnection(destConnectionId)
 	Expect(cross_connection2).ToNot(BeNil())
 
 	//Cross connection successfully created, check it closing
@@ -171,7 +188,7 @@ func TestNSMDCloseCrossConnection(t *testing.T) {
 	cross_connection = srv.testModel.GetClientConnection(nsmResponse.Id)
 	Expect(cross_connection).To(BeNil())
 
-	cross_connection2 = srv2.testModel.GetClientConnection(nsmResponse.Id)
+	cross_connection2 = srv2.testModel.GetClientConnection(destConnectionId)
 	Expect(cross_connection2).To(BeNil())
 
 }

--- a/test/integration/monitor_crossconnect_test.go
+++ b/test/integration/monitor_crossconnect_test.go
@@ -56,9 +56,9 @@ func TestSingleCrossConnect(t *testing.T) {
 	nsmdMonitor2, close2, cancel2 := createCrossConnectClient(fmt.Sprintf("localhost:%d", fwd2.ListenPort))
 	defer close2()
 
-	_, err = getCrossConnectsFromMonitor(nsmdMonitor1, cancel1, 1, 5*time.Second)
+	_, err = getCrossConnectsFromMonitor(nsmdMonitor1, cancel1, 1, 50*time.Second)
 	Expect(err).To(BeNil())
-	_, err = getCrossConnectsFromMonitor(nsmdMonitor2, cancel2, 1, 5*time.Second)
+	_, err = getCrossConnectsFromMonitor(nsmdMonitor2, cancel2, 1, 50*time.Second)
 	Expect(err).To(BeNil())
 }
 
@@ -104,9 +104,9 @@ func TestSingleCrossConnectMonitorBeforeXcons(t *testing.T) {
 	nsmd_test_utils.DeployIcmp(k8s, nodes[nodesCount-1].Node)
 	nsmd_test_utils.DeployNsc(k8s, nodes[0].Node, "nsc1")
 
-	_, err = getCrossConnectsFromMonitor(nsmdMonitor1, cancel1, 1, 5*time.Second)
+	_, err = getCrossConnectsFromMonitor(nsmdMonitor1, cancel1, 1, 50*time.Second)
 	Expect(err).To(BeNil())
-	_, err = getCrossConnectsFromMonitor(nsmdMonitor2, cancel2, 1, 5*time.Second)
+	_, err = getCrossConnectsFromMonitor(nsmdMonitor2, cancel2, 1, 50*time.Second)
 	Expect(err).To(BeNil())
 }
 

--- a/test/kube_testing/k8s.go
+++ b/test/kube_testing/k8s.go
@@ -18,8 +18,8 @@ import (
 )
 
 const (
-	podStartTimeout = 5*time.Minute
-	podDeleteTimeout = 5*time.Minute
+	podStartTimeout  = 5 * time.Minute
+	podDeleteTimeout = 5 * time.Minute
 )
 
 type PodDeployResult struct {
@@ -129,10 +129,12 @@ func blockUntilPodReady(client kubernetes.Interface, timeout time.Duration, sour
 					return pod, nil
 				}
 			}
+		case <-time.Tick(time.Second):
 			if time.Since(st) > timeout {
-				return sourcePod, podTimeout(pod)
+				return sourcePod, podTimeout(sourcePod)
 			}
 		}
+
 	}
 }
 
@@ -142,12 +144,12 @@ func podTimeout(pod *v1.Pod) error {
 
 func isPodReady(pod *v1.Pod) bool {
 	for _, containerStatus := range pod.Status.ContainerStatuses {
-		if !containerStatus.Ready {
-			return false
+		if containerStatus.Ready {
+			return true
 		}
 	}
 
-	return true
+	return false
 }
 
 func blockUntilPodWorking(client kubernetes.Interface, context context.Context, pod *v1.Pod) error {
@@ -405,7 +407,7 @@ func (k8s *K8s) GetNodesWait(requiredNumber int, timeout time.Duration) []v1.Nod
 			logrus.Warnf("Waiting for %d nodes to arrive, currenctly have: %d", len(nodes), requiredNumber)
 			warnPrinted = true
 		}
-		time.Sleep(50*time.Millisecond)
+		time.Sleep(50 * time.Millisecond)
 	}
 
 }


### PR DESCRIPTION
Right now NSMD select just one NSE and in case of error doesn't select another one, we need to update code base to support this scenarios.

  * Unify local and remote NSMs codebase to be one generic NSM implementation with two concrete for local/remote request handling.
  * Add basic Auto heal functionality
  * Fix unit tests


Signed-off-by: Andrey Sobolev <haiodo@gmail.com>