### PR TITLE
Implement cache for registry

### DIFF
--- a/k8s/pkg/registryserver/nse.go
+++ b/k8s/pkg/registryserver/nse.go
@@ -121,7 +121,7 @@ func (rs registryService) RemoveNSE(ctx context.Context, request *registry.Remov
 	if err := rs.cache.DeleteNetworkServiceEndpoint(request.EndpointName); err != nil {
 		return nil, err
 	}
-	logrus.Printf("RemoveNSE done: time %v", time.Since(st))
+	logrus.Infof("RemoveNSE done: time %v", time.Since(st))
 	return &empty.Empty{}, nil
 }
 
@@ -135,7 +135,7 @@ func (rs registryService) FindNetworkService(ctx context.Context, request *regis
 
 	t1 := time.Now()
 	endpointList := rs.cache.GetNetworkServiceEndpoints(request.NetworkServiceName)
-	logrus.Printf("NSE found %d, retrieve time: %v", len(endpointList), time.Since(t1))
+	logrus.Infof("NSE found %d, retrieve time: %v", len(endpointList), time.Since(t1))
 	NSEs := make([]*registry.NetworkServiceEndpoint, len(endpointList))
 
 	NSMs := make(map[string]*registry.NetworkServiceManager)
@@ -196,6 +196,6 @@ func (rs registryService) FindNetworkService(ctx context.Context, request *regis
 		NetworkServiceManagers:  NSMs,
 		NetworkServiceEndpoints: NSEs,
 	}
-	logrus.Printf("FindNetworkService done: time %v", time.Since(st))
+	logrus.Infof("FindNetworkService done: time %v", time.Since(st))
 	return response, nil
 }

--- a/k8s/pkg/registryserver/registry_cache.go
+++ b/k8s/pkg/registryserver/registry_cache.go
@@ -72,11 +72,10 @@ func (rc *registryCacheImpl) Start() error {
 
 func (rc *registryCacheImpl) AddNetworkService(ns *v1.NetworkService) (*v1.NetworkService, error) {
 	nsResponse, err := rc.clientset.NetworkservicemeshV1().NetworkServices("default").Create(ns)
-	if err != nil {
-		return nil, err
+	if nsResponse != nil {
+		rc.networkServiceCache.Add(nsResponse)
 	}
-	rc.networkServiceCache.Add(nsResponse)
-	return nsResponse, nil
+	return nsResponse, err
 }
 
 func (rc *registryCacheImpl) GetNetworkService(name string) (*v1.NetworkService, error) {
@@ -89,11 +88,10 @@ func (rc *registryCacheImpl) GetNetworkService(name string) (*v1.NetworkService,
 
 func (rc *registryCacheImpl) AddNetworkServiceEndpoint(nse *v1.NetworkServiceEndpoint) (*v1.NetworkServiceEndpoint, error) {
 	nseResponse, err := rc.clientset.NetworkservicemeshV1().NetworkServiceEndpoints("default").Create(nse)
-	if err != nil {
-		return nil, err
+	if nseResponse != nil {
+		rc.networkServiceEndpointCache.Add(nseResponse)
 	}
-	rc.networkServiceEndpointCache.Add(nseResponse)
-	return nseResponse, nil
+	return nseResponse, err
 }
 
 func (rc *registryCacheImpl) DeleteNetworkServiceEndpoint(endpointName string) error {
@@ -107,11 +105,10 @@ func (rc *registryCacheImpl) GetNetworkServiceEndpoints(networkServiceName strin
 
 func (rc *registryCacheImpl) AddNetworkServiceManager(nsm *v1.NetworkServiceManager) (*v1.NetworkServiceManager, error) {
 	nsmResponse, err := rc.clientset.NetworkservicemeshV1().NetworkServiceManagers("default").Create(nsm)
-	if err != nil {
-		return nil, err
+	if nsmResponse != nil {
+		rc.networkServiceManagerCache.Add(nsmResponse)
 	}
-	rc.networkServiceManagerCache.Add(nsmResponse)
-	return nsmResponse, nil
+	return nsmResponse, err
 }
 
 func (rc *registryCacheImpl) GetNetworkServiceManager(name string) (*v1.NetworkServiceManager, error) {

--- a/k8s/pkg/registryserver/registry_cache.go
+++ b/k8s/pkg/registryserver/registry_cache.go
@@ -99,4 +99,5 @@ func (rc *registryCacheImpl) GetNetworkServiceManager(name string) (*v1.NetworkS
 
 func (rc *registryCacheImpl) Close() error {
 	//todo (lobkovilya): implement close
+	return nil
 }

--- a/k8s/pkg/registryserver/registry_cache.go
+++ b/k8s/pkg/registryserver/registry_cache.go
@@ -1,0 +1,102 @@
+package registryserver
+
+import (
+	"fmt"
+	"github.com/networkservicemesh/networkservicemesh/k8s/pkg/apis/networkservice/v1"
+	nsmClientset "github.com/networkservicemesh/networkservicemesh/k8s/pkg/networkservice/clientset/versioned"
+	"github.com/networkservicemesh/networkservicemesh/k8s/pkg/networkservice/informers/externalversions"
+	"github.com/sirupsen/logrus"
+	"k8s.io/client-go/tools/cache"
+	"time"
+)
+
+const (
+	nseResource = "networkserviceendpoints"
+	nsResource  = "networkservices"
+	nsmResource = "networkservicemanagers"
+)
+
+type RegistryCache interface {
+	GetNetworkService(name string) (*v1.NetworkService, error)
+	GetNetworkServiceManager(name string) (*v1.NetworkServiceManager, error)
+	GetNetworkServiceEndpoints(networkServiceName string) ([]*v1.NetworkServiceEndpoint, error)
+	Close() error
+}
+
+type registryCacheImpl struct {
+	stores map[string]cache.Store
+}
+
+func NewRegistryCache(clientSet *nsmClientset.Clientset) (RegistryCache, error) {
+	factory := externalversions.NewSharedInformerFactory(clientSet, 100*time.Millisecond)
+	resources := []string{nseResource, nsResource, nsmResource}
+	stores := map[string]cache.Store{}
+
+	for _, resource := range resources {
+		genericInformer, err := factory.ForResource(v1.SchemeGroupVersion.WithResource(resource))
+		if err != nil {
+			return nil, err
+		}
+		informer := genericInformer.Informer()
+		if resource == nsmResource {
+			informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+				AddFunc: func(obj interface{}) {
+					nsm := obj.(*v1.NetworkServiceManager)
+					logrus.Infof("NSM added: %v", nsm.Name)
+				},
+			})
+		}
+
+		stopper := make(chan struct{})
+
+		go informer.Run(stopper)
+		stores[resource] = informer.GetStore()
+	}
+
+	return &registryCacheImpl{
+		stores: stores,
+	}, nil
+}
+
+func (rc *registryCacheImpl) GetNetworkService(name string) (*v1.NetworkService, error) {
+	item, exist, err := rc.stores[nsResource].GetByKey(name)
+	service, cast := item.(*v1.NetworkService)
+	if err != nil {
+		return nil, err
+	}
+	if !exist || !cast {
+		return nil, fmt.Errorf("failed to get NetworkService with name: %v", name)
+	}
+	return service, nil
+}
+func (rc *registryCacheImpl) GetNetworkServiceEndpoints(networkServiceName string) ([]*v1.NetworkServiceEndpoint, error) {
+	//todo (lobkovilya): use map to avoid linear search
+	var rv []*v1.NetworkServiceEndpoint
+	for _, item := range rc.stores[nseResource].List() {
+		nse := item.(*v1.NetworkServiceEndpoint)
+		if nse.Spec.NetworkServiceName == networkServiceName {
+			rv = append(rv, nse)
+		}
+	}
+	return rv, nil
+}
+
+func (rc *registryCacheImpl) GetNetworkServiceManager(name string) (*v1.NetworkServiceManager, error) {
+	item, exist, err := rc.stores[nsmResource].GetByKey(name)
+
+	logrus.Infof("rc.stores[nsmResource].List(): %v", rc.stores[nsmResource].List())
+	logrus.Infof("rc.stores[nsmResource].ListKeys(): %v", rc.stores[nsmResource].ListKeys())
+
+	nsm, cast := item.(*v1.NetworkServiceManager)
+	if err != nil {
+		return nil, err
+	}
+	if !exist || !cast {
+		return nil, fmt.Errorf("failed to get NetworkServiceManager with name: %v", name)
+	}
+	return nsm, nil
+}
+
+func (rc *registryCacheImpl) Close() error {
+	//todo (lobkovilya): implement close
+}

--- a/k8s/pkg/registryserver/resource_cache/ns_cache.go
+++ b/k8s/pkg/registryserver/resource_cache/ns_cache.go
@@ -1,0 +1,71 @@
+package resource_cache
+
+import (
+	"github.com/networkservicemesh/networkservicemesh/k8s/pkg/apis/networkservice/v1"
+	"github.com/networkservicemesh/networkservicemesh/k8s/pkg/networkservice/informers/externalversions"
+	"k8s.io/client-go/tools/cache"
+)
+
+type NetworkServiceCache struct {
+	networkServices map[string]*v1.NetworkService
+	addCh           chan *v1.NetworkService
+	deleteCh        chan *v1.NetworkService
+}
+
+func NewNetworkServiceCache() *NetworkServiceCache {
+	return &NetworkServiceCache{
+		networkServices: make(map[string]*v1.NetworkService),
+		addCh:           make(chan *v1.NetworkService, 10),
+		deleteCh:        make(chan *v1.NetworkService, 10),
+	}
+}
+
+func (nsCache *NetworkServiceCache) Add(ns *v1.NetworkService) {
+	nsCache.addCh <- ns
+}
+
+func (nsCache *NetworkServiceCache) Get(name string) *v1.NetworkService {
+	return nsCache.networkServices[name]
+}
+
+func (nsCache *NetworkServiceCache) Delete(ns *v1.NetworkService) {
+	nsCache.deleteCh <- ns
+}
+
+func (nsCache *NetworkServiceCache) GetResourceType() string {
+	return NsResource
+}
+
+func (nsCache *NetworkServiceCache) Run(informerFactory externalversions.SharedInformerFactory) error {
+	if err := nsCache.startInformer(informerFactory); err != nil {
+		return err
+	}
+
+	go func() {
+		for {
+			select {
+			case newNetworkService := <-nsCache.addCh:
+				nsCache.networkServices[newNetworkService.Name] = newNetworkService
+			case deleteNetworkService := <-nsCache.deleteCh:
+				delete(nsCache.networkServices, deleteNetworkService.Name)
+			}
+		}
+	}()
+
+	return nil
+}
+
+func (nsCache *NetworkServiceCache) startInformer(informerFactory externalversions.SharedInformerFactory) error {
+	genericInformer, err := informerFactory.ForResource(v1.SchemeGroupVersion.WithResource(NsResource))
+	if err != nil {
+		return err
+	}
+	informer := genericInformer.Informer()
+	informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    func(obj interface{}) { nsCache.Add(obj.(*v1.NetworkService)) },
+		DeleteFunc: func(obj interface{}) { nsCache.Delete(obj.(*v1.NetworkService)) },
+	})
+	stopper := make(chan struct{})
+	go informer.Run(stopper)
+	return nil
+}

--- a/k8s/pkg/registryserver/resource_cache/ns_cache.go
+++ b/k8s/pkg/registryserver/resource_cache/ns_cache.go
@@ -3,69 +3,52 @@ package resource_cache
 import (
 	"github.com/networkservicemesh/networkservicemesh/k8s/pkg/apis/networkservice/v1"
 	"github.com/networkservicemesh/networkservicemesh/k8s/pkg/networkservice/informers/externalversions"
-	"k8s.io/client-go/tools/cache"
 )
 
 type NetworkServiceCache struct {
+	cache           abstractResourceCache
 	networkServices map[string]*v1.NetworkService
-	addCh           chan *v1.NetworkService
-	deleteCh        chan *v1.NetworkService
 }
 
 func NewNetworkServiceCache() *NetworkServiceCache {
-	return &NetworkServiceCache{
+	rv := &NetworkServiceCache{
 		networkServices: make(map[string]*v1.NetworkService),
-		addCh:           make(chan *v1.NetworkService, 10),
-		deleteCh:        make(chan *v1.NetworkService, 10),
 	}
-}
-
-func (nsCache *NetworkServiceCache) Add(ns *v1.NetworkService) {
-	nsCache.addCh <- ns
-}
-
-func (nsCache *NetworkServiceCache) Get(name string) *v1.NetworkService {
-	return nsCache.networkServices[name]
-}
-
-func (nsCache *NetworkServiceCache) Delete(ns *v1.NetworkService) {
-	nsCache.deleteCh <- ns
-}
-
-func (nsCache *NetworkServiceCache) GetResourceType() string {
-	return NsResource
-}
-
-func (nsCache *NetworkServiceCache) Run(informerFactory externalversions.SharedInformerFactory) error {
-	if err := nsCache.startInformer(informerFactory); err != nil {
-		return err
+	config := cacheConfig{
+		keyFunc:             getNsKey,
+		resourceAddedFunc:   rv.resourceAdded,
+		resourceDeletedFunc: rv.resourceDeleted,
+		resourceType:        NsResource,
 	}
-
-	go func() {
-		for {
-			select {
-			case newNetworkService := <-nsCache.addCh:
-				nsCache.networkServices[newNetworkService.Name] = newNetworkService
-			case deleteNetworkService := <-nsCache.deleteCh:
-				delete(nsCache.networkServices, deleteNetworkService.Name)
-			}
-		}
-	}()
-
-	return nil
+	rv.cache = newAbstractResourceCache(config)
+	return rv
 }
 
-func (nsCache *NetworkServiceCache) startInformer(informerFactory externalversions.SharedInformerFactory) error {
-	genericInformer, err := informerFactory.ForResource(v1.SchemeGroupVersion.WithResource(NsResource))
-	if err != nil {
-		return err
-	}
-	informer := genericInformer.Informer()
-	informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc:    func(obj interface{}) { nsCache.Add(obj.(*v1.NetworkService)) },
-		DeleteFunc: func(obj interface{}) { nsCache.Delete(obj.(*v1.NetworkService)) },
-	})
-	stopper := make(chan struct{})
-	go informer.Run(stopper)
-	return nil
+func (c *NetworkServiceCache) Get(key string) *v1.NetworkService {
+	return c.networkServices[key]
+}
+
+func (c *NetworkServiceCache) Add(ns *v1.NetworkService) {
+	c.cache.add(ns)
+}
+
+func (c *NetworkServiceCache) Delete(key string) {
+	c.cache.delete(key)
+}
+
+func (c *NetworkServiceCache) Start(informerFactory externalversions.SharedInformerFactory) (func(), error) {
+	return c.cache.start(informerFactory)
+}
+
+func (c *NetworkServiceCache) resourceAdded(obj interface{}) {
+	ns := obj.(*v1.NetworkService)
+	c.networkServices[getNsKey(ns)] = ns
+}
+
+func (c *NetworkServiceCache) resourceDeleted(key string) {
+	delete(c.networkServices, key)
+}
+
+func getNsKey(obj interface{}) string {
+	return obj.(*v1.NetworkService).Name
 }

--- a/k8s/pkg/registryserver/resource_cache/nse_cache.go
+++ b/k8s/pkg/registryserver/resource_cache/nse_cache.go
@@ -1,0 +1,107 @@
+package resource_cache
+
+import (
+	"github.com/networkservicemesh/networkservicemesh/k8s/pkg/apis/networkservice/v1"
+	"github.com/networkservicemesh/networkservicemesh/k8s/pkg/networkservice/informers/externalversions"
+	"github.com/sirupsen/logrus"
+	"k8s.io/client-go/tools/cache"
+)
+
+type NetworkServiceEndpointCache struct {
+	nseByNs                 map[string][]*v1.NetworkServiceEndpoint
+	networkServiceEndpoints map[string]*v1.NetworkServiceEndpoint
+	addCh                   chan *v1.NetworkServiceEndpoint
+	deleteCh                chan string
+}
+
+func NewNetworkServiceEndpointCache() *NetworkServiceEndpointCache {
+	return &NetworkServiceEndpointCache{
+		nseByNs:                 make(map[string][]*v1.NetworkServiceEndpoint),
+		networkServiceEndpoints: make(map[string]*v1.NetworkServiceEndpoint),
+		addCh:                   make(chan *v1.NetworkServiceEndpoint, 10),
+		deleteCh:                make(chan string, 10),
+	}
+}
+
+func (nseCache *NetworkServiceEndpointCache) Add(nse *v1.NetworkServiceEndpoint) {
+	logrus.Infof("Adding NSE to cache: %v", *nse)
+	nseCache.addCh <- nse
+}
+
+func (nseCache *NetworkServiceEndpointCache) Get(networkServiceName string) []*v1.NetworkServiceEndpoint {
+	return nseCache.nseByNs[networkServiceName]
+}
+
+func (nseCache *NetworkServiceEndpointCache) Delete(name string) {
+	logrus.Infof("Deleting NSE from cache: %v", name)
+	nseCache.deleteCh <- name
+}
+
+func (nseCache *NetworkServiceEndpointCache) GetResourceType() string {
+	return NseResource
+}
+
+func (nseCache *NetworkServiceEndpointCache) Run(informerFactory externalversions.SharedInformerFactory) error {
+	if err := nseCache.startInformer(informerFactory); err != nil {
+		return err
+	}
+
+	go func() {
+		for {
+			select {
+			case newNse := <-nseCache.addCh:
+				endpoints := nseCache.nseByNs[newNse.Spec.NetworkServiceName]
+				if _, exist := nseCache.networkServiceEndpoints[newNse.Name]; !exist {
+					nseCache.nseByNs[newNse.Spec.NetworkServiceName] = append(endpoints, newNse)
+				} else {
+					for i, e := range endpoints {
+						if e.Name == newNse.Name {
+							endpoints[i] = newNse
+							break
+						}
+					}
+				}
+				nseCache.networkServiceEndpoints[newNse.Name] = newNse
+			case deleteNseName := <-nseCache.deleteCh:
+				nse, exist := nseCache.networkServiceEndpoints[deleteNseName]
+				if !exist {
+					continue
+				}
+
+				endpoints := nseCache.nseByNs[nse.Spec.NetworkServiceName]
+				logrus.Info("endpoints: %v", endpoints)
+				var index int
+				for i, e := range endpoints {
+					if nse.Name == e.Name {
+						index = i
+						break
+					}
+				}
+				endpoints = append(endpoints[:index], endpoints[index+1:]...)
+				if len(endpoints) == 0 {
+					delete(nseCache.nseByNs, nse.Spec.NetworkServiceName)
+				} else {
+					nseCache.nseByNs[nse.Spec.NetworkServiceName] = endpoints
+				}
+				delete(nseCache.networkServiceEndpoints, deleteNseName)
+			}
+		}
+	}()
+
+	return nil
+}
+
+func (nseCache *NetworkServiceEndpointCache) startInformer(informerFactory externalversions.SharedInformerFactory) error {
+	genericInformer, err := informerFactory.ForResource(v1.SchemeGroupVersion.WithResource(NseResource))
+	if err != nil {
+		return err
+	}
+	informer := genericInformer.Informer()
+	informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    func(obj interface{}) { nseCache.Add(obj.(*v1.NetworkServiceEndpoint)) },
+		DeleteFunc: func(obj interface{}) { nseCache.Delete(obj.(*v1.NetworkServiceEndpoint).Name) },
+	})
+	stopper := make(chan struct{})
+	go informer.Run(stopper)
+	return nil
+}

--- a/k8s/pkg/registryserver/resource_cache/nse_cache_test.go
+++ b/k8s/pkg/registryserver/resource_cache/nse_cache_test.go
@@ -1,0 +1,147 @@
+package resource_cache_test
+
+import (
+	"github.com/networkservicemesh/networkservicemesh/k8s/pkg/apis/networkservice/v1"
+	"github.com/networkservicemesh/networkservicemesh/k8s/pkg/networkservice/informers/externalversions"
+	"github.com/networkservicemesh/networkservicemesh/k8s/pkg/registryserver/resource_cache"
+	. "github.com/onsi/gomega"
+	"github.com/sirupsen/logrus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/tools/cache"
+	"testing"
+	"time"
+)
+
+type fakeRegistry struct {
+	externalversions.SharedInformerFactory
+	externalversions.GenericInformer
+	cache.SharedIndexInformer
+
+	eventHandlers []cache.ResourceEventHandler
+}
+
+func (f *fakeRegistry) Run(stopCh <-chan struct{}) {
+
+}
+
+func (f *fakeRegistry) ForResource(resource schema.GroupVersionResource) (externalversions.GenericInformer, error) {
+	return f, nil
+}
+
+func (f *fakeRegistry) Informer() cache.SharedIndexInformer {
+	return f
+}
+
+func (f *fakeRegistry) AddEventHandler(handler cache.ResourceEventHandler) {
+	f.eventHandlers = append(f.eventHandlers, handler)
+}
+
+func (f *fakeRegistry) Add(nse *v1.NetworkServiceEndpoint) {
+	logrus.Info(len(f.eventHandlers))
+	for _, eh := range f.eventHandlers {
+		eh.OnAdd(nse)
+	}
+}
+
+func (f *fakeRegistry) Delete(nse *v1.NetworkServiceEndpoint) {
+	for _, eh := range f.eventHandlers {
+		eh.OnDelete(nse)
+	}
+}
+
+func TestK8sRegistryAdd(t *testing.T) {
+	RegisterTestingT(t)
+
+	fakeRegistry := fakeRegistry{}
+	nseCache := resource_cache.NewNetworkServiceEndpointCache()
+
+	stopFunc, err := nseCache.Start(&fakeRegistry)
+
+	Expect(stopFunc).ToNot(BeNil())
+	Expect(err).To(BeNil())
+
+	nse := newTestNse("nse1", "ns1")
+	fakeRegistry.Add(nse)
+
+	endpointList := getEndpoints(nseCache, "ns1", 1)
+	Expect(len(endpointList)).To(Equal(1))
+	Expect(endpointList[0].Name).To(Equal("nse1"))
+}
+
+func TestNsmdRegistryAdd(t *testing.T) {
+	RegisterTestingT(t)
+
+	fakeRegistry := fakeRegistry{}
+	nseCache := resource_cache.NewNetworkServiceEndpointCache()
+
+	stopFunc, err := nseCache.Start(&fakeRegistry)
+
+	Expect(stopFunc).ToNot(BeNil())
+	Expect(err).To(BeNil())
+
+	nse := newTestNse("nse1", "ns1")
+	nseCache.Add(nse)
+
+	endpointList := getEndpoints(nseCache, "ns1", 1)
+	Expect(len(endpointList)).To(Equal(1))
+	Expect(endpointList[0].Name).To(Equal("nse1"))
+}
+
+func TestRegistryDelete(t *testing.T) {
+	RegisterTestingT(t)
+
+	fakeRegistry := fakeRegistry{}
+	nseCache := resource_cache.NewNetworkServiceEndpointCache()
+
+	stopFunc, err := nseCache.Start(&fakeRegistry)
+
+	Expect(stopFunc).ToNot(BeNil())
+	Expect(err).To(BeNil())
+
+	nse1 := newTestNse("nse1", "ns1")
+	nse2 := newTestNse("nse2", "ns1")
+	nse3 := newTestNse("nse3", "ns2")
+
+	fakeRegistry.Add(nse1)
+	fakeRegistry.Add(nse2)
+	fakeRegistry.Add(nse3)
+
+	endpointList1 := getEndpoints(nseCache, "ns1", 2)
+	Expect(len(endpointList1)).To(Equal(2))
+	endpointList2 := getEndpoints(nseCache, "ns2", 1)
+	Expect(len(endpointList2)).To(Equal(1))
+
+	fakeRegistry.Delete(nse3)
+	endpointList3 := getEndpoints(nseCache, "ns2", 0)
+	Expect(len(endpointList3)).To(Equal(0))
+}
+
+func getEndpoints(nseCache *resource_cache.NetworkServiceEndpointCache,
+	networkServiceName string, expectedLength int) []*v1.NetworkServiceEndpoint {
+	var endpointList []*v1.NetworkServiceEndpoint
+	for attempt := 0; attempt < 10; <-time.Tick(300 * time.Millisecond) {
+		attempt++
+		endpointList = nseCache.Get(networkServiceName)
+		if len(endpointList) == expectedLength {
+			logrus.Infof("Attempt: %v", attempt)
+			break
+		}
+	}
+	return endpointList
+}
+
+func newTestNse(name string, networkServiceName string) *v1.NetworkServiceEndpoint {
+	return &v1.NetworkServiceEndpoint{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Spec: v1.NetworkServiceEndpointSpec{
+			NetworkServiceName: networkServiceName,
+			NsmName:            "nsm1",
+		},
+		Status: v1.NetworkServiceEndpointStatus{
+			State: v1.RUNNING,
+		},
+	}
+}

--- a/k8s/pkg/registryserver/resource_cache/nsm_cache.go
+++ b/k8s/pkg/registryserver/resource_cache/nsm_cache.go
@@ -1,0 +1,71 @@
+package resource_cache
+
+import (
+	"github.com/networkservicemesh/networkservicemesh/k8s/pkg/apis/networkservice/v1"
+	"github.com/networkservicemesh/networkservicemesh/k8s/pkg/networkservice/informers/externalversions"
+	"k8s.io/client-go/tools/cache"
+)
+
+type NetworkServiceManagerCache struct {
+	networkServiceManagers map[string]*v1.NetworkServiceManager
+	addCh                  chan *v1.NetworkServiceManager
+	deleteCh               chan *v1.NetworkServiceManager
+}
+
+func NewNetworkServiceManagerCache() *NetworkServiceManagerCache {
+	return &NetworkServiceManagerCache{
+		networkServiceManagers: make(map[string]*v1.NetworkServiceManager),
+		addCh:                  make(chan *v1.NetworkServiceManager, 10),
+		deleteCh:               make(chan *v1.NetworkServiceManager, 10),
+	}
+}
+
+func (nsmCache *NetworkServiceManagerCache) Add(ns *v1.NetworkServiceManager) {
+	nsmCache.addCh <- ns
+}
+
+func (nsmCache *NetworkServiceManagerCache) Get(name string) *v1.NetworkServiceManager {
+	return nsmCache.networkServiceManagers[name]
+}
+
+func (nsmCache *NetworkServiceManagerCache) Delete(ns *v1.NetworkServiceManager) {
+	nsmCache.deleteCh <- ns
+}
+
+func (nsmCache *NetworkServiceManagerCache) GetResourceType() string {
+	return NsmResource
+}
+
+func (nsmCache *NetworkServiceManagerCache) Run(informerFactory externalversions.SharedInformerFactory) error {
+	if err := nsmCache.startInformer(informerFactory); err != nil {
+		return err
+	}
+
+	go func() {
+		for {
+			select {
+			case newNsm := <-nsmCache.addCh:
+				nsmCache.networkServiceManagers[newNsm.Name] = newNsm
+			case deleteNsm := <-nsmCache.deleteCh:
+				delete(nsmCache.networkServiceManagers, deleteNsm.Name)
+			}
+		}
+	}()
+
+	return nil
+}
+
+func (nsCache *NetworkServiceManagerCache) startInformer(informerFactory externalversions.SharedInformerFactory) error {
+	genericInformer, err := informerFactory.ForResource(v1.SchemeGroupVersion.WithResource(NsmResource))
+	if err != nil {
+		return err
+	}
+	informer := genericInformer.Informer()
+	informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    func(obj interface{}) { nsCache.Add(obj.(*v1.NetworkServiceManager)) },
+		DeleteFunc: func(obj interface{}) { nsCache.Delete(obj.(*v1.NetworkServiceManager)) },
+	})
+	stopper := make(chan struct{})
+	go informer.Run(stopper)
+	return nil
+}

--- a/k8s/pkg/registryserver/resource_cache/nsm_cache.go
+++ b/k8s/pkg/registryserver/resource_cache/nsm_cache.go
@@ -3,69 +3,52 @@ package resource_cache
 import (
 	"github.com/networkservicemesh/networkservicemesh/k8s/pkg/apis/networkservice/v1"
 	"github.com/networkservicemesh/networkservicemesh/k8s/pkg/networkservice/informers/externalversions"
-	"k8s.io/client-go/tools/cache"
 )
 
 type NetworkServiceManagerCache struct {
+	cache                  abstractResourceCache
 	networkServiceManagers map[string]*v1.NetworkServiceManager
-	addCh                  chan *v1.NetworkServiceManager
-	deleteCh               chan *v1.NetworkServiceManager
 }
 
 func NewNetworkServiceManagerCache() *NetworkServiceManagerCache {
-	return &NetworkServiceManagerCache{
+	rv := &NetworkServiceManagerCache{
 		networkServiceManagers: make(map[string]*v1.NetworkServiceManager),
-		addCh:                  make(chan *v1.NetworkServiceManager, 10),
-		deleteCh:               make(chan *v1.NetworkServiceManager, 10),
 	}
-}
-
-func (nsmCache *NetworkServiceManagerCache) Add(ns *v1.NetworkServiceManager) {
-	nsmCache.addCh <- ns
-}
-
-func (nsmCache *NetworkServiceManagerCache) Get(name string) *v1.NetworkServiceManager {
-	return nsmCache.networkServiceManagers[name]
-}
-
-func (nsmCache *NetworkServiceManagerCache) Delete(ns *v1.NetworkServiceManager) {
-	nsmCache.deleteCh <- ns
-}
-
-func (nsmCache *NetworkServiceManagerCache) GetResourceType() string {
-	return NsmResource
-}
-
-func (nsmCache *NetworkServiceManagerCache) Run(informerFactory externalversions.SharedInformerFactory) error {
-	if err := nsmCache.startInformer(informerFactory); err != nil {
-		return err
+	config := cacheConfig{
+		keyFunc:             getNsmKey,
+		resourceAddedFunc:   rv.resourceAdded,
+		resourceDeletedFunc: rv.resourceDeleted,
+		resourceType:        NsmResource,
 	}
-
-	go func() {
-		for {
-			select {
-			case newNsm := <-nsmCache.addCh:
-				nsmCache.networkServiceManagers[newNsm.Name] = newNsm
-			case deleteNsm := <-nsmCache.deleteCh:
-				delete(nsmCache.networkServiceManagers, deleteNsm.Name)
-			}
-		}
-	}()
-
-	return nil
+	rv.cache = newAbstractResourceCache(config)
+	return rv
 }
 
-func (nsCache *NetworkServiceManagerCache) startInformer(informerFactory externalversions.SharedInformerFactory) error {
-	genericInformer, err := informerFactory.ForResource(v1.SchemeGroupVersion.WithResource(NsmResource))
-	if err != nil {
-		return err
-	}
-	informer := genericInformer.Informer()
-	informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc:    func(obj interface{}) { nsCache.Add(obj.(*v1.NetworkServiceManager)) },
-		DeleteFunc: func(obj interface{}) { nsCache.Delete(obj.(*v1.NetworkServiceManager)) },
-	})
-	stopper := make(chan struct{})
-	go informer.Run(stopper)
-	return nil
+func (c *NetworkServiceManagerCache) Get(key string) *v1.NetworkServiceManager {
+	return c.networkServiceManagers[key]
+}
+
+func (c *NetworkServiceManagerCache) Add(nsm *v1.NetworkServiceManager) {
+	c.cache.add(nsm)
+}
+
+func (c *NetworkServiceManagerCache) Delete(key string) {
+	c.cache.delete(key)
+}
+
+func (c *NetworkServiceManagerCache) Start(informerFactory externalversions.SharedInformerFactory) (func(), error) {
+	return c.cache.start(informerFactory)
+}
+
+func (c *NetworkServiceManagerCache) resourceAdded(obj interface{}) {
+	nsm := obj.(*v1.NetworkServiceManager)
+	c.networkServiceManagers[getNsmKey(nsm)] = nsm
+}
+
+func (c *NetworkServiceManagerCache) resourceDeleted(key string) {
+	delete(c.networkServiceManagers, key)
+}
+
+func getNsmKey(obj interface{}) string {
+	return obj.(*v1.NetworkServiceManager).Name
 }

--- a/k8s/pkg/registryserver/resource_cache/resource_cache.go
+++ b/k8s/pkg/registryserver/resource_cache/resource_cache.go
@@ -1,0 +1,7 @@
+package resource_cache
+
+const (
+	NseResource = "networkserviceendpoints"
+	NsResource  = "networkservices"
+	NsmResource = "networkservicemanagers"
+)

--- a/k8s/pkg/registryserver/resource_cache/resource_cache.go
+++ b/k8s/pkg/registryserver/resource_cache/resource_cache.go
@@ -1,7 +1,86 @@
 package resource_cache
 
+import (
+	"github.com/networkservicemesh/networkservicemesh/k8s/pkg/apis/networkservice/v1"
+	"github.com/networkservicemesh/networkservicemesh/k8s/pkg/networkservice/informers/externalversions"
+	"k8s.io/client-go/tools/cache"
+)
+
 const (
 	NseResource = "networkserviceendpoints"
 	NsResource  = "networkservices"
 	NsmResource = "networkservicemanagers"
 )
+
+type cacheConfig struct {
+	keyFunc             func(obj interface{}) string
+	resourceAddedFunc   func(obj interface{})
+	resourceDeletedFunc func(key string)
+	resourceType        string
+}
+
+type abstractResourceCache struct {
+	addCh    chan interface{}
+	deleteCh chan string
+	config   cacheConfig
+}
+
+func newAbstractResourceCache(config cacheConfig) abstractResourceCache {
+	return abstractResourceCache{
+		addCh:    make(chan interface{}, 10),
+		deleteCh: make(chan string, 10),
+		config:   config,
+	}
+}
+
+func (c *abstractResourceCache) start(informerFactory externalversions.SharedInformerFactory) (func(), error) {
+	informerStopCh, err := c.startInformer(informerFactory)
+	if err != nil {
+		return nil, err
+	}
+	cacheStopCh := make(chan struct{})
+	go c.run(cacheStopCh)
+	stopFunc := func() {
+		close(informerStopCh)
+		close(cacheStopCh)
+	}
+	return stopFunc, nil
+}
+
+func (c *abstractResourceCache) add(obj interface{}) {
+	c.addCh <- obj
+}
+
+func (c *abstractResourceCache) delete(key string) {
+	c.deleteCh <- key
+}
+
+func (c *abstractResourceCache) run(stopCh chan struct{}) {
+	for {
+		select {
+		case newResource := <-c.addCh:
+			c.config.resourceAddedFunc(newResource)
+		case deleteResourceKey := <-c.deleteCh:
+			c.config.resourceDeletedFunc(deleteResourceKey)
+		case <-stopCh:
+			return
+		}
+	}
+}
+
+func (c *abstractResourceCache) startInformer(informerFactory externalversions.SharedInformerFactory) (chan struct{}, error) {
+	genericInformer, err := informerFactory.ForResource(v1.SchemeGroupVersion.WithResource(c.config.resourceType))
+	if err != nil {
+		return nil, err
+	}
+
+	informer := genericInformer.Informer()
+	informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    c.add,
+		DeleteFunc: func(obj interface{}) { c.delete(c.config.keyFunc(obj)) },
+	})
+
+	stopCh := make(chan struct{})
+	go informer.Run(stopCh)
+	return stopCh, nil
+}

--- a/k8s/pkg/registryserver/server.go
+++ b/k8s/pkg/registryserver/server.go
@@ -27,7 +27,7 @@ func New(clientset *nsmClientset.Clientset, nsmName string) *grpc.Server {
 	registry.RegisterNetworkServiceRegistryServer(server, srv)
 	registry.RegisterNetworkServiceDiscoveryServer(server, srv)
 
-	if err := cache.Run(); err != nil {
+	if err := cache.Start(); err != nil {
 		logrus.Error(err)
 	}
 	return server

--- a/k8s/pkg/registryserver/server.go
+++ b/k8s/pkg/registryserver/server.go
@@ -4,7 +4,7 @@ import (
 	"github.com/grpc-ecosystem/grpc-opentracing/go/otgrpc"
 	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/registry"
 	nsmClientset "github.com/networkservicemesh/networkservicemesh/k8s/pkg/networkservice/clientset/versioned"
-	opentracing "github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go"
 	"google.golang.org/grpc"
 )
 
@@ -16,9 +16,11 @@ func New(clientset *nsmClientset.Clientset, nsmName string) *grpc.Server {
 		grpc.StreamInterceptor(
 			otgrpc.OpenTracingStreamServerInterceptor(tracer)))
 
+	cache, _ := NewRegistryCache(clientset)
 	srv := &registryService{
 		clientset: clientset,
 		nsmName:   nsmName,
+		cache:     cache,
 	}
 	registry.RegisterNetworkServiceRegistryServer(server, srv)
 	registry.RegisterNetworkServiceDiscoveryServer(server, srv)

--- a/test/integration/nsmd_k8s_test.go
+++ b/test/integration/nsmd_k8s_test.go
@@ -57,7 +57,7 @@ func TestNSMDDRegistryNSE(t *testing.T) {
 	Expect(response).To(BeNil())
 	logrus.Print(err.Error())
 
-	Expect(err.Error()).To(Equal("rpc error: code = Unknown desc = networkservices.networkservicemesh.io \"my_service\" not found"))
+	Expect(err.Error()).To(Equal("rpc error: code = Unknown desc = failed to get NetworkService with name: my_service"))
 
 	// Lets register few hundred NSEs and check how it works.
 

--- a/test/integration/nsmd_k8s_test.go
+++ b/test/integration/nsmd_k8s_test.go
@@ -57,7 +57,7 @@ func TestNSMDDRegistryNSE(t *testing.T) {
 	Expect(response).To(BeNil())
 	logrus.Print(err.Error())
 
-	Expect(err.Error()).To(Equal("rpc error: code = Unknown desc = failed to get NetworkService with name: my_service"))
+	Expect(err.Error()).To(Equal("rpc error: code = Unknown desc = no NetworkService with name: my_service"))
 
 	// Lets register few hundred NSEs and check how it works.
 

--- a/test/integration/nsmd_test_utils/test_utils.go
+++ b/test/integration/nsmd_test_utils/test_utils.go
@@ -67,14 +67,14 @@ func DeployIcmp(k8s *kube_testing.K8s, node *v1.Node, name string, timeout time.
 	startTime := time.Now()
 
 	logrus.Infof("Starting ICMP Responder NSE on node: %s", node.Name)
-	icmp = k8s.CreatePod(pods.ICMPResponderPod(name, node,
+	icmp = k8s.CreatePod(pods.ICMPResponderPod("icmp-responder-nse1", node,
 		map[string]string{
 			"ADVERTISE_NSE_NAME":   "icmp-responder",
 			"ADVERTISE_NSE_LABELS": "app=icmp",
 			"IP_ADDRESS":           "10.20.1.0/24",
 		},
 	))
-	Expect(icmp.Name).To(Equal(name))
+	Expect(icmp.Name).To(Equal("icmp-responder-nse1"))
 
 	k8s.WaitLogsContains(icmp, "", "NSE: channel has been successfully advertised, waiting for connection from NSM...", timeout)
 

--- a/test/integration/nsmd_test_utils/test_utils.go
+++ b/test/integration/nsmd_test_utils/test_utils.go
@@ -67,14 +67,14 @@ func DeployIcmp(k8s *kube_testing.K8s, node *v1.Node, name string, timeout time.
 	startTime := time.Now()
 
 	logrus.Infof("Starting ICMP Responder NSE on node: %s", node.Name)
-	icmp = k8s.CreatePod(pods.ICMPResponderPod("icmp-responder-nse1", node,
+	icmp = k8s.CreatePod(pods.ICMPResponderPod(name, node,
 		map[string]string{
 			"ADVERTISE_NSE_NAME":   "icmp-responder",
 			"ADVERTISE_NSE_LABELS": "app=icmp",
 			"IP_ADDRESS":           "10.20.1.0/24",
 		},
 	))
-	Expect(icmp.Name).To(Equal("icmp-responder-nse1"))
+	Expect(icmp.Name).To(Equal(name))
 
 	k8s.WaitLogsContains(icmp, "", "NSE: channel has been successfully advertised, waiting for connection from NSM...", timeout)
 


### PR DESCRIPTION
Signed-off-by: Ilya Lobkov <lobkovilya@yandex.ru>

Implement caches for the following custom resources: `NetworkService`, `NetworkServiceEndpoint`, `NetworkServiceManager`. Each resource cache listens k8s-registry using `Informer` as well as handles `Add(...)` or `Delete(...)` requests from `nsmd-k8s` 

## How Has This Been Tested?
* [x]  Covered by existing integration testing
* [ ]  Added integration testing to cover
* [x]  Tested locally
* [ ]  Have not tested

## Types of changes
* [ ]  Bug fix (non-breaking change which fixes an issue)
* [ ]  New feature (non-breaking change which adds functionality)
* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
* [ ]  My change requires a change to the documentation.
* [ ]  I have updated the documentation accordingly.