### PR TITLE
integration: a better error handling in MonitorCrossconnect test

### DIFF
--- a/test/integration/monitor_crossconnect_test.go
+++ b/test/integration/monitor_crossconnect_test.go
@@ -3,6 +3,9 @@ package nsmd_integration_tests
 import (
 	"context"
 	"fmt"
+	"testing"
+	"time"
+
 	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/crossconnect"
 	"github.com/networkservicemesh/networkservicemesh/test/integration/nsmd_test_utils"
@@ -10,8 +13,6 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
-	"testing"
-	"time"
 )
 
 func TestSingleCrossConnect(t *testing.T) {
@@ -211,10 +212,15 @@ func createCrossConnectClient(address string) (crossconnect.MonitorCrossConnect_
 	monitorClient := crossconnect.NewMonitorCrossConnectClient(conn)
 	ctx, cancel := context.WithCancel(context.Background())
 	stream, err := monitorClient.MonitorCrossConnects(ctx, &empty.Empty{})
+	if err != nil {
+		Expect(err).To(BeNil())
+		cancel()
+		return nil, nil, nil
+	}
 
 	closeFunc := func() {
 		if err := conn.Close(); err != nil {
-			logrus.Error(err)
+			logrus.Errorf("Closing the stream with: %v", err)
 		}
 	}
 	return stream, closeFunc, cancel


### PR DESCRIPTION
This patch proposes a better error handling for MonitorCrossconnect test.
Currently, when the test fails it does so with nil dereference. This patch
prevents it and shows a more concise error.

However, the frequent test fail is still something to be resolved.

Signed-off-by: Nikolay Nikolaev <nnikolay@vmware.com>