### PR TITLE
Fix public IP for Packet.net Terraform Provider

### DIFF
--- a/scripts/terraform/packet.tf
+++ b/scripts/terraform/packet.tf
@@ -34,8 +34,8 @@ resource "packet_device" "worker1"{
 }
 
 output "master.public_ip" {
-    value = "${packet_device.master.network.0.address}"
+    value = "${packet_device.master.access_public_ipv4}"
 }
 output "worker1.public_ip" {
-    value = "${packet_device.worker1.network.0.address}"
+    value = "${packet_device.worker1.access_public_ipv4}"
 }


### PR DESCRIPTION
## Description
Packet.net Terraform provider recently switched to
the public IPv4 address being .1 not .0:

https://github.com/terraform-providers/terraform-provider-packet/pull/89

We were getting the address from:

network.0.address

this patch switches to access_public_ipv4 to fix it.


## Motivation and Context
Switching to using a more deterministic mechanism to get Packet.net public IPv4 address to restore the functioning of CI (which has been failing on master).

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [ ] Covered by existing integration testing
- [ ] Added integration testing to cover
- [ ] Tested locally
- [x] Have not tested
Since this is a fix to CI, passing CI is testing this fix.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.