### PR TITLE
NSE/Dataplane auto healing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -121,7 +121,7 @@ jobs:
             export CONTAINER_TAG="${COMMIT}"
             export CONTAINER_FORCE_PULL="true"
             mkdir -p ~/junit/
-            gotestsum --junitfile ~/junit/integration-tests.xml ./test/...
+            gotestsum --junitfile -timeout 30m ~/junit/integration-tests.xml ./test/...
           no_output_timeout: 30m
           environment:
             KUBECONFIG: /home/circleci/project/data/kubeconfig

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -121,7 +121,7 @@ jobs:
             export CONTAINER_TAG="${COMMIT}"
             export CONTAINER_FORCE_PULL="true"
             mkdir -p ~/junit/
-            gotestsum --junitfile -timeout 30m ~/junit/integration-tests.xml ./test/...
+            gotestsum --junitfile ~/junit/integration-tests.xml ./test/... -timeout 30m
           no_output_timeout: 30m
           environment:
             KUBECONFIG: /home/circleci/project/data/kubeconfig

--- a/controlplane/pkg/apis/local/networkservice/helpers.go
+++ b/controlplane/pkg/apis/local/networkservice/helpers.go
@@ -2,6 +2,9 @@ package networkservice
 
 import (
 	"fmt"
+	"github.com/golang/protobuf/proto"
+	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/local/connection"
+	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/nsm"
 )
 
 func (ns *NetworkServiceRequest) IsValid() error {
@@ -27,4 +30,14 @@ func (ns *NetworkServiceRequest) IsValid() error {
 }
 func (ns *NetworkServiceRequest) IsRemote() bool {
 	return false
+}
+func (ns *NetworkServiceRequest) GetConnectionId() string {
+	return ns.GetConnection().GetId()
+}
+
+func (ns *NetworkServiceRequest) Clone() nsm.NSMRequest {
+	return proto.Clone(ns).(*NetworkServiceRequest)
+}
+func (ns *NetworkServiceRequest) SetConnection(conn nsm.NSMConnection) {
+	ns.Connection = conn.(*connection.Connection)
 }

--- a/controlplane/pkg/apis/nsm/nsm.go
+++ b/controlplane/pkg/apis/nsm/nsm.go
@@ -49,9 +49,10 @@ type NetworkServiceClient interface {
 type HealState int32
 
 const (
-	HealState_DstDown       HealState = 1
-	HealState_SrcDown       HealState = 2
-	HealState_DataplaneDown HealState = 3
+	HealState_DstDown       HealState = 1	// Destination is down, we need to restore it and re-program local Datplane.
+	HealState_SrcDown       HealState = 2	// Source is down, most probable will not happen yet.
+	HealState_DataplaneDown HealState = 3	// In case local Dataplane is down, we need to heal NSE/Remote NSM and Dataplane.
+	HealState_DstUpdate		HealState = 4	// Destination is updated, most probable because of Remote Dataplane is down, we need to re-program local dataplane.
 )
 
 type NetworkServiceManager interface {

--- a/controlplane/pkg/apis/nsm/nsm.go
+++ b/controlplane/pkg/apis/nsm/nsm.go
@@ -17,7 +17,7 @@ type NSMRequest interface {
 }
 
 /*
-	Unitifed Connection interface, handles common part of local/Remote connections.
+	Unified Connection interface, handles common part of local/Remote connections.
 */
 type NSMConnection interface {
 	IsValid() error
@@ -35,7 +35,7 @@ type NSMConnection interface {
 
 type NSMClientConnection interface {
 	GetId() string
-	GetSourceConnection() NSMConnection
+	GetConnectionSource() NSMConnection
 	GetNetworkService() string
 }
 

--- a/controlplane/pkg/apis/nsm/nsm.go
+++ b/controlplane/pkg/apis/nsm/nsm.go
@@ -2,14 +2,23 @@ package nsm
 
 import (
 	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/connectioncontext"
-	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/model"
 	"golang.org/x/net/context"
 )
 
+/*
+	Unified request, handles common part of local/Remote network requests.
+*/
 type NSMRequest interface {
 	IsValid() error
 	IsRemote() bool
+	GetConnectionId() string
+	Clone() NSMRequest
+	SetConnection(connection NSMConnection)
 }
+
+/*
+	Unitifed Connection interface, handles common part of local/Remote connections.
+*/
 type NSMConnection interface {
 	IsValid() error
 	SetId(id string)
@@ -22,6 +31,12 @@ type NSMConnection interface {
 	GetLabels() map[string]string
 	GetNetworkServiceEndpointName() string
 	SetNetworkServiceName(service string)
+}
+
+type NSMClientConnection interface {
+	GetId() string
+	GetSourceConnection() NSMConnection
+	GetNetworkService() string
 }
 
 type NetworkServiceClient interface {
@@ -40,7 +55,7 @@ const (
 )
 
 type NetworkServiceManager interface {
-	Request(ctx context.Context, request NSMRequest, extra_parameters map[string]string) (NSMConnection, error)
-	Close(ctx context.Context, clientConnection *model.ClientConnection) error
-	Heal(connection *model.ClientConnection, healState HealState)
+	Request(ctx context.Context, request NSMRequest) (NSMConnection, error)
+	Close(ctx context.Context, clientConnection NSMClientConnection) error
+	Heal(connection NSMClientConnection, healState HealState)
 }

--- a/controlplane/pkg/apis/remote/networkservice/helpers.go
+++ b/controlplane/pkg/apis/remote/networkservice/helpers.go
@@ -1,6 +1,11 @@
 package networkservice
 
-import "fmt"
+import (
+	"fmt"
+	"github.com/golang/protobuf/proto"
+	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/nsm"
+	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/remote/connection"
+)
 
 func (ns *NetworkServiceRequest) IsValid() error {
 	if ns == nil {
@@ -26,4 +31,13 @@ func (ns *NetworkServiceRequest) IsValid() error {
 
 func (ns *NetworkServiceRequest) IsRemote() bool {
 	return true
+}
+func (ns *NetworkServiceRequest) GetConnectionId() string {
+	return ns.GetConnection().GetId()
+}
+func (ns *NetworkServiceRequest) Clone() nsm.NSMRequest {
+	return proto.Clone(ns).(*NetworkServiceRequest)
+}
+func (ns *NetworkServiceRequest) SetConnection(conn nsm.NSMConnection) {
+	ns.Connection = conn.(*connection.Connection)
 }

--- a/controlplane/pkg/model/model.go
+++ b/controlplane/pkg/model/model.go
@@ -76,7 +76,7 @@ type Model interface {
 	GetClientConnection(connectionId string) *ClientConnection
 	GetAllClientConnections() []*ClientConnection
 	UpdateClientConnection(clientConnection *ClientConnection)
-	DeleteClientConnection(connectionId string) *ClientConnection
+	DeleteClientConnection(connectionId string)
 
 	ConnectionId() string
 
@@ -141,12 +141,11 @@ func (i *impl) UpdateClientConnection(clientConnection *ClientConnection) {
 	}
 }
 
-func (i *impl) DeleteClientConnection(connectionId string) *ClientConnection {
+func (i *impl) DeleteClientConnection(connectionId string) {
 	i.Lock()
 	clientConnection := i.clientConnections[connectionId]
 	if clientConnection == nil {
 		i.Unlock()
-		return nil
 	}
 	delete(i.clientConnections, connectionId)
 	i.Unlock()
@@ -154,7 +153,6 @@ func (i *impl) DeleteClientConnection(connectionId string) *ClientConnection {
 	for _, listener := range i.listeners {
 		listener.ClientConnectionDeleted(clientConnection)
 	}
-	return clientConnection
 }
 
 func (i *impl) AddListener(listener ModelListener) {

--- a/controlplane/pkg/model/model.go
+++ b/controlplane/pkg/model/model.go
@@ -141,7 +141,7 @@ func (i *impl) UpdateClientConnection(clientConnection *ClientConnection) {
 	}
 }
 
-func (i *impl) DeleteClientConnection(connectionId string) {
+func (i *impl) DeleteClientConnection(connectionId string) *ClientConnection {
 	i.Lock()
 	clientConnection := i.clientConnections[connectionId]
 	if clientConnection == nil {
@@ -153,6 +153,7 @@ func (i *impl) DeleteClientConnection(connectionId string) {
 	for _, listener := range i.listeners {
 		listener.ClientConnectionDeleted(clientConnection)
 	}
+	return clientConnection
 }
 
 func (i *impl) AddListener(listener ModelListener) {

--- a/controlplane/pkg/model/model.go
+++ b/controlplane/pkg/model/model.go
@@ -76,7 +76,7 @@ type Model interface {
 	GetClientConnection(connectionId string) *ClientConnection
 	GetAllClientConnections() []*ClientConnection
 	UpdateClientConnection(clientConnection *ClientConnection)
-	DeleteClientConnection(connectionId string)
+	DeleteClientConnection(connectionId string) *ClientConnection
 
 	ConnectionId() string
 
@@ -141,11 +141,12 @@ func (i *impl) UpdateClientConnection(clientConnection *ClientConnection) {
 	}
 }
 
-func (i *impl) DeleteClientConnection(connectionId string) {
+func (i *impl) DeleteClientConnection(connectionId string) *ClientConnection {
 	i.Lock()
 	clientConnection := i.clientConnections[connectionId]
 	if clientConnection == nil {
 		i.Unlock()
+		return nil
 	}
 	delete(i.clientConnections, connectionId)
 	i.Unlock()
@@ -153,6 +154,7 @@ func (i *impl) DeleteClientConnection(connectionId string) {
 	for _, listener := range i.listeners {
 		listener.ClientConnectionDeleted(clientConnection)
 	}
+	return clientConnection
 }
 
 func (i *impl) AddListener(listener ModelListener) {

--- a/controlplane/pkg/model/model.go
+++ b/controlplane/pkg/model/model.go
@@ -22,6 +22,14 @@ type Dataplane struct {
 	LocalMechanisms  []*local.Mechanism
 	RemoteMechanisms []*remote.Mechanism
 }
+type ClientConnectionState int8
+const (
+	ClientConnection_Ready = 0
+	ClientConnection_Requesting = 1
+	ClientConnection_Healing	= 2
+	ClientConnection_Closing	= 3
+	ClientConnection_Closed	= 4
+)
 
 type ClientConnection struct {
 	ConnectionId string
@@ -29,9 +37,10 @@ type ClientConnection struct {
 	RemoteNsm    *registry.NetworkServiceManager
 	Endpoint     *registry.NSERegistration
 	Dataplane    *Dataplane
-	IsClosing    bool
-	IsHealing    bool
+	ConnectionState ClientConnectionState
 	Request      nsm.NSMRequest
+
+	UpdateRecieved    bool
 }
 
 func (cc *ClientConnection) GetId() string {

--- a/controlplane/pkg/model/model.go
+++ b/controlplane/pkg/model/model.go
@@ -30,6 +30,7 @@ type ClientConnection struct {
 	Endpoint     *registry.NSERegistration
 	Dataplane    *Dataplane
 	IsClosing    bool
+	IsHealing    bool
 	Request      nsm.NSMRequest
 }
 

--- a/controlplane/pkg/model/model.go
+++ b/controlplane/pkg/model/model.go
@@ -39,8 +39,6 @@ type ClientConnection struct {
 	Dataplane    *Dataplane
 	ConnectionState ClientConnectionState
 	Request      nsm.NSMRequest
-
-	UpdateRecieved    bool
 }
 
 func (cc *ClientConnection) GetId() string {

--- a/controlplane/pkg/model/model.go
+++ b/controlplane/pkg/model/model.go
@@ -170,9 +170,13 @@ func (i *impl) DeleteClientConnection(connectionId string) {
 	clientConnection := i.clientConnections[connectionId]
 	if clientConnection == nil {
 		i.Unlock()
+		return
 	}
 	delete(i.clientConnections, connectionId)
 	i.Unlock()
+
+	i.RLock()
+	defer i.RUnlock()
 
 	for _, listener := range i.listeners {
 		listener.ClientConnectionDeleted(clientConnection)

--- a/controlplane/pkg/model/model.go
+++ b/controlplane/pkg/model/model.go
@@ -55,7 +55,7 @@ func (cc *ClientConnection) GetNetworkService() string {
 	return cc.Endpoint.GetNetworkService().GetName()
 }
 
-func (cc *ClientConnection) GetSourceConnection() nsm.NSMConnection {
+func (cc *ClientConnection) GetConnectionSource() nsm.NSMConnection {
 	if cc.Xcon.GetLocalSource() != nil {
 		return cc.Xcon.GetLocalSource()
 	} else {

--- a/controlplane/pkg/monitor_crossconnect_server/monitor_netnsinode_server.go
+++ b/controlplane/pkg/monitor_crossconnect_server/monitor_netnsinode_server.go
@@ -42,8 +42,10 @@ func (m *MonitorNetNsInodeServer) SendMsg(msg interface{}) error {
 func copyEvent(event *crossconnect.CrossConnectEvent) *crossconnect.CrossConnectEvent {
 	crossConnectsCopy := map[string]*crossconnect.CrossConnect{}
 	for k, v := range event.CrossConnects {
-		vCopy := *v
-		crossConnectsCopy[k] = &vCopy
+		if v != nil {
+			vCopy := *v
+			crossConnectsCopy[k] = &vCopy
+		}
 	}
 
 	return &crossconnect.CrossConnectEvent{

--- a/controlplane/pkg/nsm/endpoint_client.go
+++ b/controlplane/pkg/nsm/endpoint_client.go
@@ -2,6 +2,7 @@ package nsm
 
 import (
 	"fmt"
+
 	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/local/connection"
 	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/local/networkservice"
 	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/nsm"

--- a/controlplane/pkg/nsm/endpoint_client.go
+++ b/controlplane/pkg/nsm/endpoint_client.go
@@ -2,7 +2,6 @@ package nsm
 
 import (
 	"fmt"
-
 	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/local/connection"
 	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/local/networkservice"
 	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/nsm"

--- a/controlplane/pkg/nsm/heal_constants.go
+++ b/controlplane/pkg/nsm/heal_constants.go
@@ -1,0 +1,8 @@
+package nsm
+
+import "time"
+
+const (
+	HealTimeout          = time.Minute * 10
+	HealDataplaneTimeout = time.Minute * 10
+)

--- a/controlplane/pkg/nsm/heal_constants.go
+++ b/controlplane/pkg/nsm/heal_constants.go
@@ -3,6 +3,6 @@ package nsm
 import "time"
 
 const (
-	HealTimeout          = time.Minute * 10
-	HealDataplaneTimeout = time.Minute * 10
+	HealTimeout          = time.Minute * 1
+	HealDataplaneTimeout = time.Minute * 1
 )

--- a/controlplane/pkg/nsm/nsm.go
+++ b/controlplane/pkg/nsm/nsm.go
@@ -15,7 +15,6 @@ package nsm
 
 import (
 	"fmt"
-
 	"github.com/golang/protobuf/proto"
 	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/connectioncontext"
 	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/crossconnect"
@@ -47,31 +46,69 @@ func NewNetworkServiceManager(model model.Model, serviceRegistry serviceregistry
 	}
 }
 
-func (srv *networkServiceManager) Request(ctx context.Context, request nsm.NSMRequest, extra_parameters map[string]string) (nsm.NSMConnection, error) {
-	// Make sure its a valid request
+func (srv *networkServiceManager) Request(ctx context.Context, request nsm.NSMRequest) (nsm.NSMConnection, error) {
+	// Check if we are recovering connection, by checking passed connection Id is known to us.
+	return srv.request(ctx, request, srv.model.GetClientConnection(request.GetConnectionId()))
+}
+
+func (srv *networkServiceManager) request(ctx context.Context, request nsm.NSMRequest, existingConnection *model.ClientConnection) (nsm.NSMConnection, error) {
+	// 0. Make sure its a valid request
 	err := request.IsValid()
 	if err != nil {
 		logrus.Error(err)
 		return nil, err
 	}
 
-	var nsmConnection nsm.NSMConnection = nil
-	nsmConnection = srv.cloneConnection(request, nsmConnection)
+	// 1. Create a new connection object.
+	nsmConnection := srv.newConnection(request)
 
-	// Create a ConnectId for the request.GetConnection(), since connections are managed per NSM
-	nsmConnection.SetId(srv.createConnectionId())
+	// 2. Set connection id for new connections.
+	// Every NSMD manage it's connections.
+	if existingConnection == nil {
+		nsmConnection.SetId(srv.createConnectionId())
+	} else {
+		// 2.1 we have connection updata/heal no need for new connection id
+		nsmConnection.SetId(existingConnection.GetId())
+	}
 
-	// get dataplane
+	// 3. get dataplane
 	dp, err := srv.model.SelectDataplane()
 	if err != nil {
 		return nil, err
 	}
 
-	err = srv.updateMechanism(nsmConnection, request, dp, extra_parameters)
+	// A flag if we heal to close Dataplane in case of no NSE is found or failed to establish new connection.
+	closeDataplaneOnNSEFailed := false
+
+	// 4. Check if Heal/Update if we need to ask remote NSM or it is a just local mechanism change requested.
+	// true if we detect we need to request NSE to upgrade/update connection.
+	requestNSEOnUpdate := false
+	if existingConnection != nil {
+		// 4.1 New Network service is requested, we need to close current connection and do re-request of NSE.
+		if nsmConnection.GetNetworkService() != existingConnection.GetNetworkService() {
+			requestNSEOnUpdate = true
+			closeDataplaneOnNSEFailed = true
+			// Network service is closing, we need to close remote NSM and re-programm local one.
+			if err := srv.close(ctx, existingConnection, false); err != nil {
+				logrus.Errorf("Error during close of NSE during Request.Upgrade %v Existing connection: %v error %v", request, existingConnection, err)
+			}
+		} else {
+			// 4.2 Check if NSE is still required, if some more context requests are different.
+			requestNSEOnUpdate = srv.checkNeedNSERequest(nsmConnection, existingConnection, dp)
+		}
+	}
+
+	// 5. Select a local dataplane and put it into nsmConnection object
+	err = srv.updateMechanism(nsmConnection, request, dp)
 	if err != nil {
+		// 5.1 Close Datplane connection, if had existing one and NSE is closed.
+		if closeDataplaneOnNSEFailed {
+			srv.closeDataplaneLog(existingConnection)
+		}
 		return nil, err
 	}
 
+	// 6. Prepare dataplane connection is fine.
 	logrus.Infof("Preparing to program dataplane: %v...", dp)
 	dataplaneClient, dataplaneConn, err := srv.serviceRegistry.DataplaneConnection(dp)
 	if err != nil {
@@ -88,43 +125,61 @@ func (srv *networkServiceManager) Request(ctx context.Context, request nsm.NSMRe
 
 	ignore_endpoints := map[string]*registry.NSERegistration{}
 
-	var clientConnection *model.ClientConnection
-	var last_error error
-	var endpoint *registry.NSERegistration
-	for {
-		// Clone Connection to support iteration via EndPoints
-		nseConnection := srv.cloneConnection(request, nsmConnection)
+	var clientConnection *model.ClientConnection = existingConnection
 
-		endpoint, err = srv.getEndpoint(ctx, nseConnection, ignore_endpoints)
+	// 7. do a Request() on NSE and select it.
+	if existingConnection == nil || requestNSEOnUpdate {
+		//7.1 try find NSE and do a Request to it.
+		clientConnection, err = srv.findConnectNSE(ctx, ignore_endpoints, request, nsmConnection, existingConnection, dp)
 		if err != nil {
-			if last_error != nil {
-				return nil, fmt.Errorf("%v. Last NSE Error: %v", err, last_error)
+			if closeDataplaneOnNSEFailed {
+				// 7.1.x We are failed to find NSE, and we need to close local dataplane in case of recovery.
+				srv.closeDataplaneLog(existingConnection)
 			}
 			return nil, err
 		}
-		// Update Request with exclude_prefixes
-		srv.updateExcludePrefixes(nseConnection)
-		clientConnection, err = srv.performNSERequest(request, endpoint, ctx, nseConnection, dp)
-
-		if err != nil {
-			logrus.Errorf("NSE respond with error: %v ", err)
-			last_error = err
-			ignore_endpoints[endpoint.NetworkserviceEndpoint.EndpointName] = endpoint
-			continue
+	} else if existingConnection != nil {
+		// 7.2 We do not need to access NSE, since all parameters are same.
+		if request.IsRemote() {
+			// 7.2.1 We are called from remote NSM so just copy.
+			rs := clientConnection.Xcon.GetRemoteSource()
+			rs.Mechanism = nsmConnection.(*remote_connection.Connection).Mechanism
+			rs.State = remote_connection.State_UP
+		} else {
+			// 7.2.2 It is local connection from NSC, so just copy values.
+			ls := clientConnection.Xcon.GetLocalSource()
+			ls.Mechanism = nsmConnection.(*connection.Connection).Mechanism
+			ls.State = connection.State_UP
 		}
-		break
 	}
 
-	srv.model.AddClientConnection(clientConnection)
+	// 8. Remember original Request for Heal cases.
+	if existingConnection == nil {
+		clientConnection.Request = request
+	}
 
+	// 9. We need Add connection to model, or update it in case of Healing.
+	if existingConnection == nil {
+		srv.model.AddClientConnection(clientConnection)
+	} else {
+		srv.model.UpdateClientConnection(clientConnection)
+	}
+
+	// 10. We need to programm dataplane with our values.
 	logrus.Infof("Sending request to dataplane: %v", clientConnection.Xcon)
 	clientConnection.Xcon, err = dataplaneClient.Request(ctx, clientConnection.Xcon)
 	if err != nil {
 		logrus.Errorf("Dataplane request failed: %s", err)
+		// 10.1 If datplane configuration are failed, we need to close remore NSE actually.
+		if dp_err := srv.close(context.Background(), clientConnection, true); dp_err != nil {
+			logrus.Errorf("Failed to NSe.Close() caused by local dataplane confuguration failure.")
+		}
+		// 10.2 We need to remove local connection we just added already.
 		srv.model.DeleteClientConnection(clientConnection.ConnectionId)
 		return nil, err
 	}
 
+	// 11. We are done with configuration here.
 	if request.IsRemote() {
 		nsmConnection = clientConnection.Xcon.GetSource().(*crossconnect.CrossConnect_RemoteSource).RemoteSource
 	} else {
@@ -134,25 +189,84 @@ func (srv *networkServiceManager) Request(ctx context.Context, request nsm.NSMRe
 	return nsmConnection, nil
 }
 
+func (srv *networkServiceManager) closeDataplaneLog(existingConnection *model.ClientConnection) {
+	if dp_err := srv.closeDataplane(existingConnection); dp_err != nil {
+		logrus.Errorf("Failed to close local Dataplane for connection %v", existingConnection)
+	}
+}
+
+func (srv *networkServiceManager) findConnectNSE(ctx context.Context, ignore_endpoints map[string]*registry.NSERegistration, request nsm.NSMRequest, nsmConnection nsm.NSMConnection, existingConnection *model.ClientConnection, dp *model.Dataplane) (*model.ClientConnection, error) {
+	var endpoint *registry.NSERegistration
+	var err error
+	var last_error error
+	var clientConnection *model.ClientConnection
+	for {
+		endpoint = nil
+		// 7.1.1 Clone Connection to support iteration via EndPoints
+		nseConnection := srv.cloneConnection(request, nsmConnection)
+
+		if existingConnection != nil {
+			// 7.2.1 Check previous endpoint, and it we will be able to contact it, it should be fine.
+			if ignore_endpoints[existingConnection.Endpoint.NetworkserviceEndpoint.EndpointName] == nil {
+				endpoint = existingConnection.Endpoint
+			}
+		}
+		// 7.2.2 Check if endpoint is not ignored yet
+
+		if endpoint == nil {
+			// 7.2.3 Choose a new endpoint
+			endpoint, err = srv.getEndpoint(ctx, nseConnection, ignore_endpoints)
+		}
+		if err != nil {
+			// 7.2.4 No endpoints found, we need to return error, including last error for previous NSE
+			if last_error != nil {
+				return nil, fmt.Errorf("%v. Last NSE Error: %v", err, last_error)
+			} else {
+				return nil, err
+			}
+		}
+		// 7.2.5 Update Request with exclude_prefixes, etc
+		srv.updateExcludePrefixes(nseConnection)
+
+		// 7.2.6 perform request to NSE/remote NSMD/NSE
+		clientConnection, err = srv.performNSERequest(ctx, endpoint, nseConnection, request, dp, existingConnection)
+
+		// 7.2.7 in case of error we put NSE into ignored list to check another one.
+		if err != nil {
+			logrus.Errorf("NSE respond with error: %v ", err)
+			last_error = err
+			ignore_endpoints[endpoint.NetworkserviceEndpoint.EndpointName] = endpoint
+			continue
+		}
+		// 7.2.8 We are fine with NSE connection and could continue.
+		return clientConnection, nil
+	}
+}
+
 func (srv *networkServiceManager) cloneConnection(request nsm.NSMRequest, response nsm.NSMConnection) nsm.NSMConnection {
 	var requestConnection nsm.NSMConnection
 	if request.IsRemote() {
-		if response == nil {
-			requestConnection = proto.Clone(request.(*remote_networkservice.NetworkServiceRequest).Connection).(*remote_connection.Connection)
-		} else {
-			requestConnection = proto.Clone(response.(*remote_connection.Connection)).(*remote_connection.Connection)
-		}
+		requestConnection = proto.Clone(response.(*remote_connection.Connection)).(*remote_connection.Connection)
 	} else {
-		if response == nil {
-			requestConnection = proto.Clone(request.(*networkservice.NetworkServiceRequest).Connection).(*connection.Connection)
-		} else {
-			requestConnection = proto.Clone(response.(*connection.Connection)).(*connection.Connection)
-		}
+		requestConnection = proto.Clone(response.(*connection.Connection)).(*connection.Connection)
+	}
+	return requestConnection
+}
+func (srv *networkServiceManager) newConnection(request nsm.NSMRequest) nsm.NSMConnection {
+	var requestConnection nsm.NSMConnection
+	if request.IsRemote() {
+		requestConnection = proto.Clone(request.(*remote_networkservice.NetworkServiceRequest).Connection).(*remote_connection.Connection)
+	} else {
+		requestConnection = proto.Clone(request.(*networkservice.NetworkServiceRequest).Connection).(*connection.Connection)
 	}
 	return requestConnection
 }
 
-func (srv *networkServiceManager) Close(ctx context.Context, clientConnection *model.ClientConnection) error {
+func (srv *networkServiceManager) Close(ctx context.Context, connection nsm.NSMClientConnection) error {
+	return srv.close(ctx, connection.(*model.ClientConnection), true)
+}
+
+func (srv *networkServiceManager) close(ctx context.Context, clientConnection *model.ClientConnection, closeDataplane bool) error {
 	logrus.Infof("Closing connection %v", clientConnection)
 	if clientConnection.IsClosing {
 		return nil
@@ -181,23 +295,17 @@ func (srv *networkServiceManager) Close(ctx context.Context, clientConnection *m
 	} else {
 		logrus.Errorf("Failed to create NSE Client %v", nseClientError)
 	}
-
-	dpCloseError := srv.closeDataplane(clientConnection)
-	// TODO: We need to be sure Dataplane is respond well so we could delete connection.
-	srv.model.DeleteClientConnection(clientConnection.ConnectionId)
+	var dpCloseError error = nil
+	if closeDataplane {
+		dpCloseError = srv.closeDataplane(clientConnection)
+		// TODO: We need to be sure Dataplane is respond well so we could delete connection.
+		srv.model.DeleteClientConnection(clientConnection.ConnectionId)
+	}
 
 	if nseClientError != nil || nseCloseError != nil || dpCloseError != nil {
 		return fmt.Errorf("Close error: %v", []error{nseClientError, nseCloseError, dpCloseError})
 	}
 	return nil
-}
-
-func (srv *networkServiceManager) CreateNSERequest(endpoint *registry.NSERegistration, requestConnection nsm.NSMConnection, dataplane *model.Dataplane) nsm.NSMRequest {
-	if srv.isLocalEndpoint(endpoint) {
-		return srv.createLocalNSERequest(endpoint, requestConnection)
-	} else {
-		return srv.createRemoteNSMRequest(endpoint, requestConnection, dataplane)
-	}
 }
 
 func (srv *networkServiceManager) isLocalEndpoint(endpoint *registry.NSERegistration) bool {
@@ -220,7 +328,7 @@ func (srv *networkServiceManager) createNSEClient(endpoint *registry.NSERegistra
 	}
 }
 
-func (srv *networkServiceManager) performNSERequest(request nsm.NSMRequest, endpoint *registry.NSERegistration, ctx context.Context, requestConnection nsm.NSMConnection, dp *model.Dataplane) (*model.ClientConnection, error) {
+func (srv *networkServiceManager) performNSERequest(ctx context.Context, endpoint *registry.NSERegistration, requestConnection nsm.NSMConnection, request nsm.NSMRequest, dp *model.Dataplane, existingConnection *model.ClientConnection) (*model.ClientConnection, error) {
 	client, err := srv.createNSEClient(endpoint)
 	if err != nil {
 		return nil, err
@@ -232,7 +340,12 @@ func (srv *networkServiceManager) performNSERequest(request nsm.NSMRequest, endp
 		}
 	}()
 
-	message := srv.CreateNSERequest(endpoint, requestConnection, dp)
+	var message nsm.NSMRequest
+	if srv.isLocalEndpoint(endpoint) {
+		message = srv.createLocalNSERequest(endpoint, requestConnection)
+	} else {
+		message = srv.createRemoteNSMRequest(endpoint, requestConnection, dp, existingConnection)
+	}
 	nseConnection, e := client.Request(ctx, message)
 
 	if e != nil {
@@ -417,4 +530,38 @@ func (srv *networkServiceManager) filterRegEndpoints(endpoints []*registry.NSERe
 		}
 	}
 	return result
+}
+
+/**
+check if we need to do a NSE/Remote NSM request in case of our connection Upgrade/Healing procedure.
+*/
+func (srv *networkServiceManager) checkNeedNSERequest(nsmConnection nsm.NSMConnection, existingConnection *model.ClientConnection, dp *model.Dataplane) bool {
+	// Check if context is changed, if changed we need to
+	if !proto.Equal(nsmConnection.GetContext(), existingConnection.GetSourceConnection().GetContext()) {
+		return true
+	}
+	// We need to check, dp has mechanism changes in our Remote connection selected mechanism.
+
+	if remoteDestination := existingConnection.Xcon.GetRemoteDestination(); remoteDestination != nil {
+		// Let's check if remote destination is matchs our dataplane destination.
+		if dpM := findRemoteMechanism(dp.RemoteMechanisms, remoteDestination.GetMechanism().GetType()); dpM != nil {
+			// We need to check if source mechanism type and source parameters are different
+			for k, v := range dpM.Parameters {
+				rmV := remoteDestination.Mechanism.Parameters[k]
+				if v != rmV {
+					logrus.Infof("Remote mechanism parameter %s was different with previous one : %v  %v", k, rmV, v)
+					return true
+				}
+			}
+			if !proto.Equal(dpM, remoteDestination.Mechanism) {
+				logrus.Infof("Remote mechanism was different with previous selected one : %v  %v", remoteDestination.Mechanism, dpM)
+				return true
+			}
+		} else {
+			logrus.Infof("Remote mechanism previously selected was not found: %v  in dataplane %v", remoteDestination.Mechanism, dp.RemoteMechanisms)
+			return true
+		}
+	}
+
+	return false
 }

--- a/controlplane/pkg/nsm/nsm.go
+++ b/controlplane/pkg/nsm/nsm.go
@@ -15,6 +15,7 @@ package nsm
 
 import (
 	"fmt"
+
 	"github.com/golang/protobuf/proto"
 	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/connectioncontext"
 	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/crossconnect"
@@ -186,7 +187,7 @@ func (srv *networkServiceManager) Close(ctx context.Context, clientConnection *m
 	srv.model.DeleteClientConnection(clientConnection.ConnectionId)
 
 	if nseClientError != nil || nseCloseError != nil || dpCloseError != nil {
-		return fmt.Errorf("Close error: %v", []error{ nseClientError, nseCloseError, dpCloseError})
+		return fmt.Errorf("Close error: %v", []error{nseClientError, nseCloseError, dpCloseError})
 	}
 	return nil
 }

--- a/controlplane/pkg/nsm/nsm.go
+++ b/controlplane/pkg/nsm/nsm.go
@@ -57,7 +57,7 @@ func create_logid() (uuid string) {
 	b := make([]byte, 4)
 	_, err := rand.Read(b)
 	if err != nil {
-		logrus.Errorf("Error: ", err)
+		logrus.Errorf("Error: %v", err)
 		return
 	}
 

--- a/controlplane/pkg/nsm/nsm.go
+++ b/controlplane/pkg/nsm/nsm.go
@@ -57,12 +57,11 @@ func create_logid() (uuid string) {
 	b := make([]byte, 4)
 	_, err := rand.Read(b)
 	if err != nil {
-		fmt.Println("Error: ", err)
+		logrus.Errorf("Error: ", err)
 		return
 	}
 
 	uuid = fmt.Sprintf("%X", b[0:4])
-
 	return
 }
 
@@ -585,7 +584,7 @@ check if we need to do a NSE/Remote NSM request in case of our connection Upgrad
 func (srv *networkServiceManager) checkNeedNSERequest(requestId string, nsmConnection nsm.NSMConnection, existingConnection *model.ClientConnection, dp *model.Dataplane) bool {
 	// 4.2.x
 	// 4.2.1 Check if context is changed, if changed we need to
-	if !proto.Equal(nsmConnection.GetContext(), existingConnection.GetSourceConnection().GetContext()) {
+	if !proto.Equal(nsmConnection.GetContext(), existingConnection.GetConnectionSource().GetContext()) {
 		return true
 	}
 	// We need to check, dp has mechanism changes in our Remote connection selected mechanism.

--- a/controlplane/pkg/nsm/nsm_heal.go
+++ b/controlplane/pkg/nsm/nsm_heal.go
@@ -1,6 +1,7 @@
 package nsm
 
 import (
+	"fmt"
 	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/nsm"
 	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/model"
 	"github.com/sirupsen/logrus"
@@ -8,7 +9,8 @@ import (
 )
 
 func (srv *networkServiceManager) Heal(connection nsm.NSMClientConnection, healState nsm.HealState) {
-	logrus.Infof("Heal %v", connection)
+	healId := create_logid()
+	logrus.Infof("NSM_Heal(1-%v) %v", healId, connection)
 
 	clientConnection := connection.(*model.ClientConnection)
 	if clientConnection.ConnectionState != model.ClientConnection_Ready {
@@ -17,44 +19,44 @@ func (srv *networkServiceManager) Heal(connection nsm.NSMClientConnection, healS
 	}
 
 	defer func(){
-		logrus.Infof("Connection %v healing state is finished...", clientConnection.GetId())
+		logrus.Infof("NSM_Heal(1.1-%v) Connection %v healing state is finished...", healId, clientConnection.GetId())
 		clientConnection.ConnectionState = model.ClientConnection_Ready
-		clientConnection.UpdateRecieved = false
 	}()
 
 	clientConnection.ConnectionState = model.ClientConnection_Healing
-	clientConnection.UpdateRecieved = false
 
 	ctx, cancel := context.WithTimeout(context.Background(), HealTimeout)
 	defer cancel()
 
+	// 2 Choose heal style
 	switch healState {
 	case nsm.HealState_DstDown:
 		// Destination is down, we need to find it again.
 		if clientConnection.Xcon.GetRemoteSource() != nil {
 			// NSMd id remote one, we just need to close and return.
+			logrus.Infof("NSM_Heal(2.1-%v) Remote NSE heal is done on source side", healId)
 			break
 		} else {
 			// We are client NSMd, we need to try recover our connection.
 			//srv.
 			err := srv.close(ctx, clientConnection, false)
 			if err != nil {
-				logrus.Warnf("Ignored error during connection healing: %v", err)
+				logrus.Warnf("NSM_Heal(2.2-%v) Ignored error during connection healing: %v", healId, err)
 			}
 			recoveredConnection, err := srv.request(ctx, clientConnection.Request, clientConnection)
-			logrus.Infof("Recovered: %v", recoveredConnection)
+			logrus.Infof("NSM_Heal(2.3-%v) Recovered: %v", healId, recoveredConnection)
 			if err != nil {
-				logrus.Errorf("Failed to heal connection: %v", err)
+				logrus.Errorf("NSM_Heal(2.3.1-%v) Failed to heal connection: %v", healId, err)
 				// We just need to close dataplane, since connection is already closed
 				err = srv.closeDataplane(clientConnection)
 				// We need to delete connection, since we are not able to Heal it
 				srv.model.DeleteClientConnection(clientConnection.ConnectionId)
 				if err != nil {
-					logrus.Errorf("Error in Recovery Close: %v", err)
+					logrus.Errorf("NSM_Heal(2.3.2-%v) Error in Recovery Close: %v", healId, err)
 				}
 				clientConnection.ConnectionState = model.ClientConnection_Closed
 			} else {
-				logrus.Infof("Heal: Connection recovered: %v", connection)
+				logrus.Infof("NSM_Heal(2.4-%v) Heal: Connection recovered: %v", healId, connection)
 			}
 			return
 		}
@@ -63,49 +65,59 @@ func (srv *networkServiceManager) Heal(connection nsm.NSMClientConnection, healS
 	case nsm.HealState_DataplaneDown:
 		// Dataplane is down, we only need to re-programm dataplane.
 		// 1. Wait for dataplane to appear.
-		logrus.Infof("Waiting for Dataplane to recovery...")
+		logrus.Infof("NSM_Heal(3.1-%v) Waiting for Dataplane to recovery...", healId)
 		if err := srv.serviceRegistry.WaitForDataplaneAvailable(srv.model, HealDataplaneTimeout); err != nil {
-			logrus.Errorf("Dataplane is not available on recovery for timeout %v: %v", HealDataplaneTimeout, err)
+			logrus.Errorf("NSM_Heal(3.1-%v) Dataplane is not available on recovery for timeout %v: %v", HealDataplaneTimeout, healId, err)
 			break
+		}
+		logrus.Infof("NSM_Heal(3.2-%v) Dataplane is now available...", healId)
+
+		// We could send connection is down now.
+		srv.model.UpdateClientConnection(clientConnection)
+
+		if clientConnection.Xcon.GetRemoteSource() != nil {
+			// NSMd id remote one, we just need to close and return.
+			// Recovery will be performed by NSM client side.
+			logrus.Infof("NSM_Heal(3.3-%v)  Healing will be continued on source side...", healId)
+			return
 		}
 
 		// We have Dataplane now, let's try request all again.
 		// Update request to contain a proper connection object from previous attempt.
 		request := clientConnection.Request.Clone()
 		request.SetConnection(clientConnection.GetSourceConnection())
-		srv.requestOrClose(ctx, request, clientConnection)
+		srv.requestOrClose(fmt.Sprintf("NSM_Heal(3.4-%v) ", healId) ,ctx, request, clientConnection)
 		return
 	case nsm.HealState_DstUpdate:
 		// Remote DST is updated.
 		// Update request to contain a proper connection object from previous attempt.
-		logrus.Infof("Healing DST Update... %v", clientConnection)
+		logrus.Infof("NSM_Heal(4.1-%v) Healing DST Update/Remote Dataplane... %v", healId, clientConnection)
 		if clientConnection.Request != nil {
 			request := clientConnection.Request.Clone()
 			request.SetConnection(clientConnection.GetSourceConnection())
 
-			srv.requestOrClose(ctx, request, clientConnection)
-		} else {
-			logrus.Errorf("Initial request is empty... %v", clientConnection)
-			_ = srv.Close(ctx, clientConnection)
+			srv.requestOrClose(fmt.Sprintf("NSM_Heal(4.2-%v) ", healId), ctx, request, clientConnection)
+			return
 		}
-		return
 	}
 
 	// Close both connection and dataplane
 	err := srv.Close(context.Background(), clientConnection)
 	if err != nil {
-		logrus.Errorf("Error in Recovery: %v", err)
+		logrus.Errorf("NSM_Heal(4-%v) Error in Recovery: %v", healId, err)
 	}
+
 }
 
-func (srv *networkServiceManager) requestOrClose(ctx context.Context, request nsm.NSMRequest, clientConnection *model.ClientConnection) {
+func (srv *networkServiceManager) requestOrClose(logPrefix string, ctx context.Context, request nsm.NSMRequest, clientConnection *model.ClientConnection) {
+	logrus.Infof("%v delegate to Request %v", logPrefix, request )
 	connection, err := srv.request(ctx, request, clientConnection)
 	if err != nil {
-		logrus.Errorf("Failed to heal connection: %v", err)
+		logrus.Errorf("%v Failed to heal connection: %v", logPrefix, err)
 		// Close in case of any errors in recovery.
 		err = srv.Close(context.Background(), clientConnection)
-		logrus.Errorf("Error in Recovery Close: %v", err)
+		logrus.Errorf("%v Error in Recovery Close: %v", logPrefix, err)
 	} else {
-		logrus.Infof("Heal: Connection recovered: %v", connection)
+		logrus.Infof("%v Heal: Connection recovered: %v", logPrefix, connection)
 	}
 }

--- a/controlplane/pkg/nsm/nsm_heal.go
+++ b/controlplane/pkg/nsm/nsm_heal.go
@@ -39,16 +39,16 @@ func (srv *networkServiceManager) Heal(connection nsm.NSMClientConnection, healS
 		} else {
 			// We are client NSMd, we need to try recover our connection.
 			//srv.
-			err := srv.close(ctx, clientConnection, false)
+			logrus.Infof("NSM_Heal(2.2-%v) Closing local connection: %v", healId, connection.GetConnectionSource())
+			// Since Dataplane could work unproperly if we do not close existing one, we do so.
+			err := srv.close(ctx, clientConnection, true)
 			if err != nil {
-				logrus.Warnf("NSM_Heal(2.2-%v) Ignored error during connection healing: %v", healId, err)
+				logrus.Warnf("NSM_Heal(2.2.1-%v) Ignored error during connection healing: %v", healId, err)
 			}
 			recoveredConnection, err := srv.request(ctx, clientConnection.Request, clientConnection)
 			logrus.Infof("NSM_Heal(2.3-%v) Recovered: %v", healId, recoveredConnection)
 			if err != nil {
 				logrus.Errorf("NSM_Heal(2.3.1-%v) Failed to heal connection: %v", healId, err)
-				// We just need to close dataplane, since connection is already closed
-				err = srv.closeDataplane(clientConnection)
 				// We need to delete connection, since we are not able to Heal it
 				srv.model.DeleteClientConnection(clientConnection.ConnectionId)
 				if err != nil {

--- a/controlplane/pkg/nsm/nsm_heal.go
+++ b/controlplane/pkg/nsm/nsm_heal.go
@@ -85,7 +85,7 @@ func (srv *networkServiceManager) Heal(connection nsm.NSMClientConnection, healS
 		// We have Dataplane now, let's try request all again.
 		// Update request to contain a proper connection object from previous attempt.
 		request := clientConnection.Request.Clone()
-		request.SetConnection(clientConnection.GetSourceConnection())
+		request.SetConnection(clientConnection.GetConnectionSource())
 		srv.requestOrClose(fmt.Sprintf("NSM_Heal(3.4-%v) ", healId) ,ctx, request, clientConnection)
 		return
 	case nsm.HealState_DstUpdate:
@@ -94,7 +94,7 @@ func (srv *networkServiceManager) Heal(connection nsm.NSMClientConnection, healS
 		logrus.Infof("NSM_Heal(4.1-%v) Healing DST Update/Remote Dataplane... %v", healId, clientConnection)
 		if clientConnection.Request != nil {
 			request := clientConnection.Request.Clone()
-			request.SetConnection(clientConnection.GetSourceConnection())
+			request.SetConnection(clientConnection.GetConnectionSource())
 
 			srv.requestOrClose(fmt.Sprintf("NSM_Heal(4.2-%v) ", healId), ctx, request, clientConnection)
 			return

--- a/controlplane/pkg/nsm/nsm_heal.go
+++ b/controlplane/pkg/nsm/nsm_heal.go
@@ -7,9 +7,12 @@ import (
 	"golang.org/x/net/context"
 )
 
-func (srv *networkServiceManager) Heal(clientConnection *model.ClientConnection, healState nsm.HealState) {
-	logrus.Infof("Heal %v", clientConnection)
+func (srv *networkServiceManager) Heal(connection nsm.NSMClientConnection, healState nsm.HealState) {
+	logrus.Infof("Heal %v", connection)
 
+	ctx, cancel := context.WithTimeout(context.Background(), HealTimeout)
+	defer cancel()
+	clientConnection := connection.(*model.ClientConnection)
 	if clientConnection.IsClosing {
 		//means that we already invoke closing of remotes, nothing to do here
 		return
@@ -17,13 +20,62 @@ func (srv *networkServiceManager) Heal(clientConnection *model.ClientConnection,
 
 	switch healState {
 	case nsm.HealState_DstDown:
-		// Destination is down.
+		// Destination is down, we need to find it again.
+		if clientConnection.Xcon.GetRemoteSource() != nil {
+			// NSMd id remote one, we just need to close and return.
+			break
+		} else {
+			// We are client NSMd, we need to try recover our connection.
+			//srv.
+			err := srv.close(ctx, clientConnection, false)
+			if err != nil {
+				logrus.Warnf("Ignored error during connection healing: %v", err)
+			}
+			recoveredConnection, err := srv.request(ctx, clientConnection.Request, clientConnection)
+			logrus.Infof("Recovered: %v", recoveredConnection)
+			if err != nil {
+				logrus.Errorf("Failed to heal connection: %v", err)
+				// We just need to close dataplane, since connection is already closed
+				err = srv.closeDataplane(clientConnection)
+				// We need to delete connection, since we are not able to Heal it
+				srv.model.DeleteClientConnection(clientConnection.ConnectionId)
+				if err != nil {
+					logrus.Errorf("Error in Recovery Close: %v", err)
+				}
+			} else {
+				logrus.Infof("Heal: Connection recovered: %v", connection)
+			}
+			return
+		}
+
 		// Let's Close remote connection and re-create new one.
 	case nsm.HealState_DataplaneDown:
-		// Source is down, lets check if this is dataplane down and we could heal.
+		// Dataplane is down, we only need to re-programm dataplane.
+		// 1. Wait for dataplane to appear.
+		if err := srv.serviceRegistry.WaitForDataplaneAvailable(srv.model, HealDataplaneTimeout); err != nil {
+			logrus.Errorf("Dataplane is not available on recovery for timeout %v: %v", HealDataplaneTimeout, err)
+			break
+		}
+
+		// We have dataplane now, let's try request all again.
+
+		// Update request to contain a proper connection object from previous attempt.
+		request := clientConnection.Request.Clone()
+		request.SetConnection(clientConnection.GetSourceConnection())
+
+		connection, err := srv.request(ctx, request, clientConnection)
+		if err != nil {
+			logrus.Errorf("Failed to heal connection: %v", err)
+			// Close in any case
+			err = srv.Close(context.Background(), clientConnection)
+			logrus.Errorf("Error in Recovery Close: %v", err)
+		} else {
+			logrus.Infof("Heal: Connection recovered: %v", connection)
+		}
+		return
 	}
 
-	// We could not find new NSE, so just close Dataplane and let Client know.
+	// Close both connection and dataplane
 	err := srv.Close(context.Background(), clientConnection)
 	if err != nil {
 		logrus.Errorf("Error in Recovery: %v", err)

--- a/controlplane/pkg/nsm/remote_nsm_client.go
+++ b/controlplane/pkg/nsm/remote_nsm_client.go
@@ -2,6 +2,7 @@ package nsm
 
 import (
 	"fmt"
+
 	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/nsm"
 	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/remote/connection"
 	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/remote/networkservice"
@@ -26,7 +27,7 @@ func (c *nsmClient) Close(ctx context.Context, conn nsm.NSMConnection) error {
 		return fmt.Errorf("Remote NSM Connection is not initialized...")
 	}
 	_, err := c.client.Close(ctx, conn.(*connection.Connection))
-	_= c.Cleanup()
+	_ = c.Cleanup()
 	return err
 }
 

--- a/controlplane/pkg/nsmd/network_service_server.go
+++ b/controlplane/pkg/nsmd/network_service_server.go
@@ -2,6 +2,8 @@ package nsmd
 
 import (
 	"fmt"
+	"time"
+
 	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/local/connection"
 	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/local/networkservice"
@@ -10,7 +12,6 @@ import (
 	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/serviceregistry"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
-	"time"
 )
 
 const (

--- a/controlplane/pkg/nsmd/network_service_server.go
+++ b/controlplane/pkg/nsmd/network_service_server.go
@@ -37,12 +37,15 @@ func NewNetworkServiceServer(model model.Model, workspace *Workspace, manager ns
 }
 
 func (srv *networkServiceServer) Request(ctx context.Context, request *networkservice.NetworkServiceRequest) (*connection.Connection, error) {
-	logrus.Infof("Received request from client to connect to NetworkService: %v", request)
-	// This parameters will go into selected mechanism
-	params := map[string]string{}
-	params[connection.Workspace] = srv.workspace.Name()
+	// Update passed local mechanism paramaters to contains a workspace name
+	for _, mechanism := range request.MechanismPreferences {
+		if mechanism.Parameters == nil {
+			mechanism.Parameters = map[string]string{}
+		}
+		mechanism.Parameters[connection.Workspace] = srv.workspace.Name()
+	}
 
-	conn, err := srv.manager.Request(ctx, request, params)
+	conn, err := srv.manager.Request(ctx, request)
 	if err != nil {
 		return nil, err
 	}

--- a/controlplane/pkg/nsmd/nsmd.go
+++ b/controlplane/pkg/nsmd/nsmd.go
@@ -2,14 +2,16 @@ package nsmd
 
 import (
 	"fmt"
+	"os"
+	"strings"
+	"sync"
+
 	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/remote/connection"
 	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/remote/networkservice"
 	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/monitor/crossconnect_monitor"
 	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/monitor/remote_connection_monitor"
 	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/services"
-	"os"
-	"strings"
-	"sync"
+	opentracing "github.com/opentracing/opentracing-go"
 
 	"github.com/grpc-ecosystem/grpc-opentracing/go/otgrpc"
 	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/crossconnect"
@@ -20,7 +22,6 @@ import (
 	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/remote/network_service_server"
 	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/serviceregistry"
 	"github.com/networkservicemesh/networkservicemesh/pkg/tools"
-	"github.com/opentracing/opentracing-go"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"

--- a/controlplane/pkg/nsmd/nsmd.go
+++ b/controlplane/pkg/nsmd/nsmd.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/remote/connection"
 	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/remote/networkservice"
@@ -105,7 +106,9 @@ func StartNSMServer(model model.Model, manager nsm.NetworkServiceManager, servic
 	if err := tools.SocketCleanup(ServerSock); err != nil {
 		return err
 	}
-	serviceRegistry.WaitForDataplaneAvailable(model)
+	if err := serviceRegistry.WaitForDataplaneAvailable(model, time.Hour*1); err != nil {
+		return err
+	}
 
 	tracer := opentracing.GlobalTracer()
 	grpcServer := grpc.NewServer(

--- a/controlplane/pkg/nsmd/nsmd_crossconnect_client.go
+++ b/controlplane/pkg/nsmd/nsmd_crossconnect_client.go
@@ -102,6 +102,11 @@ func (client *NsmMonitorCrossConnectClient) ClientConnectionAdded(clientConnecti
 	client.remotePeers[clientConnection.RemoteNsm.Name] = &remotePeerDescriptor{cancel: cancel, xconCounter: 1}
 	go client.remotePeerConnectionMonitor(clientConnection.RemoteNsm, ctx)
 }
+func (client *NsmMonitorCrossConnectClient) ClientConnectionUpdated(clientConnection *model.ClientConnection) {
+	logrus.Infof("ClientConnectionUpdated: %v", clientConnection)
+	//if clientConnection.
+	//client.ClientConnectionUpdated(clientConnection)
+}
 
 func (client *NsmMonitorCrossConnectClient) ClientConnectionDeleted(clientConnection *model.ClientConnection) {
 	logrus.Infof("ClientConnectionDeleted: %v", clientConnection)
@@ -194,6 +199,10 @@ func (client *NsmMonitorCrossConnectClient) remotePeerConnectionMonitor(remotePe
 		return
 	}
 	defer conn.Close()
+
+	defer func() {
+		logrus.Infof("Remote monitor closed... %v", remotePeer)
+	}()
 
 	monitorClient := remote_connection.NewMonitorConnectionClient(conn)
 	selector := &remote_connection.MonitorScopeSelector{NetworkServiceManagerName: remotePeer.Name}

--- a/controlplane/pkg/nsmd/nsmd_crossconnect_client.go
+++ b/controlplane/pkg/nsmd/nsmd_crossconnect_client.go
@@ -16,10 +16,12 @@ package nsmd
 
 import (
 	"context"
-	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/monitor/crossconnect_monitor"
-	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/monitor/remote_connection_monitor"
 	"net"
 	"time"
+
+	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/monitor/crossconnect_monitor"
+	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/monitor/remote_connection_monitor"
+	opentracing "github.com/opentracing/opentracing-go"
 
 	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/grpc-ecosystem/grpc-opentracing/go/otgrpc"
@@ -30,7 +32,6 @@ import (
 	remote_connection "github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/remote/connection"
 	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/model"
 	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/services"
-	"github.com/opentracing/opentracing-go"
 	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
 )

--- a/controlplane/pkg/nsmd/serviceregistry.go
+++ b/controlplane/pkg/nsmd/serviceregistry.go
@@ -227,13 +227,18 @@ func NewServiceRegistryAt(nsmAddress string) serviceregistry.ServiceRegistry {
 	}
 }
 
-func (impl *nsmdServiceRegistry) WaitForDataplaneAvailable(model model.Model) {
+func (impl *nsmdServiceRegistry) WaitForDataplaneAvailable(model model.Model, timeout time.Duration) error {
 	logrus.Info("Waiting for dataplane available...")
+	st := time.Now()
 	for ; true; <-time.After(100 * time.Millisecond) {
 		if dp, _ := model.SelectDataplane(); dp != nil {
 			break
 		}
+		if time.Since(st) > timeout {
+			break
+		}
 	}
+	return nil
 }
 
 func (impl *nsmdServiceRegistry) VniAllocator() vni.VniAllocator {

--- a/controlplane/pkg/nsmd/workspace.go
+++ b/controlplane/pkg/nsmd/workspace.go
@@ -15,11 +15,12 @@
 package nsmd
 
 import (
-	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/monitor/local_connection_monitor"
-	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/nsm"
 	"net"
 	"os"
 	"sync"
+
+	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/nsm"
+	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/monitor/local_connection_monitor"
 
 	"github.com/grpc-ecosystem/grpc-opentracing/go/otgrpc"
 	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/local/connection"

--- a/controlplane/pkg/prefix_pool/prefixpool.go
+++ b/controlplane/pkg/prefix_pool/prefixpool.go
@@ -38,6 +38,7 @@ type connectionRecord struct {
 }
 
 func NewPrefixPool(prefixes ...string) (PrefixPool, error) {
+	//TODO: Add validation of input prefixes.
 	return &prefixPool{
 		basePrefixes: prefixes,
 		prefixes:     prefixes,

--- a/controlplane/pkg/remote/network_service_server/remote_network_service_server.go
+++ b/controlplane/pkg/remote/network_service_server/remote_network_service_server.go
@@ -40,9 +40,7 @@ func NewRemoteNetworkServiceServer(model model.Model, manager nsm.NetworkService
 
 func (srv *remoteNetworkServiceServer) Request(ctx context.Context, request *remote_networkservice.NetworkServiceRequest) (*remote_connection.Connection, error) {
 	logrus.Infof("RemoteNSMD: Received request from client to connect to NetworkService: %v", request)
-	params := map[string]string{}
-
-	conn, err := srv.manager.Request(ctx, request, params)
+	conn, err := srv.manager.Request(ctx, request)
 	if err != nil {
 		logrus.Error(err)
 		return nil, err

--- a/controlplane/pkg/remote/network_service_server/remote_network_service_server.go
+++ b/controlplane/pkg/remote/network_service_server/remote_network_service_server.go
@@ -3,9 +3,10 @@ package network_service_server
 import (
 	"context"
 	"fmt"
+	"time"
+
 	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/nsm"
 	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/monitor/remote_connection_monitor"
-	"time"
 
 	"github.com/golang/protobuf/ptypes/empty"
 	remote_connection "github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/remote/connection"

--- a/controlplane/pkg/serviceregistry/serviceregistry.go
+++ b/controlplane/pkg/serviceregistry/serviceregistry.go
@@ -2,6 +2,7 @@ package serviceregistry
 
 import (
 	"net"
+	"time"
 
 	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/local/networkservice"
 	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/nsmdapi"
@@ -34,7 +35,7 @@ type ServiceRegistry interface {
 	EndpointConnection(endpoint *registry.NSERegistration) (networkservice.NetworkServiceClient, *grpc.ClientConn, error)
 	RemoteNetworkServiceClient(nsm *registry.NetworkServiceManager) (remote_networkservice.NetworkServiceClient, *grpc.ClientConn, error)
 
-	WaitForDataplaneAvailable(model model.Model)
+	WaitForDataplaneAvailable(model model.Model, timeout time.Duration) error
 
 	WorkspaceName(endpoint *registry.NSERegistration) string
 

--- a/controlplane/pkg/services/client_connection_manager.go
+++ b/controlplane/pkg/services/client_connection_manager.go
@@ -6,7 +6,7 @@ import (
 	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/crossconnect"
 	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/local/connection"
 	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/nsm"
-	connection2 "github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/remote/connection"
+	remote_connection "github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/remote/connection"
 	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/model"
 	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/serviceregistry"
 	"github.com/sirupsen/logrus"
@@ -53,7 +53,7 @@ func (m *ClientConnectionManager) UpdateClientConnectionDstStateDown(clientConne
 	if clientConnection.Xcon.GetLocalDestination() != nil {
 		clientConnection.Xcon.GetLocalDestination().State = connection.State_DOWN
 	} else if clientConnection.Xcon.GetRemoteDestination() != nil {
-		clientConnection.Xcon.GetRemoteDestination().State = connection2.State_DOWN
+		clientConnection.Xcon.GetRemoteDestination().State = remote_connection.State_DOWN
 	}
 	m.model.UpdateClientConnection(clientConnection)
 	m.manager.Heal(clientConnection, nsm.HealState_DstDown)

--- a/controlplane/pkg/services/client_connection_manager.go
+++ b/controlplane/pkg/services/client_connection_manager.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"context"
+
 	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/crossconnect"
 	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/local/connection"
 	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/nsm"
@@ -33,7 +34,7 @@ func (m *ClientConnectionManager) UpdateClientConnectionSrcStateDown(clientConne
 	logrus.Info("ClientConnection src state is down")
 	clientConnection.Xcon.GetLocalSource().State = connection.State_DOWN
 	m.model.UpdateClientConnection(clientConnection)
-	_= m.manager.Close(context.Background(), clientConnection)
+	_ = m.manager.Close(context.Background(), clientConnection)
 }
 
 func (m *ClientConnectionManager) UpdateClientConnectionDataplaneStateDown(clientConnections []*model.ClientConnection) {
@@ -51,7 +52,7 @@ func (m *ClientConnectionManager) UpdateClientConnectionDstStateDown(clientConne
 	logrus.Info("ClientConnection dst state is down")
 	if clientConnection.Xcon.GetLocalDestination() != nil {
 		clientConnection.Xcon.GetLocalDestination().State = connection.State_DOWN
-	} else if( clientConnection.Xcon.GetRemoteDestination() != nil) {
+	} else if clientConnection.Xcon.GetRemoteDestination() != nil {
 		clientConnection.Xcon.GetRemoteDestination().State = connection2.State_DOWN
 	}
 	m.model.UpdateClientConnection(clientConnection)

--- a/controlplane/pkg/tests/dataplane_heal_test.go
+++ b/controlplane/pkg/tests/dataplane_heal_test.go
@@ -1,0 +1,102 @@
+package tests
+
+import (
+	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/connectioncontext"
+	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/local/connection"
+	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/local/networkservice"
+	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/registry"
+	connection2 "github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/remote/connection"
+	. "github.com/onsi/gomega"
+	"golang.org/x/net/context"
+	"testing"
+	"time"
+)
+
+func TestHealLocalDataplane(t *testing.T) {
+	RegisterTestingT(t)
+
+	srv := newNSMDFullServer()
+	srv2 := newNSMDFullServer()
+	defer srv.Stop()
+	defer srv2.Stop()
+
+	srv.testModel.AddDataplane(testDataplane1)
+	srv2.testModel.AddDataplane(testDataplane2)
+
+	// Register in both
+	nseReg := srv.registerFakeEndpointWithName("golden_network", "test", srv2.serviceRegistry.GetPublicAPI(), "ep1")
+
+	// Add to local endpoints for Server2
+	srv2.testModel.AddEndpoint(nseReg)
+
+	l1 := newTestConnectionModelListener()
+	l2 := newTestConnectionModelListener()
+
+	srv.testModel.AddListener(l1)
+	srv2.testModel.AddListener(l2)
+
+	// Now we could try to connect via Client API
+	nsmClient, conn := srv.requestNSMConnection("nsm-1")
+	defer conn.Close()
+
+	request := &networkservice.NetworkServiceRequest{
+		Connection: &connection.Connection{
+			NetworkService: "golden_network",
+			Context: &connectioncontext.ConnectionContext{
+				DstIpRequired: true,
+				SrcIpRequired: true,
+			},
+			Labels: make(map[string]string),
+		},
+		MechanismPreferences: []*connection.Mechanism{
+			{
+				Type: connection.MechanismType_KERNEL_INTERFACE,
+				Parameters: map[string]string{
+					connection.NetNsInodeKey:    "10",
+					connection.InterfaceNameKey: "icmp-responder1",
+				},
+			},
+		},
+	}
+
+	nsmResponse, err := nsmClient.Request(context.Background(), request)
+	Expect(err).To(BeNil())
+	Expect(nsmResponse.GetNetworkService()).To(Equal("golden_network"))
+
+	// We need to check for cross connections.
+	clientConnection1 := srv.testModel.GetClientConnection(nsmResponse.GetId())
+	Expect(clientConnection1.GetId()).To(Equal("1"))
+	Expect(clientConnection1.Xcon.GetRemoteDestination().GetMechanism().GetParameters()[connection2.VXLANSrcIP]).To(Equal("127.0.0.1"))
+
+	clientConnection2 := srv2.testModel.GetClientConnection(clientConnection1.Xcon.GetRemoteDestination().GetId())
+	Expect(clientConnection2.GetId()).To(Equal("1"))
+
+	timeout := time.Second * 10
+
+	l1.WaitAdd(1, timeout, t)
+	// We need to inform cross connection monitor about this connection, since dataplane is fake one.
+	epName := clientConnection1.Endpoint.NetworkserviceEndpoint.GetEndpointName()
+	_, err = srv.nseRegistry.RemoveNSE(context.Background(), &registry.RemoveNSERequest{
+		EndpointName: epName,
+	})
+	if err != nil {
+		t.Fatal("Err must be nil")
+	}
+
+	// Simlate dataplane dead
+	srv.testModel.AddDataplane(testDataplane1_1)
+	srv.testModel.DeleteDataplane(testDataplane1.RegisteredName)
+
+	// We need to inform cross connection monitor about this connection, since dataplane is fake one.
+	// First update is with down state
+	// But we want to wait for Up state
+	l1.WaitUpdate(2, timeout, t)
+	// We need to inform cross connection monitor about this connection, since dataplane is fake one.
+
+	clientConnection1_1 := srv.testModel.GetClientConnection(nsmResponse.GetId())
+	Expect(clientConnection1_1 != nil).To(Equal(true))
+	Expect(clientConnection1_1.GetId()).To(Equal("1"))
+	Expect(clientConnection1_1.Xcon.GetRemoteDestination().GetId()).To(Equal("1"))
+	Expect(clientConnection1_1.Xcon.GetRemoteDestination().GetNetworkServiceEndpointName()).To(Equal(epName))
+	Expect(clientConnection1_1.Xcon.GetRemoteDestination().GetMechanism().GetParameters()[connection2.VXLANSrcIP]).To(Equal("127.0.0.7"))
+}

--- a/controlplane/pkg/tests/heal_nse_test.go
+++ b/controlplane/pkg/tests/heal_nse_test.go
@@ -1,0 +1,110 @@
+package tests
+
+import (
+	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/connectioncontext"
+	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/local/connection"
+	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/local/networkservice"
+	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/nsm"
+	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/registry"
+	. "github.com/onsi/gomega"
+	"golang.org/x/net/context"
+	"testing"
+	"time"
+)
+
+func TestHealRemoteNSE(t *testing.T) {
+	RegisterTestingT(t)
+
+	srv := newNSMDFullServer()
+	srv2 := newNSMDFullServer()
+	defer srv.Stop()
+	defer srv2.Stop()
+
+	srv.testModel.AddDataplane(testDataplane1)
+	srv2.testModel.AddDataplane(testDataplane2)
+
+	// Register in both
+	nseReg := srv.registerFakeEndpointWithName("golden_network", "test", srv2.serviceRegistry.GetPublicAPI(), "ep1")
+	nseReg2 := srv.registerFakeEndpointWithName("golden_network", "test", srv2.serviceRegistry.GetPublicAPI(), "ep2")
+
+	// Add to local endpoints for Server2
+	srv2.testModel.AddEndpoint(nseReg)
+	srv2.testModel.AddEndpoint(nseReg2)
+
+	l1 := newTestConnectionModelListener()
+	l2 := newTestConnectionModelListener()
+
+	srv.testModel.AddListener(l1)
+	srv2.testModel.AddListener(l2)
+
+	// Now we could try to connect via Client API
+	nsmClient, conn := srv.requestNSMConnection("nsm-1")
+	defer conn.Close()
+
+	request := &networkservice.NetworkServiceRequest{
+		Connection: &connection.Connection{
+			NetworkService: "golden_network",
+			Context: &connectioncontext.ConnectionContext{
+				DstIpRequired: true,
+				SrcIpRequired: true,
+			},
+			Labels: make(map[string]string),
+		},
+		MechanismPreferences: []*connection.Mechanism{
+			{
+				Type: connection.MechanismType_KERNEL_INTERFACE,
+				Parameters: map[string]string{
+					connection.NetNsInodeKey:    "10",
+					connection.InterfaceNameKey: "icmp-responder1",
+				},
+			},
+		},
+	}
+
+	timeout := time.Second * 1000
+
+	nsmResponse, err := nsmClient.Request(context.Background(), request)
+	Expect(err).To(BeNil())
+	Expect(nsmResponse.GetNetworkService()).To(Equal("golden_network"))
+
+	// We need to check for cross connections.
+	clientConnection1 := srv.testModel.GetClientConnection(nsmResponse.GetId())
+	Expect(clientConnection1.GetId()).To(Equal("1"))
+
+	clientConnection2 := srv2.testModel.GetClientConnection(clientConnection1.Xcon.GetRemoteDestination().GetId())
+	Expect(clientConnection2.GetId()).To(Equal("1"))
+
+	// We need to inform cross connection monitor about this connection, since dataplane is fake one.
+	l1.WaitAdd(1, timeout, t)
+
+	epName := clientConnection1.Endpoint.NetworkserviceEndpoint.GetEndpointName()
+	_, err = srv.nseRegistry.RemoveNSE(context.Background(), &registry.RemoveNSERequest{
+		EndpointName: epName,
+	})
+	if err != nil {
+		t.Fatal("Err must be nil")
+	}
+
+	err = srv2.testModel.DeleteEndpoint(epName)
+	if err != nil {
+		t.Fatal("Err must be nil")
+	}
+	// Simlate delete
+	clientConnection2.Xcon.GetLocalDestination().State = connection.State_DOWN
+	srv2.manager.Heal(clientConnection2, nsm.HealState_DstDown)
+
+	// First update, is delete
+	// Second update is update
+	l1.WaitUpdate(2, timeout, t)
+
+	// Choose a epName not first one.
+	newEpName := "ep1"
+	if epName == newEpName {
+		newEpName = "ep2"
+	}
+
+	clientConnection1_1 := srv.testModel.GetClientConnection(nsmResponse.GetId())
+	Expect(clientConnection1_1.GetId()).To(Equal("1"))
+	Expect(clientConnection1_1.Xcon.GetRemoteDestination().GetId()).To(Equal("4"))
+	Expect(clientConnection1_1.Xcon.GetRemoteDestination().GetNetworkServiceEndpointName()).To(Equal(newEpName))
+}

--- a/controlplane/pkg/tests/heal_nse_test.go
+++ b/controlplane/pkg/tests/heal_nse_test.go
@@ -61,7 +61,7 @@ func TestHealRemoteNSE(t *testing.T) {
 		},
 	}
 
-	timeout := time.Second * 1000
+	timeout := time.Second * 10
 
 	nsmResponse, err := nsmClient.Request(context.Background(), request)
 	Expect(err).To(BeNil())

--- a/controlplane/pkg/tests/nsmd_local_test.go
+++ b/controlplane/pkg/tests/nsmd_local_test.go
@@ -12,6 +12,7 @@ import (
 	context2 "golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"os"
+	"strings"
 	"testing"
 )
 
@@ -134,7 +135,7 @@ func TestNSENoSrc(t *testing.T) {
 
 	nsmResponse, err := nsmClient.Request(context.Background(), request)
 	println(err.Error())
-	Expect(err.Error()).To(Equal("rpc error: code = Unknown desc = Failed to find NSE for NetworkService golden_network. Checked: 1 of total NSEs: 0. Last NSE Error: failure Validating NSE Connection: ConnectionContext.SrcIp is required cannot be empty/nil: dst_ip_addr:\"169083137/30\" "))
+	Expect(strings.Contains(err.Error(), "failure Validating NSE Connection: ConnectionContext.SrcIp is required cannot be empty/nil")).To(Equal(true))
 	Expect(nsmResponse).To(BeNil())
 }
 

--- a/controlplane/pkg/tests/nsmd_remote_test.go
+++ b/controlplane/pkg/tests/nsmd_remote_test.go
@@ -21,43 +21,10 @@ func TestNSMDRequestClientRemoteNSMD(t *testing.T) {
 	srv2 := newNSMDFullServer()
 	defer srv.Stop()
 	defer srv2.Stop()
-	srv.testModel.AddDataplane(&model.Dataplane{
-		RegisteredName: "test_data_plane",
-		SocketLocation: "tcp:some_addr",
-		LocalMechanisms: []*connection.Mechanism{
-			&connection.Mechanism {
-				Type: connection.MechanismType_KERNEL_INTERFACE,
-			},
-		},
-		RemoteMechanisms: []*connection2.Mechanism{
-			&connection2.Mechanism{
-				Type: connection2.MechanismType_VXLAN,
-				Parameters: map[string]string{
-					connection2.VXLANVNI:   "1",
-					connection2.VXLANSrcIP: "127.0.0.1",
-				},
-			},
-		},
-	})
 
-	srv2.testModel.AddDataplane(&model.Dataplane{
-		RegisteredName: "test_data_plane",
-		SocketLocation: "tcp:some_addr",
-		LocalMechanisms: []*connection.Mechanism{
-			&connection.Mechanism {
-				Type: connection.MechanismType_KERNEL_INTERFACE,
-			},
-		},
-		RemoteMechanisms: []*connection2.Mechanism{
-			&connection2.Mechanism{
-				Type: connection2.MechanismType_VXLAN,
-				Parameters: map[string]string{
-					connection2.VXLANVNI:   "3",
-					connection2.VXLANSrcIP: "127.0.0.2",
-				},
-			},
-		},
-	})
+	srv.testModel.AddDataplane(testDataplane1)
+
+	srv2.testModel.AddDataplane(testDataplane2)
 
 	// Register in both
 	nseReg := srv.registerFakeEndpoint("golden_network", "test", srv2.serviceRegistry.GetPublicAPI())
@@ -109,7 +76,7 @@ func TestNSMDCloseCrossConnection(t *testing.T) {
 		RegisteredName: "test_data_plane",
 		SocketLocation: "tcp:some_addr",
 		LocalMechanisms: []*connection.Mechanism{
-			&connection.Mechanism {
+			&connection.Mechanism{
 				Type: connection.MechanismType_KERNEL_INTERFACE,
 			},
 		},

--- a/controlplane/pkg/tests/test-listener.go
+++ b/controlplane/pkg/tests/test-listener.go
@@ -1,0 +1,90 @@
+package tests
+
+import (
+	"github.com/golang/protobuf/proto"
+	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/model"
+	"github.com/sirupsen/logrus"
+	"testing"
+	"time"
+)
+
+type testConnectionModelListener struct {
+	model.ModelListenerImpl
+	additions int
+	updates   int
+	deletions int
+
+	connections   map[string]*model.ClientConnection
+	textMarshaler proto.TextMarshaler
+}
+
+func (impl *testConnectionModelListener) ClientConnectionAdded(clientConnection *model.ClientConnection) {
+	impl.additions++
+	impl.connections[clientConnection.GetId()] = clientConnection
+	logrus.Infof("ClientConnectionAdded: %v", clientConnection)
+}
+
+func (impl *testConnectionModelListener) ClientConnectionDeleted(clientConnection *model.ClientConnection) {
+	impl.deletions++
+	logrus.Infof("ClientConnectionDeleted: %v", clientConnection)
+	delete(impl.connections, clientConnection.GetId())
+}
+
+func (impl *testConnectionModelListener) ClientConnectionUpdated(clientConnection *model.ClientConnection) {
+	impl.updates++
+	impl.connections[clientConnection.GetId()] = clientConnection
+	logrus.Infof("ClientConnectionUpdated: %s %v", clientConnection.GetId(), impl.textMarshaler.Text(clientConnection.Xcon))
+}
+
+func (impl *testConnectionModelListener) WaitAdd(count int, duration time.Duration, t *testing.T) {
+	st := time.Now()
+	for {
+		<-time.Tick(1 * time.Second)
+		if impl.additions == count {
+			break
+		}
+		if time.Since(st) > duration {
+			t.Fatalf("Failed to wait for add events.. %d timeout happened...", count)
+			break
+		}
+		logrus.Warnf("Waiting for additions: %d to match %d", impl.additions, count)
+	}
+}
+func (impl *testConnectionModelListener) WaitUpdate(count int, duration time.Duration, t *testing.T) {
+	st := time.Now()
+	for {
+		<-time.Tick(1 * time.Second)
+		if impl.updates == count {
+			break
+		}
+		if time.Since(st) > duration {
+			t.Fatalf("Failed to wait for add events.. %d timeout happened...", count)
+			break
+		}
+		logrus.Warnf("Waiting for updates: %d to match %d", impl.updates, count)
+	}
+}
+
+func (impl *testConnectionModelListener) WaitDelete(count int, duration time.Duration, t *testing.T) {
+	st := time.Now()
+	for {
+		<-time.Tick(1 * time.Second)
+		if impl.deletions == count {
+			break
+		}
+		if time.Since(st) > duration {
+			t.Fatalf("Failed to wait for add events.. %d timeout happened...", count)
+			break
+		}
+		logrus.Warnf("Waiting for deletions: %d to match %d", impl.deletions, count)
+	}
+}
+func newTestConnectionModelListener() *testConnectionModelListener {
+	return &testConnectionModelListener{
+		updates:       0,
+		additions:     0,
+		deletions:     0,
+		textMarshaler: proto.TextMarshaler{},
+		connections:   map[string]*model.ClientConnection{},
+	}
+}

--- a/controlplane/pkg/tests/test_dataplanes.go
+++ b/controlplane/pkg/tests/test_dataplanes.go
@@ -1,0 +1,60 @@
+package tests
+
+import (
+	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/local/connection"
+	connection2 "github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/remote/connection"
+	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/model"
+)
+
+var testDataplane1 = &model.Dataplane{
+	RegisteredName: "test_data_plane",
+	SocketLocation: "tcp:some_addr",
+	LocalMechanisms: []*connection.Mechanism{
+		&connection.Mechanism{
+			Type: connection.MechanismType_KERNEL_INTERFACE,
+		},
+	},
+	RemoteMechanisms: []*connection2.Mechanism{
+		&connection2.Mechanism{
+			Type: connection2.MechanismType_VXLAN,
+			Parameters: map[string]string{
+				connection2.VXLANSrcIP: "127.0.0.1",
+			},
+		},
+	},
+}
+var testDataplane1_1 = &model.Dataplane{
+	RegisteredName: "test_data_plane_11",
+	SocketLocation: "tcp:some_addr",
+	LocalMechanisms: []*connection.Mechanism{
+		&connection.Mechanism{
+			Type: connection.MechanismType_KERNEL_INTERFACE,
+		},
+	},
+	RemoteMechanisms: []*connection2.Mechanism{
+		&connection2.Mechanism{
+			Type: connection2.MechanismType_VXLAN,
+			Parameters: map[string]string{
+				connection2.VXLANSrcIP: "127.0.0.7",
+			},
+		},
+	},
+}
+
+var testDataplane2 = &model.Dataplane{
+	RegisteredName: "test_data_plane2",
+	SocketLocation: "tcp:some_addr",
+	LocalMechanisms: []*connection.Mechanism{
+		&connection.Mechanism{
+			Type: connection.MechanismType_KERNEL_INTERFACE,
+		},
+	},
+	RemoteMechanisms: []*connection2.Mechanism{
+		&connection2.Mechanism{
+			Type: connection2.MechanismType_VXLAN,
+			Parameters: map[string]string{
+				connection2.VXLANSrcIP: "127.0.0.2",
+			},
+		},
+	},
+}

--- a/test/integration/death_handling_test.go
+++ b/test/integration/death_handling_test.go
@@ -66,7 +66,7 @@ func testDie(t *testing.T, killSrc bool, nodesCount int) {
 
 	nodes := nsmd_test_utils.SetupNodes(k8s, nodesCount)
 
-	icmp := nsmd_test_utils.DeployIcmp(k8s, nodes[nodesCount-1].Node)
+	icmp := nsmd_test_utils.DeployIcmp(k8s, nodes[nodesCount-1].Node, "icmp-responder-nse1")
 	nsc := nsmd_test_utils.DeployNsc(k8s, nodes[0].Node, "nsc1")
 
 	failures := InterceptGomegaFailures(func() {
@@ -95,7 +95,7 @@ func testDie(t *testing.T, killSrc bool, nodesCount int) {
 			podToCheck = nsc
 		}
 
-		k8s.DeletePods("default", podToKill)
+		k8s.DeletePods(podToKill)
 		success := false
 		for attempt := 0; attempt < 20; <-time.Tick(300 * time.Millisecond) {
 			attempt++

--- a/test/integration/monitor_crossconnect_test.go
+++ b/test/integration/monitor_crossconnect_test.go
@@ -34,7 +34,7 @@ func TestSingleCrossConnect(t *testing.T) {
 	nodesCount := 2
 
 	nodes := nsmd_test_utils.SetupNodes(k8s, nodesCount)
-	nsmd_test_utils.DeployIcmp(k8s, nodes[nodesCount-1].Node)
+	nsmd_test_utils.DeployIcmp(k8s, nodes[nodesCount-1].Node, "icmp-responder-nse1")
 	nsmd_test_utils.DeployNsc(k8s, nodes[0].Node, "nsc1")
 
 	fwd, err := k8s.NewPortForwarder(nodes[0].Nsmd, 5001)
@@ -101,7 +101,7 @@ func TestSingleCrossConnectMonitorBeforeXcons(t *testing.T) {
 	nsmdMonitor2, close2, cancel2 := createCrossConnectClient(fmt.Sprintf("localhost:%d", fwd2.ListenPort))
 	defer close2()
 
-	nsmd_test_utils.DeployIcmp(k8s, nodes[nodesCount-1].Node)
+	nsmd_test_utils.DeployIcmp(k8s, nodes[nodesCount-1].Node, "icmp-responder-nse1")
 	nsmd_test_utils.DeployNsc(k8s, nodes[0].Node, "nsc1")
 
 	_, err = getCrossConnectsFromMonitor(nsmdMonitor1, cancel1, 1, 50*time.Second)
@@ -129,7 +129,7 @@ func TestSeveralCrossConnects(t *testing.T) {
 	nodesCount := 2
 
 	nodes := nsmd_test_utils.SetupNodes(k8s, nodesCount)
-	nsmd_test_utils.DeployIcmp(k8s, nodes[nodesCount-1].Node)
+	nsmd_test_utils.DeployIcmp(k8s, nodes[nodesCount-1].Node,"icmp-responder-nse1")
 	nsmd_test_utils.DeployNsc(k8s, nodes[0].Node, "nsc1")
 	nsmd_test_utils.DeployNsc(k8s, nodes[0].Node, "nsc2")
 
@@ -177,7 +177,7 @@ func TestCrossConnectMonitorRestart(t *testing.T) {
 	nodesCount := 2
 
 	nodes := nsmd_test_utils.SetupNodes(k8s, nodesCount)
-	nsmd_test_utils.DeployIcmp(k8s, nodes[nodesCount-1].Node)
+	nsmd_test_utils.DeployIcmp(k8s, nodes[nodesCount-1].Node, "icmp-responder-nse1")
 	nsmd_test_utils.DeployNsc(k8s, nodes[0].Node, "nsc1")
 	nsmd_test_utils.DeployNsc(k8s, nodes[0].Node, "nsc2")
 

--- a/test/integration/nsc_deploy_test.go
+++ b/test/integration/nsc_deploy_test.go
@@ -37,6 +37,6 @@ func TestDeployPodIntoInvalidEnv(t *testing.T) {
 	nsmdPodNode1, err := k8s.CreatePodsRaw(10*time.Second, false, pods.NSCPod("nsc1", &nodes[0], map[string]string{}))
 	Expect(len(nsmdPodNode1)).To(Equal(1))
 
-	k8s.DeletePods("default", nsmdPodNode1...)
+	k8s.DeletePods(nsmdPodNode1...)
 
 }

--- a/test/integration/nse_dataplane_heal_test.go
+++ b/test/integration/nse_dataplane_heal_test.go
@@ -48,8 +48,6 @@ func testDataplaneHeal(t *testing.T, nodesCount int) {
 	logrus.Printf("Cleanup done: %v", time.Since(s1))
 
 	// Deploy open tracing to see what happening.
-	jaeger := k8s.CreatePod(pods.Jaeger())
-	k8s.CreateService(pods.JaegerService(jaeger))
 	nodes_setup := nsmd_test_utils.SetupNodes(k8s, nodesCount )
 
 	// Run ICMP on latest node

--- a/test/integration/nse_dataplane_heal_test.go
+++ b/test/integration/nse_dataplane_heal_test.go
@@ -1,6 +1,7 @@
 package nsmd_integration_tests
 
 import (
+	"fmt"
 	"github.com/networkservicemesh/networkservicemesh/test/integration/nsmd_test_utils"
 	"github.com/networkservicemesh/networkservicemesh/test/kube_testing/pods"
 	"strings"
@@ -12,7 +13,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-func TestNSEHealLocal(t *testing.T) {
+func TestDataplaneHealLocal(t *testing.T) {
 	RegisterTestingT(t)
 
 	if testing.Short() {
@@ -20,10 +21,10 @@ func TestNSEHealLocal(t *testing.T) {
 		return
 	}
 
-	testNSEHeal(t, 1)
+	testDataplaneHeal(t, 1)
 }
 
-func TestNSEHealRemote(t *testing.T) {
+func TestDataplaneHealRemote(t *testing.T) {
 	RegisterTestingT(t)
 
 	if testing.Short() {
@@ -31,13 +32,13 @@ func TestNSEHealRemote(t *testing.T) {
 		return
 	}
 
-	testNSEHeal(t, 2)
+	testDataplaneHeal(t, 2)
 }
 
 /**
 If passed 1 both will be on same node, if not on different.
 */
-func testNSEHeal(t *testing.T, nodesCount int) {
+func testDataplaneHeal(t *testing.T, nodesCount int) {
 	k8s, err := kube_testing.NewK8s()
 	defer k8s.Cleanup()
 
@@ -53,7 +54,7 @@ func testNSEHeal(t *testing.T, nodesCount int) {
 	nodes_setup := nsmd_test_utils.SetupNodes(k8s, nodesCount )
 
 	// Run ICMP on latest node
-	nse1 := nsmd_test_utils.DeployIcmp(k8s, nodes_setup[nodesCount-1].Node, "icmp-responder-nse1")
+	_ = nsmd_test_utils.DeployIcmp(k8s, nodes_setup[nodesCount-1].Node, "icmp-responder-nse1")
 
 	nscPodNode := nsmd_test_utils.DeployNsc(k8s, nodes_setup[0].Node, "nsc1")
 	var nscInfo *nsmd_test_utils.NSCCheckInfo
@@ -63,15 +64,21 @@ func testNSEHeal(t *testing.T, nodesCount int) {
 	// Do dumping of container state to dig into what is happened.
 	printErrors(failures, k8s, nodes_setup, nscInfo, t)
 
-	// Since all is fine now, we need to add new ICMP responder and delete previous one.
-	_ = nsmd_test_utils.DeployIcmp(k8s, nodes_setup[nodesCount-1].Node, "icmp-responder-nse2")
+	logrus.Infof("Delete Selected dataplane")
+	k8s.DeletePods(nodes_setup[nodesCount-1].Dataplane)
 
-	logrus.Infof("Delete first NSE")
-	k8s.DeletePods(nse1)
+	k8s.WaitLogsContains(nodes_setup[nodesCount-1].Nsmd, "nsmd", "Waiting for Dataplane to recovery...", 60*time.Second)
+	// Now are are in dataplane dead state, and in Heal procedure waiting for dataplane.
+	dpName := fmt.Sprintf("dataplane-recovered-%d", nodesCount-1)
+	startTime := time.Now()
+	nodes_setup[nodesCount-1].Dataplane = k8s.CreatePod(pods.VPPDataplanePod(dpName, nodes_setup[nodesCount-1].Node))
+	logrus.Printf("Started new Dataplane: %v on node %s", time.Since(startTime), nodes_setup[nodesCount-1].Node.Name)
+
+	// Check NSMd goint into HEAL state.
 
 	logrus.Infof("Waiting for connection recovery...")
-	k8s.WaitLogsContains(nodes_setup[0].Nsmd, "nsmd", "Heal: Connection recovered:", 60*time.Second)
-	l1, err := k8s.GetLogs(nodes_setup[0].Nsmd, "nsmd")
+	k8s.WaitLogsContains(nodes_setup[nodesCount-1].Nsmd, "nsmd", "Heal: Connection recovered:", 60*time.Second)
+	l1, err := k8s.GetLogs(nodes_setup[nodesCount-1].Nsmd, "nsmd")
 
 	Expect(err).To(BeNil())
 	if strings.Contains(l1, "Dataplane0 request failed:") {
@@ -90,14 +97,4 @@ func testNSEHeal(t *testing.T, nodesCount int) {
 		nscInfo = nsmd_test_utils.CheckNSC(k8s, t, nscPodNode)
 	})
 	printErrors(failures, k8s, nodes_setup, nscInfo, t)
-}
-
-func printErrors(failures []string, k8s *kube_testing.K8s, nodes_setup []*nsmd_test_utils.NodeConf, nscInfo *nsmd_test_utils.NSCCheckInfo, t *testing.T) {
-	if len(failures) > 0 {
-		logrus.Errorf("Failures: %v", failures)
-		nsmd_test_utils.PrintLogs(k8s, nodes_setup);
-		nscInfo.PrintLogs()
-
-		t.Fail()
-	}
 }

--- a/test/integration/nse_heal_test.go
+++ b/test/integration/nse_heal_test.go
@@ -67,12 +67,11 @@ func testNSEHeal(t *testing.T, nodesCount int) {
 	k8s.DeletePods(nse1)
 
 	logrus.Infof("Waiting for connection recovery...")
-	k8s.WaitLogsContains(nodes_setup[0].Nsmd, "nsmd", "Heal: Connection recovered:", 60*time.Second)
-	l1, err := k8s.GetLogs(nodes_setup[0].Nsmd, "nsmd")
-
-	Expect(err).To(BeNil())
-	if strings.Contains(l1, "Dataplane0 request failed:") {
-		logrus.Infof("Dataplane first attempt was failed: %v", l1)
+	failures = InterceptGomegaFailures(func() {
+		k8s.WaitLogsContains(nodes_setup[0].Nsmd, "nsmd", "Heal: Connection recovered:", 60*time.Second)
+	})
+	if len(failures) > 0 {
+		printErrors(failures, k8s, nodes_setup, nscInfo, t)
 	}
 
 	if len(nodes_setup) > 1 {

--- a/test/integration/nse_heal_test.go
+++ b/test/integration/nse_heal_test.go
@@ -2,7 +2,6 @@ package nsmd_integration_tests
 
 import (
 	"github.com/networkservicemesh/networkservicemesh/test/integration/nsmd_test_utils"
-	"github.com/networkservicemesh/networkservicemesh/test/kube_testing/pods"
 	"strings"
 	"testing"
 	"time"
@@ -48,8 +47,6 @@ func testNSEHeal(t *testing.T, nodesCount int) {
 	logrus.Printf("Cleanup done: %v", time.Since(s1))
 
 	// Deploy open tracing to see what happening.
-	jaeger := k8s.CreatePod(pods.Jaeger())
-	k8s.CreateService(pods.JaegerService(jaeger))
 	nodes_setup := nsmd_test_utils.SetupNodes(k8s, nodesCount )
 
 	// Run ICMP on latest node

--- a/test/integration/nsmd_deploy_test.go
+++ b/test/integration/nsmd_deploy_test.go
@@ -46,8 +46,8 @@ func TestNSMDDdataplabeDeploy(t *testing.T) {
 		}
 	}
 
-	k8s.DeletePods("default", nsmdPodNode1...)
-	k8s.DeletePods("default", nsmdPodNode2...)
+	k8s.DeletePods(nsmdPodNode1...)
+	k8s.DeletePods(nsmdPodNode2...)
 	var count int = 0
 	for _, lpod := range k8s.ListPods() {
 		logrus.Printf("Found pod %s %+v", lpod.Name, lpod.Status)

--- a/test/integration/nsmd_test_utils/test_utils.go
+++ b/test/integration/nsmd_test_utils/test_utils.go
@@ -3,7 +3,6 @@ package nsmd_test_utils
 import (
 	"fmt"
 	"time"
-
 	"github.com/networkservicemesh/networkservicemesh/test/kube_testing"
 	"github.com/networkservicemesh/networkservicemesh/test/kube_testing/pods"
 	. "github.com/onsi/gomega"
@@ -11,7 +10,6 @@ import (
 	"k8s.io/api/core/v1"
 	"strings"
 	"testing"
-	"time"
 )
 
 const defaultTimeout = 60 * time.Second

--- a/test/integration/nsmd_test_utils/test_utils.go
+++ b/test/integration/nsmd_test_utils/test_utils.go
@@ -8,7 +8,10 @@ import (
 	"github.com/networkservicemesh/networkservicemesh/test/kube_testing/pods"
 	. "github.com/onsi/gomega"
 	"github.com/sirupsen/logrus"
-	v1 "k8s.io/api/core/v1"
+	"k8s.io/api/core/v1"
+	"strings"
+	"testing"
+	"time"
 )
 
 const defaultTimeout = 60 * time.Second
@@ -56,23 +59,23 @@ func deployNsmdAndDataplane(k8s *kube_testing.K8s, node *v1.Node) (nsmd *v1.Pod,
 	return
 }
 
-func DeployIcmp(k8s *kube_testing.K8s, node *v1.Node) (icmp *v1.Pod) {
+func DeployIcmp(k8s *kube_testing.K8s, node *v1.Node, name string) (icmp *v1.Pod) {
 	startTime := time.Now()
 
 	logrus.Infof("Starting ICMP Responder NSE on node: %s", node.Name)
-	icmp = k8s.CreatePod(pods.ICMPResponderPod("icmp-responder-nse1", node,
+	icmp = k8s.CreatePod(pods.ICMPResponderPod(name, node,
 		map[string]string{
 			"ADVERTISE_NSE_NAME":   "icmp-responder",
 			"ADVERTISE_NSE_LABELS": "app=icmp",
 			"IP_ADDRESS":           "10.20.1.0/24",
 		},
 	))
-	Expect(icmp.Name).To(Equal("icmp-responder-nse1"))
+	Expect(icmp.Name).To(Equal(name))
 
 	k8s.WaitLogsContains(icmp, "", "NSE: channel has been successfully advertised, waiting for connection from NSM...", defaultTimeout)
 
-	logrus.Printf("ICMP Responder started done: %v", time.Since(startTime))
-	return
+	logrus.Printf("ICMP Responder %v started done: %v", name, time.Since(startTime))
+	return icmp
 }
 
 func DeployNsc(k8s *kube_testing.K8s, node *v1.Node, name string) (nsc *v1.Pod) {
@@ -89,5 +92,62 @@ func DeployNsc(k8s *kube_testing.K8s, node *v1.Node, name string) (nsc *v1.Pod) 
 
 	k8s.WaitLogsContains(nsc, "nsc", "nsm client: initialization is completed successfully", defaultTimeout)
 	logrus.Printf("NSC started done: %v", time.Since(startTime))
-	return
+	return nsc
+}
+
+func PrintLogs(k8s *kube_testing.K8s, nodesSetup []*NodeConf) {
+	for k := 0; k < len(nodesSetup); k++ {
+		nsmdPod := nodesSetup[k].Nsmd
+		nsmdLogs, _ := k8s.GetLogs(nsmdPod, "nsmd")
+		logrus.Errorf("===================== NSMD %d output since test is failing %v\n=====================", k, nsmdLogs)
+
+		nsmdk8sLogs, _ := k8s.GetLogs(nsmdPod, "nsmd-k8s")
+		logrus.Errorf("===================== NSMD K8S %d output since test is failing %v\n=====================", k, nsmdk8sLogs)
+
+		nsmdpLogs, _ := k8s.GetLogs(nsmdPod, "nsmdp")
+		logrus.Errorf("===================== NSMD K8S %d output since test is failing %v\n=====================", k, nsmdpLogs)
+
+		dataplaneLogs, _ := k8s.GetLogs(nodesSetup[k].Dataplane, "")
+		logrus.Errorf("===================== Dataplane %d output since test is failing %v\n=====================", k, dataplaneLogs)
+	}
+}
+
+type NSCCheckInfo struct {
+	ipResponse string
+	routeResponse string
+	pingResponse string
+	errOut string
+}
+
+func (info *NSCCheckInfo) PrintLogs() {
+	logrus.Errorf("===================== NSC IP Addr %v\n=====================", info.ipResponse)
+	logrus.Errorf("===================== NSC IP Route %v\n=====================", info.routeResponse)
+	logrus.Errorf("===================== NSC IP PING %v\n=====================", info.pingResponse)
+	logrus.Errorf("===================== NSC errOut %v\n=====================", info.errOut)
+}
+
+func CheckNSC(k8s *kube_testing.K8s, t *testing.T, nscPodNode *v1.Pod) *NSCCheckInfo {
+	var err error
+	info := &NSCCheckInfo{}
+	info.ipResponse, info.errOut, err = k8s.Exec(nscPodNode, nscPodNode.Spec.Containers[0].Name, "ip", "addr")
+	Expect(err).To(BeNil())
+	Expect(info.errOut).To(Equal(""))
+	logrus.Printf("NSC IP status Ok")
+
+	Expect(strings.Contains(info.ipResponse, "10.20.1.1")).To(Equal(true))
+	Expect(strings.Contains(info.ipResponse, "nsm")).To(Equal(true))
+
+	info.routeResponse, info.errOut, err = k8s.Exec(nscPodNode, nscPodNode.Spec.Containers[0].Name, "ip", "route")
+	Expect(err).To(BeNil())
+	Expect(info.errOut).To(Equal(""))
+	logrus.Printf("NSC Route status, Ok")
+
+	Expect(strings.Contains(info.routeResponse, "8.8.8.8")).To(Equal(true))
+	Expect(strings.Contains(info.routeResponse, "nsm")).To(Equal(true))
+
+	info.pingResponse, info.errOut, err = k8s.Exec(nscPodNode, nscPodNode.Spec.Containers[0].Name, "ping", "10.20.1.2", "-c", "5")
+	Expect(err).To(BeNil())
+	Expect(strings.Contains(info.pingResponse, "5 packets transmitted, 5 packets received, 0% packet loss")).To(Equal(true))
+	logrus.Printf("NSC Ping is success:%s", info.pingResponse)
+	return info
 }

--- a/test/integration/vpn_test.go
+++ b/test/integration/vpn_test.go
@@ -2,6 +2,7 @@ package nsmd_integration_tests
 
 import (
 	"fmt"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -12,7 +13,7 @@ import (
 	"github.com/networkservicemesh/networkservicemesh/test/kube_testing/pods"
 	. "github.com/onsi/gomega"
 	"github.com/sirupsen/logrus"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 )
 
 func TestVPNLocal(t *testing.T) {
@@ -33,6 +34,10 @@ func TestVPNLocal(t *testing.T) {
 func TestVPNFirewallRemote(t *testing.T) {
 	RegisterTestingT(t)
 
+	if !isVPNRemoteEnabled() {
+		t.Skip("VPN_REMOTE_ENABLED not defined.")
+	}
+
 	if testing.Short() {
 		t.Skip("Skip, please run without -short")
 		return
@@ -48,6 +53,10 @@ func TestVPNFirewallRemote(t *testing.T) {
 func TestVPNNSERemote(t *testing.T) {
 	RegisterTestingT(t)
 
+	if !isVPNRemoteEnabled() {
+		t.Skip("VPN_REMOTE_ENABLED not defined.")
+	}
+
 	if testing.Short() {
 		t.Skip("Skip, please run without -short")
 		return
@@ -62,7 +71,11 @@ func TestVPNNSERemote(t *testing.T) {
 
 func TestVPNNSCRemote(t *testing.T) {
 	RegisterTestingT(t)
-	
+
+	if !isVPNRemoteEnabled() {
+		t.Skip("VPN_REMOTE_ENABLED not defined.")
+	}
+
 	if testing.Short() {
 		t.Skip("Skip, please run without -short")
 		return
@@ -73,6 +86,11 @@ func TestVPNNSCRemote(t *testing.T) {
 		"vpn-gateway-nse1":       0,
 		"vpn-gateway-nsc1":       1,
 	}, false)
+}
+
+func isVPNRemoteEnabled() bool {
+	_, ok := os.LookupEnv("VPN_REMOTE_ENABLED")
+	return ok
 }
 
 func testVPN(t *testing.T, nodesCount int, affinity map[string]int, verbose bool) {

--- a/test/integration/vpn_test.go
+++ b/test/integration/vpn_test.go
@@ -2,7 +2,6 @@ package nsmd_integration_tests
 
 import (
 	"fmt"
-	"os"
 	"strings"
 	"testing"
 	"time"
@@ -13,7 +12,7 @@ import (
 	"github.com/networkservicemesh/networkservicemesh/test/kube_testing/pods"
 	. "github.com/onsi/gomega"
 	"github.com/sirupsen/logrus"
-	v1 "k8s.io/api/core/v1"
+	"k8s.io/api/core/v1"
 )
 
 func TestVPNLocal(t *testing.T) {
@@ -34,10 +33,6 @@ func TestVPNLocal(t *testing.T) {
 func TestVPNFirewallRemote(t *testing.T) {
 	RegisterTestingT(t)
 
-	if !isVPNRemoteEnabled() {
-		t.Skip("VPN_REMOTE_ENABLED not defined.")
-	}
-
 	if testing.Short() {
 		t.Skip("Skip, please run without -short")
 		return
@@ -53,10 +48,6 @@ func TestVPNFirewallRemote(t *testing.T) {
 func TestVPNNSERemote(t *testing.T) {
 	RegisterTestingT(t)
 
-	if !isVPNRemoteEnabled() {
-		t.Skip("VPN_REMOTE_ENABLED not defined.")
-	}
-
 	if testing.Short() {
 		t.Skip("Skip, please run without -short")
 		return
@@ -71,11 +62,7 @@ func TestVPNNSERemote(t *testing.T) {
 
 func TestVPNNSCRemote(t *testing.T) {
 	RegisterTestingT(t)
-
-	if !isVPNRemoteEnabled() {
-		t.Skip("VPN_REMOTE_ENABLED not defined.")
-	}
-
+	
 	if testing.Short() {
 		t.Skip("Skip, please run without -short")
 		return
@@ -86,11 +73,6 @@ func TestVPNNSCRemote(t *testing.T) {
 		"vpn-gateway-nse1":       0,
 		"vpn-gateway-nsc1":       1,
 	}, false)
-}
-
-func isVPNRemoteEnabled() bool {
-	_, ok := os.LookupEnv("VPN_REMOTE_ENABLED")
-	return ok
 }
 
 func testVPN(t *testing.T, nodesCount int, affinity map[string]int, verbose bool) {

--- a/test/kube_testing/k8s.go
+++ b/test/kube_testing/k8s.go
@@ -411,3 +411,12 @@ func (k8s *K8s) GetNodesWait(requiredNumber int, timeout time.Duration) []v1.Nod
 	}
 
 }
+
+func (o *K8s) CreateService(service *v1.Service) {
+	_ = o.clientset.CoreV1().Services("default").Delete(service.Name, &metaV1.DeleteOptions{})
+	s, err := o.clientset.CoreV1().Services("default").Create(service)
+	if err != nil {
+		logrus.Errorf("Error creating service: %v %v", s, err)
+	}
+	logrus.Infof("Service is created: %v", s)
+}

--- a/test/kube_testing/k8s.go
+++ b/test/kube_testing/k8s.go
@@ -267,7 +267,7 @@ func (l *K8s) Prepare(noPods ...string) {
 	for _, podName := range noPods {
 		for _, lpod := range l.ListPods() {
 			if strings.Contains(lpod.Name, podName) {
-				l.DeletePods("default", &lpod)
+				l.DeletePods(&lpod)
 			}
 		}
 	}
@@ -312,7 +312,7 @@ func (l *K8s) CreatePod(template *v1.Pod) *v1.Pod {
 	return results[0]
 }
 
-func (l *K8s) DeletePods(namespace string, pods ...*v1.Pod) {
+func (l *K8s) DeletePods(pods ...*v1.Pod) {
 	err := l.deletePods(pods...)
 	Expect(err).To(BeNil())
 

--- a/test/kube_testing/pods/jaeger.go
+++ b/test/kube_testing/pods/jaeger.go
@@ -1,0 +1,50 @@
+package pods
+
+import (
+	"k8s.io/api/core/v1"
+	v12 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func JaegerService(pod *v1.Pod) *v1.Service {
+	return &v1.Service{
+		ObjectMeta: v12.ObjectMeta{
+			Name: pod.Name,
+			Labels: map[string]string{"run": pod.Name},
+		},
+		Spec: v1.ServiceSpec {
+			Ports: []v1.ServicePort{
+				{Name:"http", Port: 16686, Protocol: "TCP"},
+				{Name: "jaeger", Port: 6831, Protocol: "UDP"},
+			},
+			Selector: map[string]string{"run": "jaeger"},
+		},
+	}
+}
+func Jaeger() *v1.Pod {
+	pod := &v1.Pod{
+		ObjectMeta: v12.ObjectMeta{
+			Name: "jaeger",
+			Labels: map[string]string{
+				"run": "jaeger",
+			},
+		},
+		TypeMeta: v12.TypeMeta{
+			Kind: "Deployment",
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				{
+					Name:            "jaeger",
+					Image:           "jaegertracing/all-in-one:latest",
+					ImagePullPolicy: v1.PullIfNotPresent,
+					Ports: []v1.ContainerPort {
+						{Name: "http", ContainerPort: 16686, Protocol:"TCP"},
+						{Name: "jaeger", ContainerPort: 6831, Protocol:"UDP"},
+					},
+				},
+			},
+		},
+
+	}
+	return pod
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Implementation of Auto heal functionality for NSE local/remote die and Dataplane local/remote die.

## Description
Auto heal functionality allow to recover NSC <-> NSE operability via requesting new NSE if previous one is lost, and recover from situations if Dataplane pod is die because of implementation errors/development instabilities.

## Motivation and Context
Fixes for issue: #697

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [x] Covered by existing integration testing
- [x] Added integration testing to cover
- [x] Tested locally
- [ ] Have not tested
- [x] NSE die tested unit
- [x] NSE die tested integration
- [x] Dataplane die tested unit
-  [x] Dataplane die tested integration

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.