### PR TITLE
Fix CI push :latest to docker hub

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,8 +40,7 @@ jobs:
       - run:
           command: |
             export COMMIT="${CIRCLE_SHA1:8:8}"
-            export BUILD_TAG="circle-${CIRCLE_BUILD_NUM}"
-            export TAG="$BUILD_TAG"
+            export TAG="circle-${CIRCLE_BUILD_NUM}"
             go install ./vendor/k8s.io/kube-openapi/cmd/openapi-gen
             make verify docker-build docker-push
       - run:
@@ -170,8 +169,7 @@ jobs:
       - run:
           command: |
             export COMMIT="${CIRCLE_SHA1:8:8}"
-            export BUILD_TAG="circle-${CIRCLE_BUILD_NUM}"
-            export TAG="$BUILD_TAG"
+            export TAG="circle-${CIRCLE_BUILD_NUM}"
             make docker-nsmd-build
             make docker-nsmd-push
   build-nsmd-k8s:
@@ -185,8 +183,7 @@ jobs:
       - run:
           command: |
             export COMMIT="${CIRCLE_SHA1:8:8}"
-            export BUILD_TAG="circle-${CIRCLE_BUILD_NUM}"
-            export TAG="$BUILD_TAG"
+            export TAG="circle-${CIRCLE_BUILD_NUM}"
             make docker-nsmd-k8s-build
             make docker-nsmd-k8s-push
   build-nsmdp:
@@ -200,8 +197,7 @@ jobs:
       - run:
           command: |
             export COMMIT="${CIRCLE_SHA1:8:8}"
-            export BUILD_TAG="circle-${CIRCLE_BUILD_NUM}"
-            export TAG="$BUILD_TAG"
+            export TAG="circle-${CIRCLE_BUILD_NUM}"
             make docker-nsmdp-build
             make docker-nsmdp-push
   build-crossconnect-monitor:
@@ -215,8 +211,7 @@ jobs:
       - run:
           command: |
             export COMMIT="${CIRCLE_SHA1:8:8}"
-            export BUILD_TAG="circle-${CIRCLE_BUILD_NUM}"
-            export TAG="$BUILD_TAG"
+            export TAG="circle-${CIRCLE_BUILD_NUM}"
             make docker-crossconnect-monitor-build
             make docker-crossconnect-monitor-push
   build-icmp-responder-nse:
@@ -230,8 +225,7 @@ jobs:
       - run:
           command: |
             export COMMIT="${CIRCLE_SHA1:8:8}"
-            export BUILD_TAG="circle-${CIRCLE_BUILD_NUM}"
-            export TAG="$BUILD_TAG"
+            export TAG="circle-${CIRCLE_BUILD_NUM}"
             make docker-icmp-responder-nse-build
             make docker-icmp-responder-nse-push
 
@@ -246,8 +240,7 @@ jobs:
       - run:
           command: |
             export COMMIT="${CIRCLE_SHA1:8:8}"
-            export BUILD_TAG="circle-${CIRCLE_BUILD_NUM}"
-            export TAG="$BUILD_TAG"
+            export TAG="circle-${CIRCLE_BUILD_NUM}"
             make docker-vppagent-icmp-responder-nse-build
             make docker-vppagent-icmp-responder-nse-push
   build-vppagent-nsc:
@@ -261,8 +254,7 @@ jobs:
       - run:
           command: |
             export COMMIT="${CIRCLE_SHA1:8:8}"
-            export BUILD_TAG="circle-${CIRCLE_BUILD_NUM}"
-            export TAG="$BUILD_TAG"
+            export TAG="circle-${CIRCLE_BUILD_NUM}"
             make docker-vppagent-nsc-build
             make docker-vppagent-nsc-push
   build-nsc:
@@ -276,8 +268,7 @@ jobs:
       - run:
           command: |
             export COMMIT="${CIRCLE_SHA1:8:8}"
-            export BUILD_TAG="circle-${CIRCLE_BUILD_NUM}"
-            export TAG="$BUILD_TAG"
+            export TAG="circle-${CIRCLE_BUILD_NUM}"
             make docker-nsc-build
             make docker-nsc-push
   build-vppagent-dataplane:
@@ -291,8 +282,7 @@ jobs:
       - run:
           command: |
             export COMMIT="${CIRCLE_SHA1:8:8}"
-            export BUILD_TAG="circle-${CIRCLE_BUILD_NUM}"
-            export TAG="$BUILD_TAG"
+            export TAG="circle-${CIRCLE_BUILD_NUM}"
             make docker-vppagent-dataplane-build
             make docker-vppagent-dataplane-push
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ jobs:
             export COMMIT="${CIRCLE_SHA1:8:8}"
             export TAG="circle-${CIRCLE_BUILD_NUM}"
             go install ./vendor/k8s.io/kube-openapi/cmd/openapi-gen
-            make verify docker-build
+            make verify docker-build docker-push
       - run:
           when: on_fail
           name: Trigger packet-destroy
@@ -171,6 +171,7 @@ jobs:
             export COMMIT="${CIRCLE_SHA1:8:8}"
             export TAG="circle-${CIRCLE_BUILD_NUM}"
             make docker-nsmd-build
+            make docker-nsmd-push
   build-nsmd-k8s:
     working_directory: /go/src/github.com/networkservicemesh/networkservicemesh/
     docker:
@@ -184,6 +185,7 @@ jobs:
             export COMMIT="${CIRCLE_SHA1:8:8}"
             export TAG="circle-${CIRCLE_BUILD_NUM}"
             make docker-nsmd-k8s-build
+            make docker-nsmd-k8s-push
   build-nsmdp:
     working_directory: /go/src/github.com/networkservicemesh/networkservicemesh/
     docker:
@@ -197,6 +199,7 @@ jobs:
             export COMMIT="${CIRCLE_SHA1:8:8}"
             export TAG="circle-${CIRCLE_BUILD_NUM}"
             make docker-nsmdp-build
+            make docker-nsmdp-push
   build-crossconnect-monitor:
     working_directory: /go/src/github.com/networkservicemesh/networkservicemesh/
     docker:
@@ -210,6 +213,7 @@ jobs:
             export COMMIT="${CIRCLE_SHA1:8:8}"
             export TAG="circle-${CIRCLE_BUILD_NUM}"
             make docker-crossconnect-monitor-build
+            make docker-crossconnect-monitor-push
   build-icmp-responder-nse:
     working_directory: /go/src/github.com/networkservicemesh/networkservicemesh/
     docker:
@@ -223,6 +227,7 @@ jobs:
             export COMMIT="${CIRCLE_SHA1:8:8}"
             export TAG="circle-${CIRCLE_BUILD_NUM}"
             make docker-icmp-responder-nse-build
+            make docker-icmp-responder-nse-push
 
   build-vppagent-icmp-responder-nse:
     working_directory: /go/src/github.com/networkservicemesh/networkservicemesh/
@@ -237,6 +242,7 @@ jobs:
             export COMMIT="${CIRCLE_SHA1:8:8}"
             export TAG="circle-${CIRCLE_BUILD_NUM}"
             make docker-vppagent-icmp-responder-nse-build
+            make docker-vppagent-icmp-responder-nse-push
   build-vppagent-nsc:
     working_directory: /go/src/github.com/networkservicemesh/networkservicemesh/
     docker:
@@ -250,6 +256,7 @@ jobs:
             export COMMIT="${CIRCLE_SHA1:8:8}"
             export TAG="circle-${CIRCLE_BUILD_NUM}"
             make docker-vppagent-nsc-build
+            make docker-vppagent-nsc-push
   build-nsc:
     working_directory: /go/src/github.com/networkservicemesh/networkservicemesh/
     docker:
@@ -263,6 +270,7 @@ jobs:
             export COMMIT="${CIRCLE_SHA1:8:8}"
             export TAG="circle-${CIRCLE_BUILD_NUM}"
             make docker-nsc-build
+            make docker-nsc-push
   build-vppagent-dataplane:
     working_directory: /go/src/github.com/networkservicemesh/networkservicemesh/
     docker:
@@ -276,6 +284,7 @@ jobs:
             export COMMIT="${CIRCLE_SHA1:8:8}"
             export TAG="circle-${CIRCLE_BUILD_NUM}"
             make docker-vppagent-dataplane-build
+            make docker-vppagent-dataplane-push
   docker-push-latest:
     working_directory: /go/src/github.com/networkservicemesh/networkservicemesh/
     docker:
@@ -289,7 +298,7 @@ jobs:
             export COMMIT="${CIRCLE_SHA1:8:8}"
             export TAG="latest"
             export CONTAINERS=nsmd nsmd-k8s nsmdp crossconnect-monitor icmp-responder-nse vppagent-icmp-responder-nse vppagent-nsc nsc vppagent-dataplane
-            for c in ${CONTAINERS}; do docker-${c}-push; done
+            for c in ${CONTAINERS}; do make docker-${c}-build docker-${c}-push; done
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,13 @@ jobs:
       # - run: PATH=${PATH}:~/bin go generate ./...; git diff --exit-code || (echo "Run go generate ./... and recommit. If that doesn't work make sure you have installed via 'go install ./vendor/github.com/golang/protobuf/protoc-gen-go/'";exit 1)
       - run: go build ./...
       - run: mkdir -p ~/junit/
-      - run: gotestsum --junitfile ~/junit/unit-tests.xml -- -short `go list ./... | grep -v networkservicemesh/test/`
+      - run:
+          command: gotestsum --junitfile ~/junit/unit-tests.xml -- -short `go list ./... | grep -v networkservicemesh/test/`
+          environment:
+            KUBECONFIG: /home/circleci/project/data/kubeconfig
+            GO111MODULE: 'on'
+            CONTAINER_TAG: "circle-${COMMIT}"
+            CONTAINER_FORCE_PULL: "true"
       - store_test_results:
           path: ~/junit
       - store_artifacts:
@@ -40,7 +46,7 @@ jobs:
       - run:
           command: |
             export COMMIT="${CIRCLE_SHA1:8:8}"
-            export TAG="circle-${CIRCLE_BUILD_NUM}"
+            export TAG="circle-${COMMIT}"
             go install ./vendor/k8s.io/kube-openapi/cmd/openapi-gen
             make verify docker-build docker-push
       - run:
@@ -117,7 +123,7 @@ jobs:
           environment:
             KUBECONFIG: /home/circleci/project/data/kubeconfig
             GO111MODULE: 'on'
-            CONTAINER_TAG: "circle-${CIRCLE_BUILD_NUM}"
+            CONTAINER_TAG: "circle-${COMMIT}"
             CONTAINER_FORCE_PULL: "true"
       - store_test_results:
           path: ~/junit
@@ -171,7 +177,7 @@ jobs:
       - run:
           command: |
             export COMMIT="${CIRCLE_SHA1:8:8}"
-            export TAG="circle-${CIRCLE_BUILD_NUM}"
+            export TAG="circle-${COMMIT}"
             make docker-nsmd-build
             make docker-nsmd-push
   build-nsmd-k8s:
@@ -185,7 +191,7 @@ jobs:
       - run:
           command: |
             export COMMIT="${CIRCLE_SHA1:8:8}"
-            export TAG="circle-${CIRCLE_BUILD_NUM}"
+            export TAG="circle-${COMMIT}"
             make docker-nsmd-k8s-build
             make docker-nsmd-k8s-push
   build-nsmdp:
@@ -199,7 +205,7 @@ jobs:
       - run:
           command: |
             export COMMIT="${CIRCLE_SHA1:8:8}"
-            export TAG="circle-${CIRCLE_BUILD_NUM}"
+            export TAG="circle-${COMMIT}"
             make docker-nsmdp-build
             make docker-nsmdp-push
   build-crossconnect-monitor:
@@ -213,7 +219,7 @@ jobs:
       - run:
           command: |
             export COMMIT="${CIRCLE_SHA1:8:8}"
-            export TAG="circle-${CIRCLE_BUILD_NUM}"
+            export TAG="circle-${COMMIT}"
             make docker-crossconnect-monitor-build
             make docker-crossconnect-monitor-push
   build-icmp-responder-nse:
@@ -227,7 +233,7 @@ jobs:
       - run:
           command: |
             export COMMIT="${CIRCLE_SHA1:8:8}"
-            export TAG="circle-${CIRCLE_BUILD_NUM}"
+            export TAG="circle-${COMMIT}"
             make docker-icmp-responder-nse-build
             make docker-icmp-responder-nse-push
 
@@ -242,7 +248,7 @@ jobs:
       - run:
           command: |
             export COMMIT="${CIRCLE_SHA1:8:8}"
-            export TAG="circle-${CIRCLE_BUILD_NUM}"
+            export TAG="circle-${COMMIT}"
             make docker-vppagent-icmp-responder-nse-build
             make docker-vppagent-icmp-responder-nse-push
   build-vppagent-nsc:
@@ -256,7 +262,7 @@ jobs:
       - run:
           command: |
             export COMMIT="${CIRCLE_SHA1:8:8}"
-            export TAG="circle-${CIRCLE_BUILD_NUM}"
+            export TAG="circle-${COMMIT}"
             make docker-vppagent-nsc-build
             make docker-vppagent-nsc-push
   build-nsc:
@@ -270,7 +276,7 @@ jobs:
       - run:
           command: |
             export COMMIT="${CIRCLE_SHA1:8:8}"
-            export TAG="circle-${CIRCLE_BUILD_NUM}"
+            export TAG="circle-${COMMIT}"
             make docker-nsc-build
             make docker-nsc-push
   build-vppagent-dataplane:
@@ -284,7 +290,7 @@ jobs:
       - run:
           command: |
             export COMMIT="${CIRCLE_SHA1:8:8}"
-            export TAG="circle-${CIRCLE_BUILD_NUM}"
+            export TAG="circle-${COMMIT}"
             make docker-vppagent-dataplane-build
             make docker-vppagent-dataplane-push
   docker-push-latest:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ jobs:
             export COMMIT="${CIRCLE_SHA1:8:8}"
             export TAG="circle-${CIRCLE_BUILD_NUM}"
             go install ./vendor/k8s.io/kube-openapi/cmd/openapi-gen
-            make verify docker-build docker-push
+            make verify docker-build
       - run:
           when: on_fail
           name: Trigger packet-destroy
@@ -171,7 +171,6 @@ jobs:
             export COMMIT="${CIRCLE_SHA1:8:8}"
             export TAG="circle-${CIRCLE_BUILD_NUM}"
             make docker-nsmd-build
-            make docker-nsmd-push
   build-nsmd-k8s:
     working_directory: /go/src/github.com/networkservicemesh/networkservicemesh/
     docker:
@@ -185,7 +184,6 @@ jobs:
             export COMMIT="${CIRCLE_SHA1:8:8}"
             export TAG="circle-${CIRCLE_BUILD_NUM}"
             make docker-nsmd-k8s-build
-            make docker-nsmd-k8s-push
   build-nsmdp:
     working_directory: /go/src/github.com/networkservicemesh/networkservicemesh/
     docker:
@@ -199,7 +197,6 @@ jobs:
             export COMMIT="${CIRCLE_SHA1:8:8}"
             export TAG="circle-${CIRCLE_BUILD_NUM}"
             make docker-nsmdp-build
-            make docker-nsmdp-push
   build-crossconnect-monitor:
     working_directory: /go/src/github.com/networkservicemesh/networkservicemesh/
     docker:
@@ -213,7 +210,6 @@ jobs:
             export COMMIT="${CIRCLE_SHA1:8:8}"
             export TAG="circle-${CIRCLE_BUILD_NUM}"
             make docker-crossconnect-monitor-build
-            make docker-crossconnect-monitor-push
   build-icmp-responder-nse:
     working_directory: /go/src/github.com/networkservicemesh/networkservicemesh/
     docker:
@@ -227,7 +223,6 @@ jobs:
             export COMMIT="${CIRCLE_SHA1:8:8}"
             export TAG="circle-${CIRCLE_BUILD_NUM}"
             make docker-icmp-responder-nse-build
-            make docker-icmp-responder-nse-push
 
   build-vppagent-icmp-responder-nse:
     working_directory: /go/src/github.com/networkservicemesh/networkservicemesh/
@@ -242,7 +237,6 @@ jobs:
             export COMMIT="${CIRCLE_SHA1:8:8}"
             export TAG="circle-${CIRCLE_BUILD_NUM}"
             make docker-vppagent-icmp-responder-nse-build
-            make docker-vppagent-icmp-responder-nse-push
   build-vppagent-nsc:
     working_directory: /go/src/github.com/networkservicemesh/networkservicemesh/
     docker:
@@ -256,7 +250,6 @@ jobs:
             export COMMIT="${CIRCLE_SHA1:8:8}"
             export TAG="circle-${CIRCLE_BUILD_NUM}"
             make docker-vppagent-nsc-build
-            make docker-vppagent-nsc-push
   build-nsc:
     working_directory: /go/src/github.com/networkservicemesh/networkservicemesh/
     docker:
@@ -270,7 +263,6 @@ jobs:
             export COMMIT="${CIRCLE_SHA1:8:8}"
             export TAG="circle-${CIRCLE_BUILD_NUM}"
             make docker-nsc-build
-            make docker-nsc-push
   build-vppagent-dataplane:
     working_directory: /go/src/github.com/networkservicemesh/networkservicemesh/
     docker:
@@ -284,7 +276,6 @@ jobs:
             export COMMIT="${CIRCLE_SHA1:8:8}"
             export TAG="circle-${CIRCLE_BUILD_NUM}"
             make docker-vppagent-dataplane-build
-            make docker-vppagent-dataplane-push
   docker-push-latest:
     working_directory: /go/src/github.com/networkservicemesh/networkservicemesh/
     docker:
@@ -298,7 +289,7 @@ jobs:
             export COMMIT="${CIRCLE_SHA1:8:8}"
             export TAG="latest"
             export CONTAINERS=nsmd nsmd-k8s nsmdp crossconnect-monitor icmp-responder-nse vppagent-icmp-responder-nse vppagent-nsc nsc vppagent-dataplane
-            for c in ${CONTAINERS}; do make docker-${c}-build docker-${c}-push; done
+            for c in ${CONTAINERS}; do docker-${c}-push; done
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -306,8 +306,7 @@ jobs:
       - run:
           command: |
             export COMMIT="${CIRCLE_SHA1:8:8}"
-            export BUILD_TAG="circle-${CIRCLE_BUILD_NUM}"
-            export TAG="$BUILD_TAG"
+            export TAG="circle-${COMMIT}"
             make docker-vppagent-firewall-nse-build
             make docker-vppagent-firewall-nse-push
   docker-push-latest:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,12 +21,10 @@ jobs:
       - run: go build ./...
       - run: mkdir -p ~/junit/
       - run:
-          command: gotestsum --junitfile ~/junit/unit-tests.xml -- -short `go list ./... | grep -v networkservicemesh/test/`
-          environment:
-            KUBECONFIG: /home/circleci/project/data/kubeconfig
-            GO111MODULE: 'on'
-            CONTAINER_TAG: "circle-${COMMIT}"
-            CONTAINER_FORCE_PULL: "true"
+          command: |
+            export CONTAINER_TAG="circle-${COMMIT}"
+            export CONTAINER_FORCE_PULL="true"
+            gotestsum --junitfile ~/junit/unit-tests.xml -- -short `go list ./... | grep -v networkservicemesh/test/`
       - store_test_results:
           path: ~/junit
       - store_artifacts:
@@ -118,13 +116,10 @@ jobs:
       - run:
           command: |
             ./scripts/prepare-circle-integration-tests.sh
+            export CONTAINER_TAG="circle-${COMMIT}"
+            export CONTAINER_FORCE_PULL="true"
             mkdir -p ~/junit/
             gotestsum --junitfile ~/junit/integration-tests.xml ./test/...
-          environment:
-            KUBECONFIG: /home/circleci/project/data/kubeconfig
-            GO111MODULE: 'on'
-            CONTAINER_TAG: "circle-${COMMIT}"
-            CONTAINER_FORCE_PULL: "true"
       - store_test_results:
           path: ~/junit
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -285,6 +285,21 @@ jobs:
             export TAG="circle-${CIRCLE_BUILD_NUM}"
             make docker-vppagent-dataplane-build
             make docker-vppagent-dataplane-push
+  docker-push-latest:
+    working_directory: /go/src/github.com/networkservicemesh/networkservicemesh/
+    docker:
+      - image: circleci/golang:1.11
+    steps:
+      - checkout
+      - setup_remote_docker:
+          docker_layer_caching: true
+      - run:
+          command: |
+            export COMMIT="${CIRCLE_SHA1:8:8}"
+            export TAG="latest"
+            export CONTAINERS=nsmd nsmd-k8s nsmdp crossconnect-monitor icmp-responder-nse vppagent-icmp-responder-nse vppagent-nsc nsc vppagent-dataplane
+            for c in ${CONTAINERS}; do make docker-${c}-build docker-${c}-push; done
+
 workflows:
   version: 2
   build-and-test:
@@ -334,3 +349,9 @@ workflows:
       - packet-destroy:
           requires:
             - packet-integration-tests
+      - docker-push-latest:
+          requires:
+            - packet-destroy
+          filters:
+            branches:
+              only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,8 +133,9 @@ jobs:
           when: always
           name: Dump K8s state
           command: |
-            kubectl get pods -o wide
             kubectl get nodes
+            kubectl get pods -o wide
+            kubectl describe pods
           environment:
             KUBECONFIG: /home/circleci/project/data/kubeconfig
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,6 +117,8 @@ jobs:
           environment:
             KUBECONFIG: /home/circleci/project/data/kubeconfig
             GO111MODULE: 'on'
+            CONTAINER_TAG: "circle-${CIRCLE_BUILD_NUM}"
+            CONTAINER_FORCE_PULL: "true"
       - store_test_results:
           path: ~/junit
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,6 +22,7 @@ jobs:
       - run: mkdir -p ~/junit/
       - run:
           command: |
+            export COMMIT="${CIRCLE_SHA1:8:8}"
             export CONTAINER_TAG="circle-${COMMIT}"
             export CONTAINER_FORCE_PULL="true"
             gotestsum --junitfile ~/junit/unit-tests.xml -- -short `go list ./... | grep -v networkservicemesh/test/`
@@ -116,6 +117,7 @@ jobs:
       - run:
           command: |
             ./scripts/prepare-circle-integration-tests.sh
+            export COMMIT="${CIRCLE_SHA1:8:8}"
             export CONTAINER_TAG="circle-${COMMIT}"
             export CONTAINER_FORCE_PULL="true"
             mkdir -p ~/junit/

--- a/.docker.mk
+++ b/.docker.mk
@@ -86,8 +86,7 @@ docker-%-debug:
 .PHONY: docker-push-%
 docker-%-push: docker-login docker-%-build
 	docker tag ${ORG}/$*:${COMMIT} ${ORG}/$*:${TAG}
-	docker tag ${ORG}/$*:${COMMIT} ${ORG}/$*:${BUILD_TAG}
-	docker push ${ORG}/$*
+	docker push ${ORG}/$*:${TAG}
 
 PHONY: docker-push
 docker-push: $(addsuffix -push,$(addprefix docker-,$(BUILD_CONTAINERS)))

--- a/test/integration/nsmd_test_utils/test_utils.go
+++ b/test/integration/nsmd_test_utils/test_utils.go
@@ -2,12 +2,13 @@ package nsmd_test_utils
 
 import (
 	"fmt"
+	"time"
+
 	"github.com/networkservicemesh/networkservicemesh/test/kube_testing"
 	"github.com/networkservicemesh/networkservicemesh/test/kube_testing/pods"
 	. "github.com/onsi/gomega"
 	"github.com/sirupsen/logrus"
-	"k8s.io/api/core/v1"
-	"time"
+	v1 "k8s.io/api/core/v1"
 )
 
 const defaultTimeout = 60 * time.Second
@@ -62,7 +63,7 @@ func DeployIcmp(k8s *kube_testing.K8s, node *v1.Node) (icmp *v1.Pod) {
 	icmp = k8s.CreatePod(pods.ICMPResponderPod("icmp-responder-nse1", node,
 		map[string]string{
 			"ADVERTISE_NSE_NAME":   "icmp-responder",
-			"ADVERTISE_NSE_LABELS": "app=icmp-responder",
+			"ADVERTISE_NSE_LABELS": "app=icmp",
 			"IP_ADDRESS":           "10.20.1.0/24",
 		},
 	))
@@ -76,6 +77,8 @@ func DeployIcmp(k8s *kube_testing.K8s, node *v1.Node) (icmp *v1.Pod) {
 
 func DeployNsc(k8s *kube_testing.K8s, node *v1.Node, name string) (nsc *v1.Pod) {
 	startTime := time.Now()
+
+	logrus.Infof("Starting NSC %s on node: %s", name, node.Name)
 	nsc = k8s.CreatePod(pods.NSCPod(name, node,
 		map[string]string{
 			"OUTGOING_NSC_LABELS": "app=icmp",

--- a/test/kube_testing/pods/alpine.go
+++ b/test/kube_testing/pods/alpine.go
@@ -1,7 +1,7 @@
 package pods
 
 import (
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	v12 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -18,14 +18,14 @@ func AlpinePod(name string, node *v1.Node) *v1.Pod {
 		},
 		Spec: v1.PodSpec{
 			Containers: []v1.Container{
-				{
+				containerMod(&v1.Container{
 					Name:            "alpine-img",
 					Image:           "alpine:latest",
 					ImagePullPolicy: v1.PullIfNotPresent,
 					Command: []string{
 						"tail", "-f", "/dev/null",
 					},
-				},
+				}),
 			},
 		},
 	}

--- a/test/kube_testing/pods/alpine.go
+++ b/test/kube_testing/pods/alpine.go
@@ -18,14 +18,14 @@ func AlpinePod(name string, node *v1.Node) *v1.Pod {
 		},
 		Spec: v1.PodSpec{
 			Containers: []v1.Container{
-				containerMod(&v1.Container{
+				{
 					Name:            "alpine-img",
 					Image:           "alpine:latest",
 					ImagePullPolicy: v1.PullIfNotPresent,
 					Command: []string{
 						"tail", "-f", "/dev/null",
 					},
-				}),
+				},
 			},
 		},
 	}

--- a/test/kube_testing/pods/icmp_responder.go
+++ b/test/kube_testing/pods/icmp_responder.go
@@ -1,7 +1,7 @@
 package pods
 
 import (
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	v12 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -10,7 +10,7 @@ func ICMPResponderPod(name string, node *v1.Node, env map[string]string) *v1.Pod
 	ht := new(v1.HostPathType)
 	*ht = v1.HostPathDirectoryOrCreate
 
-	nsc_container := v1.Container{
+	nsc_container := containerMod(&v1.Container{
 		Name:            "icmp-responder-nse",
 		Image:           "networkservicemesh/icmp-responder-nse:latest",
 		ImagePullPolicy: v1.PullIfNotPresent,
@@ -20,7 +20,7 @@ func ICMPResponderPod(name string, node *v1.Node, env map[string]string) *v1.Pod
 			},
 			Requests: nil,
 		},
-	}
+	})
 	for k, v := range env {
 		nsc_container.Env = append(nsc_container.Env,
 			v1.EnvVar{

--- a/test/kube_testing/pods/nsc.go
+++ b/test/kube_testing/pods/nsc.go
@@ -1,7 +1,7 @@
 package pods
 
 import (
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	v12 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -10,7 +10,7 @@ func NSCPod(name string, node *v1.Node, env map[string]string) *v1.Pod {
 	ht := new(v1.HostPathType)
 	*ht = v1.HostPathDirectoryOrCreate
 
-	nsc_container := v1.Container{
+	nsc_container := containerMod(&v1.Container{
 		Name:            "nsc",
 		Image:           "networkservicemesh/nsc:latest",
 		ImagePullPolicy: v1.PullIfNotPresent,
@@ -20,7 +20,7 @@ func NSCPod(name string, node *v1.Node, env map[string]string) *v1.Pod {
 			},
 			Requests: nil,
 		},
-	}
+	})
 	for k, v := range env {
 		nsc_container.Env = append(nsc_container.Env,
 			v1.EnvVar{
@@ -48,7 +48,7 @@ func NSCPod(name string, node *v1.Node, env map[string]string) *v1.Pod {
 					},
 				},
 			},
-			InitContainers: []v1.Container {
+			InitContainers: []v1.Container{
 				nsc_container,
 			},
 		},

--- a/test/kube_testing/pods/nsmd.go
+++ b/test/kube_testing/pods/nsmd.go
@@ -1,7 +1,7 @@
 package pods
 
 import (
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	v12 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -58,19 +58,19 @@ func NSMDPod(name string, node *v1.Node) *v1.Pod {
 				},
 			},
 			Containers: []v1.Container{
-				{
+				containerMod(&v1.Container{
 					Name:            "nsmdp",
 					Image:           "networkservicemesh/nsmdp",
 					ImagePullPolicy: v1.PullIfNotPresent,
 					VolumeMounts:    []v1.VolumeMount{newDevMount(), newNSMMount()},
-				},
-				{
+				}),
+				containerMod(&v1.Container{
 					Name:            "nsmd",
 					Image:           "networkservicemesh/nsmd",
 					ImagePullPolicy: v1.PullIfNotPresent,
 					VolumeMounts:    []v1.VolumeMount{newNSMMount()},
-				},
-				{
+				}),
+				containerMod(&v1.Container{
 					Name:            "nsmd-k8s",
 					Image:           "networkservicemesh/nsmd-k8s",
 					ImagePullPolicy: v1.PullIfNotPresent,
@@ -80,7 +80,7 @@ func NSMDPod(name string, node *v1.Node) *v1.Pod {
 							Value: nodeName,
 						},
 					},
-				},
+				}),
 			},
 		},
 	}

--- a/test/kube_testing/pods/versioning.go
+++ b/test/kube_testing/pods/versioning.go
@@ -1,0 +1,59 @@
+// Copyright 2019 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pods
+
+import (
+	"os"
+	"strings"
+
+	v1 "k8s.io/api/core/v1"
+)
+
+const (
+	containerRegistryEnv  = "CONTAINER_REGISTRY"
+	containerTagEnv       = "CONTAINER_TAG"
+	containerTagDefault   = "latest"
+	containerForcePullEnv = "CONTAINER_FORCE_PULL"
+)
+
+var containerRegistry = ""
+var containerTag = "latest"
+var containerForcePull = false
+
+func init() {
+	found := false
+	containerRegistry, found = os.LookupEnv(containerRegistryEnv)
+
+	containerTag, found = os.LookupEnv(containerTagEnv)
+	if !found {
+		containerTag = containerTagDefault
+	}
+
+	pull := os.Getenv(containerForcePullEnv)
+	containerForcePull = (pull == "true")
+}
+
+func containerMod(c *v1.Container) v1.Container {
+	c.Image = strings.Split(c.Image, ":")[0] + ":" + containerTag
+	if len(containerRegistry) > 0 {
+		c.Image = containerRegistry + "/" + c.Image
+	}
+
+	if containerForcePull {
+		c.ImagePullPolicy = v1.PullAlways
+	}
+	return *c
+}

--- a/test/kube_testing/pods/versioning.go
+++ b/test/kube_testing/pods/versioning.go
@@ -47,13 +47,16 @@ func init() {
 }
 
 func containerMod(c *v1.Container) v1.Container {
-	c.Image = strings.Split(c.Image, ":")[0] + ":" + containerTag
-	if len(containerRegistry) > 0 {
-		c.Image = containerRegistry + "/" + c.Image
+	if strings.HasPrefix(c.Image, "networkservicemesh") {
+		c.Image = strings.Split(c.Image, ":")[0] + ":" + containerTag
+		if len(containerRegistry) > 0 {
+			c.Image = containerRegistry + "/" + c.Image
+		}
+
+		if containerForcePull {
+			c.ImagePullPolicy = v1.PullAlways
+		}
 	}
 
-	if containerForcePull {
-		c.ImagePullPolicy = v1.PullAlways
-	}
 	return *c
 }

--- a/test/kube_testing/pods/vppagent-firewall-nse.go
+++ b/test/kube_testing/pods/vppagent-firewall-nse.go
@@ -28,7 +28,7 @@ func VppAgentFirewallNSEPod(name string, node *v1.Node, env map[string]string) *
 		},
 		Spec: v1.PodSpec{
 			Containers: []v1.Container{
-				{
+				containerMod(&v1.Container{
 					Name:            "firewall-nse",
 					Image:           "networkservicemesh/vppagent-firewall-nse:latest",
 					ImagePullPolicy: v1.PullIfNotPresent,
@@ -39,7 +39,7 @@ func VppAgentFirewallNSEPod(name string, node *v1.Node, env map[string]string) *
 						Requests: nil,
 					},
 					Env: envVars,
-				},
+				}),
 			},
 		},
 	}

--- a/test/kube_testing/pods/vppagent_dataplane.go
+++ b/test/kube_testing/pods/vppagent_dataplane.go
@@ -1,7 +1,7 @@
 package pods
 
 import (
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	v12 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -33,7 +33,7 @@ func VPPDataplanePod(name string, node *v1.Node) *v1.Pod {
 				},
 			},
 			Containers: []v1.Container{
-				{
+				containerMod(&v1.Container{
 					Name:            "vppagent-dataplane",
 					Image:           "networkservicemesh/vppagent-dataplane:latest",
 					ImagePullPolicy: v1.PullIfNotPresent,
@@ -57,7 +57,7 @@ func VPPDataplanePod(name string, node *v1.Node) *v1.Pod {
 					SecurityContext: &v1.SecurityContext{
 						Privileged: &priv,
 					},
-				},
+				}),
 			},
 		},
 	}


### PR DESCRIPTION
## Description
The current CircleCI script invokes the `docker-%-push` target with TAG and BUILD_TAG refering
to the CircleCI SHA. The target then pushes to dockerhub but without specifying the image tag to push which results in pushing virtually all new images under the same name. The one that is not tagged gets an automatic :latest from dockerhub.

## Motivation and Context
We get :latest images in dockerhub build out of PR branches. That is fundamentally wrong.
These images should be generated out of `master` branch only.

## How Has This Been Tested?
- [ ] Covered by existing integration testing
- [ ] Added integration testing to cover
- [ ] Tested locally
- [X] Have not tested
Need the CircleCI to test.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
