### PR TITLE
Handle Client connection failure

### DIFF
--- a/examples/cmd/nsc/nsc.go
+++ b/examples/cmd/nsc/nsc.go
@@ -32,7 +32,8 @@ func main() {
 		logrus.Fatalf("Unable to create the NSM client %v", err)
 	}
 
-	client.Connect("nsm", "kernel", "Primary interface")
+	if _, err := client.Connect("nsm", "kernel", "Primary interface"); err != nil {
+		logrus.Fatalf("Client connect failed with error: %v", err)
+	}
 	logrus.Info("nsm client: initialization is completed successfully")
-
 }

--- a/sdk/client/client.go
+++ b/sdk/client/client.go
@@ -83,6 +83,7 @@ func (nsmc *NsmClient) Connect(name, mechanism, description string) (*connection
 				continue
 			}
 			logrus.Errorf("Connect failed after %v iterations", connectRetries)
+			return nil, err
 		}
 
 		nsmc.OutgoingConnections = append(nsmc.OutgoingConnections, outgoingConnection)
@@ -104,7 +105,7 @@ func (nsmc *NsmClient) Close(outgoingConnection *connection.Connection) error {
 	for i, c := range arr {
 		if c == outgoingConnection {
 			copy(arr[i:], arr[i+1:])
-			arr[len(arr)-1] = nil // or the zero value of T
+			arr[len(arr)-1] = nil
 			arr = arr[:len(arr)-1]
 		}
 	}


### PR DESCRIPTION
The SDK client does have wrong behaviour after 10 iterations of retries to connect.

## Description
This patch adds a proper error handling in SDK/client for the case where all iteration retries failed.

## Motivation and Context
A wrong behaviour and crash were observed while the client runs in a volatile environment.
NSC for example just continues and finished its operation even though the Connect failed.

## How Has This Been Tested?
- [ ] Covered by existing integration testing
- [ ] Added integration testing to cover
- [X] Tested locally
- [ ] Have not tested

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
