### PR TITLE
Add liveness/readiness probes for nsmd and vppagent-dataplane

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ jobs:
       - run:
           command: |
             export COMMIT="${CIRCLE_SHA1:8:8}"
-            export CONTAINER_TAG="circle-${COMMIT}"
+            export CONTAINER_TAG="${COMMIT}"
             export CONTAINER_FORCE_PULL="true"
             gotestsum --junitfile ~/junit/unit-tests.xml -- -short `go list ./... | grep -v networkservicemesh/test/`
       - store_test_results:
@@ -45,7 +45,7 @@ jobs:
       - run:
           command: |
             export COMMIT="${CIRCLE_SHA1:8:8}"
-            export TAG="circle-${COMMIT}"
+            export TAG="${COMMIT}"
             go install ./vendor/k8s.io/kube-openapi/cmd/openapi-gen
             make verify docker-build docker-push
       - run:
@@ -118,7 +118,7 @@ jobs:
           command: |
             ./scripts/prepare-circle-integration-tests.sh
             export COMMIT="${CIRCLE_SHA1:8:8}"
-            export CONTAINER_TAG="circle-${COMMIT}"
+            export CONTAINER_TAG="${COMMIT}"
             export CONTAINER_FORCE_PULL="true"
             mkdir -p ~/junit/
             gotestsum --junitfile ~/junit/integration-tests.xml ./test/...
@@ -179,7 +179,7 @@ jobs:
       - run:
           command: |
             export COMMIT="${CIRCLE_SHA1:8:8}"
-            export TAG="circle-${COMMIT}"
+            export TAG="${COMMIT}"
             make docker-nsmd-build
             make docker-nsmd-push
   build-nsmd-k8s:
@@ -193,7 +193,7 @@ jobs:
       - run:
           command: |
             export COMMIT="${CIRCLE_SHA1:8:8}"
-            export TAG="circle-${COMMIT}"
+            export TAG="${COMMIT}"
             make docker-nsmd-k8s-build
             make docker-nsmd-k8s-push
   build-nsmdp:
@@ -207,7 +207,7 @@ jobs:
       - run:
           command: |
             export COMMIT="${CIRCLE_SHA1:8:8}"
-            export TAG="circle-${COMMIT}"
+            export TAG="${COMMIT}"
             make docker-nsmdp-build
             make docker-nsmdp-push
   build-crossconnect-monitor:
@@ -221,7 +221,7 @@ jobs:
       - run:
           command: |
             export COMMIT="${CIRCLE_SHA1:8:8}"
-            export TAG="circle-${COMMIT}"
+            export TAG="${COMMIT}"
             make docker-crossconnect-monitor-build
             make docker-crossconnect-monitor-push
   build-icmp-responder-nse:
@@ -235,7 +235,7 @@ jobs:
       - run:
           command: |
             export COMMIT="${CIRCLE_SHA1:8:8}"
-            export TAG="circle-${COMMIT}"
+            export TAG="${COMMIT}"
             make docker-icmp-responder-nse-build
             make docker-icmp-responder-nse-push
 
@@ -250,7 +250,7 @@ jobs:
       - run:
           command: |
             export COMMIT="${CIRCLE_SHA1:8:8}"
-            export TAG="circle-${COMMIT}"
+            export TAG="${COMMIT}"
             make docker-vppagent-icmp-responder-nse-build
             make docker-vppagent-icmp-responder-nse-push
   build-vppagent-nsc:
@@ -264,7 +264,7 @@ jobs:
       - run:
           command: |
             export COMMIT="${CIRCLE_SHA1:8:8}"
-            export TAG="circle-${COMMIT}"
+            export TAG="${COMMIT}"
             make docker-vppagent-nsc-build
             make docker-vppagent-nsc-push
   build-nsc:
@@ -278,7 +278,7 @@ jobs:
       - run:
           command: |
             export COMMIT="${CIRCLE_SHA1:8:8}"
-            export TAG="circle-${COMMIT}"
+            export TAG="${COMMIT}"
             make docker-nsc-build
             make docker-nsc-push
   build-vppagent-dataplane:
@@ -292,7 +292,7 @@ jobs:
       - run:
           command: |
             export COMMIT="${CIRCLE_SHA1:8:8}"
-            export TAG="circle-${COMMIT}"
+            export TAG="${COMMIT}"
             make docker-vppagent-dataplane-build
             make docker-vppagent-dataplane-push
   build-vppagent-firewall-nse:
@@ -306,7 +306,7 @@ jobs:
       - run:
           command: |
             export COMMIT="${CIRCLE_SHA1:8:8}"
-            export TAG="circle-${COMMIT}"
+            export TAG="${COMMIT}"
             make docker-vppagent-firewall-nse-build
             make docker-vppagent-firewall-nse-push
   docker-push-latest:
@@ -320,10 +320,11 @@ jobs:
       - run:
           command: |
             export COMMIT="${CIRCLE_SHA1:8:8}"
-            export PULL_TAG="circle-${COMMIT}"
+            export PULL_TAG="${COMMIT}"
             export TAG="latest"
             export REPO="networkservicemesh"
             export CONTAINERS=(nsmd nsmd-k8s nsmdp crossconnect-monitor icmp-responder-nse vppagent-icmp-responder-nse vppagent-nsc nsc vppagent-dataplane)
+            echo "${DOCKER_PASSWORD}" | docker login -u "${DOCKER_USERNAME}" --password-stdin
             for c in ${CONTAINERS[@]}; do
               docker pull ${REPO}/${c}:${PULL_TAG}
               docker tag ${REPO}/${c}:${PULL_TAG} ${REPO}/${c}:${TAG}

--- a/controlplane/cmd/nsmd/nsmd.go
+++ b/controlplane/cmd/nsmd/nsmd.go
@@ -5,6 +5,7 @@ import (
 	"os/signal"
 	"sync"
 	"syscall"
+	"time"
 
 	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/model"
 	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/nsm"
@@ -15,6 +16,7 @@ import (
 )
 
 func main() {
+	start := time.Now()
 	tracer, closer := tools.InitJaeger("nsmd")
 	opentracing.SetGlobalTracer(tracer)
 	defer closer.Close()
@@ -45,10 +47,13 @@ func main() {
 		nsmd.SetAPIServerFailed()
 	}
 
+	elapsed := time.Since(start)
+	logrus.Debugf("Starting NSMD took: %s", elapsed)
 	var wg sync.WaitGroup
 	wg.Add(1)
 	c := make(chan os.Signal)
 	signal.Notify(c, os.Interrupt, syscall.SIGTERM)
+
 	go func() {
 		<-c
 		wg.Done()

--- a/controlplane/pkg/nsmd/probes.go
+++ b/controlplane/pkg/nsmd/probes.go
@@ -1,0 +1,62 @@
+// Copyright 2019 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nsmd
+
+import (
+	"fmt"
+	"net/http"
+)
+
+const (
+	healthcheckProbesPort = "0.0.0.0:5555"
+)
+
+var (
+	dpStatusOK  = true
+	nsmStatusOK = true
+	apiStatusOK = true
+)
+
+func SetDPServerFailed() {
+	dpStatusOK = false
+}
+
+func SetNSMServerFailed() {
+	nsmStatusOK = false
+}
+
+func SetAPIServerFailed() {
+	apiStatusOK = false
+}
+
+func readiness(w http.ResponseWriter, r *http.Request) {
+	if !dpStatusOK || !nsmStatusOK || !apiStatusOK {
+		errMsg := fmt.Sprintf("NSMD not ready. DPServer - %t, NSMServer - %t, APIServer - %t", dpStatusOK, nsmStatusOK, apiStatusOK)
+		http.Error(w, errMsg, http.StatusServiceUnavailable)
+	} else {
+		w.Write([]byte("OK"))
+	}
+}
+
+func liveness(w http.ResponseWriter, r *http.Request) {
+	w.Write([]byte("OK"))
+}
+
+func BeginHealthCheck() {
+	http.HandleFunc("/liveness", liveness)
+	http.HandleFunc("/readiness", readiness)
+	http.ListenAndServe(healthcheckProbesPort, nil)
+}

--- a/controlplane/pkg/nsmd/probes.go
+++ b/controlplane/pkg/nsmd/probes.go
@@ -18,6 +18,8 @@ package nsmd
 import (
 	"fmt"
 	"net/http"
+
+	"github.com/sirupsen/logrus"
 )
 
 const (
@@ -56,6 +58,7 @@ func liveness(w http.ResponseWriter, r *http.Request) {
 }
 
 func BeginHealthCheck() {
+	logrus.Debug("Starting NSMD liveness/readiness healthcheck")
 	http.HandleFunc("/liveness", liveness)
 	http.HandleFunc("/readiness", readiness)
 	http.ListenAndServe(healthcheckProbesPort, nil)

--- a/dataplane/vppagent/cmd/vppagent-dataplane.go
+++ b/dataplane/vppagent/cmd/vppagent-dataplane.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
 
 	"github.com/networkservicemesh/networkservicemesh/dataplane/impl/dataplaneregistrarclient"
 	"github.com/networkservicemesh/networkservicemesh/dataplane/vppagent/pkg/vppagent"
@@ -45,6 +46,7 @@ const (
 )
 
 func main() {
+	start := time.Now()
 	tracer, closer := tools.InitJaeger("vppagent-dataplane")
 	opentracing.SetGlobalTracer(tracer)
 	defer closer.Close()
@@ -124,10 +126,14 @@ func main() {
 		logrus.Fatalf("Error listening on socket %s: %s ", dataplaneSocket, err)
 		vppagent.SetSocketListenFailed()
 	}
+
 	logrus.Info("Creating vppagent server")
 	server := vppagent.NewServer(vppAgentEndpoint, nsmBaseDir, srcIp, *srcIpNet, ifaceName)
 	go server.Serve(ln)
 	logrus.Info("vppagent server serving")
+
+	elapsed := time.Since(start)
+	logrus.Debugf("Starting VPP Agent server took: %s", elapsed)
 
 	logrus.Info("Dataplane Registrar Client")
 	registrar := dataplaneregistrarclient.NewDataplaneRegistrarClient(dataplaneRegistrarSocket)

--- a/dataplane/vppagent/pkg/vppagent/probes.go
+++ b/dataplane/vppagent/pkg/vppagent/probes.go
@@ -1,0 +1,72 @@
+// Copyright 2019 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vppagent
+
+import (
+	"fmt"
+	"net/http"
+)
+
+const (
+	healthcheckProbesPort = "0.0.0.0:5555"
+)
+
+var (
+	srcIPOK        = true
+	validIPOK      = true
+	ifNameOK       = true
+	socketCleanOK  = true
+	socketListenOK = true
+)
+
+func SetSrcIPFailed() {
+	srcIPOK = false
+}
+
+func SetValidIPFailed() {
+	validIPOK = false
+}
+
+func SetExtractIFNameFailed() {
+	ifNameOK = false
+}
+
+func SetSocketCleanFailed() {
+	socketCleanOK = false
+}
+
+func SetSocketListenFailed() {
+	socketListenOK = false
+}
+
+func readiness(w http.ResponseWriter, r *http.Request) {
+	if !srcIPOK || !validIPOK || !ifNameOK || !socketCleanOK || !socketListenOK {
+		errMsg := fmt.Sprintf("VPP Agent not ready. srcIPOK - %t, validIPOK - %t, ifNameOK - %t, socketCleanOK - %t, socketListenOK - %t", srcIPOK, validIPOK, ifNameOK, socketCleanOK, socketListenOK)
+		http.Error(w, errMsg, http.StatusServiceUnavailable)
+	} else {
+		w.Write([]byte("OK"))
+	}
+}
+
+func liveness(w http.ResponseWriter, r *http.Request) {
+	w.Write([]byte("OK"))
+}
+
+func BeginHealthCheck() {
+	http.HandleFunc("/liveness", liveness)
+	http.HandleFunc("/readiness", readiness)
+	http.ListenAndServe(healthcheckProbesPort, nil)
+}

--- a/dataplane/vppagent/pkg/vppagent/probes.go
+++ b/dataplane/vppagent/pkg/vppagent/probes.go
@@ -18,6 +18,8 @@ package vppagent
 import (
 	"fmt"
 	"net/http"
+
+	"github.com/sirupsen/logrus"
 )
 
 const (
@@ -66,6 +68,7 @@ func liveness(w http.ResponseWriter, r *http.Request) {
 }
 
 func BeginHealthCheck() {
+	logrus.Debug("Starting VPP Agent liveness/readiness healthcheck")
 	http.HandleFunc("/liveness", liveness)
 	http.HandleFunc("/readiness", readiness)
 	http.ListenAndServe(healthcheckProbesPort, nil)

--- a/docs/spec/PROBES.md
+++ b/docs/spec/PROBES.md
@@ -1,0 +1,54 @@
+Liveness/Readiness probes
+============================
+
+Specification
+-------------
+
+Kubernetes provides a mechanism called [Readiness and Liveliness probes](https://cloud.google.com/blog/products/gcp/kubernetes-best-practices-setting-up-health-checks-with-readiness-and-liveness-probes)
+to allow it to determine whether a Pod is ‘Ready’ or in need of restart (Liveliness).
+
+The following is a [good example](https://www.ianlewis.org/en/using-kubernetes-health-checks)
+of how to write a simple Readiness Probe in Go.
+
+For the time being, the probe checking covers the following services - `nsmd` and `vppagent-dataplane`.
+
+Implementation details
+---------------------------------
+
+* Created `/liveness` and `/readiness` HTTP handlers for both components serving on port `5555` (configurable)
+* Each component sets specific flags stating if its dependencies initialized okay or not
+* Updated the `kube-testing` description files to take into account these changes
+* Updated the Kubernetes configuration files to enable liveness/readiness probing
+* Added measuring of the boot time for NSMD and VPP agent data-plane for debugging
+* The timings used for the liveness/readiness probes are more or less the default ones
+adjusted to match our Vagrant setup and keep the deployment stable.
+* For instance, the default `timeoutSeconds` value of 1 was not suitable for our use case causing
+the liveness probe check to fail.
+
+Example usage
+------------------------
+
+Leveraging the healthcheck features in Kubernetes is enabled by adding the following to the yaml file:
+
+```bash
+          livenessProbe:
+            httpGet:
+              path: /liveness
+              port: 5555
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 3
+          readinessProbe:
+            httpGet:
+              path: /readiness
+              port: 5555
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 3
+```
+
+References
+----------
+
+* Issue(s) reference - [#711](https://github.com/networkservicemesh/networkservicemesh/issues/711)
+* PR reference - [#730](https://github.com/networkservicemesh/networkservicemesh/pull/730)

--- a/k8s/conf/nsmd.yaml
+++ b/k8s/conf/nsmd.yaml
@@ -28,14 +28,16 @@ spec:
             httpGet:
               path: /liveness
               port: 5555
-            initialDelaySeconds: 3
-            periodSeconds: 3
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 3
           readinessProbe:
             httpGet:
               path: /readiness
               port: 5555
-            initialDelaySeconds: 5
-            periodSeconds: 3
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 3
         - name: nsmd-k8s
           image: networkservicemesh/nsmd-k8s
           imagePullPolicy: IfNotPresent

--- a/k8s/conf/nsmd.yaml
+++ b/k8s/conf/nsmd.yaml
@@ -24,6 +24,18 @@ spec:
           volumeMounts:
             - name: nsm-socket
               mountPath: /var/lib/networkservicemesh
+          livenessProbe:
+            httpGet:
+              path: /liveness
+              port: 5555
+            initialDelaySeconds: 3
+            periodSeconds: 3
+          readinessProbe:
+            httpGet:
+              path: /readiness
+              port: 5555
+            initialDelaySeconds: 5
+            periodSeconds: 3
         - name: nsmd-k8s
           image: networkservicemesh/nsmd-k8s
           imagePullPolicy: IfNotPresent

--- a/k8s/conf/vppagent-dataplane.yaml
+++ b/k8s/conf/vppagent-dataplane.yaml
@@ -23,6 +23,18 @@ spec:
             - name: workspace
               mountPath: /var/lib/networkservicemesh/
               mountPropagation: Bidirectional
+          livenessProbe:
+            httpGet:
+              path: /liveness
+              port: 5555
+            initialDelaySeconds: 3
+            periodSeconds: 3
+          readinessProbe:
+            httpGet:
+              path: /readiness
+              port: 5555
+            initialDelaySeconds: 5
+            periodSeconds: 3
       volumes:
         - hostPath:
             path: /var/lib/networkservicemesh

--- a/k8s/conf/vppagent-dataplane.yaml
+++ b/k8s/conf/vppagent-dataplane.yaml
@@ -27,14 +27,16 @@ spec:
             httpGet:
               path: /liveness
               port: 5555
-            initialDelaySeconds: 3
-            periodSeconds: 3
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 3
           readinessProbe:
             httpGet:
               path: /readiness
               port: 5555
-            initialDelaySeconds: 5
-            periodSeconds: 3
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 3
       volumes:
         - hostPath:
             path: /var/lib/networkservicemesh

--- a/test/kube_testing/pods/nsmd.go
+++ b/test/kube_testing/pods/nsmd.go
@@ -1,8 +1,9 @@
 package pods
 
 import (
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	v12 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 func newNSMMount() v1.VolumeMount {
@@ -73,7 +74,7 @@ func NSMDPod(name string, node *v1.Node) *v1.Pod {
 						Handler: v1.Handler{
 							HTTPGet: &v1.HTTPGetAction{
 								Path:   "/liveness",
-								Port:   5555,
+								Port:   intstr.IntOrString{Type: 0, IntVal: 5555, StrVal: ""},
 								Scheme: "HTTP",
 							},
 						},
@@ -84,7 +85,7 @@ func NSMDPod(name string, node *v1.Node) *v1.Pod {
 						Handler: v1.Handler{
 							HTTPGet: &v1.HTTPGetAction{
 								Path:   "/readiness",
-								Port:   5555,
+								Port:   intstr.IntOrString{Type: 0, IntVal: 5555, StrVal: ""},
 								Scheme: "HTTP",
 							},
 						},

--- a/test/kube_testing/pods/nsmd.go
+++ b/test/kube_testing/pods/nsmd.go
@@ -78,8 +78,9 @@ func NSMDPod(name string, node *v1.Node) *v1.Pod {
 								Scheme: "HTTP",
 							},
 						},
-						InitialDelaySeconds: 3,
-						PeriodSeconds:       3,
+						InitialDelaySeconds: 10,
+						PeriodSeconds:       10,
+						TimeoutSeconds:      3,
 					},
 					ReadinessProbe: &v1.Probe{
 						Handler: v1.Handler{
@@ -89,8 +90,9 @@ func NSMDPod(name string, node *v1.Node) *v1.Pod {
 								Scheme: "HTTP",
 							},
 						},
-						InitialDelaySeconds: 5,
-						PeriodSeconds:       3,
+						InitialDelaySeconds: 10,
+						PeriodSeconds:       10,
+						TimeoutSeconds:      3,
 					},
 				},
 				{

--- a/test/kube_testing/pods/nsmd.go
+++ b/test/kube_testing/pods/nsmd.go
@@ -69,6 +69,28 @@ func NSMDPod(name string, node *v1.Node) *v1.Pod {
 					Image:           "networkservicemesh/nsmd",
 					ImagePullPolicy: v1.PullIfNotPresent,
 					VolumeMounts:    []v1.VolumeMount{newNSMMount()},
+					LivenessProbe: &v1.Probe{
+						Handler: v1.Handler{
+							HTTPGet: &v1.HTTPGetAction{
+								Path:   "/liveness",
+								Port:   5555,
+								Scheme: "HTTP",
+							},
+						},
+						InitialDelaySeconds: 3,
+						PeriodSeconds:       3,
+					},
+					ReadinessProbe: &v1.Probe{
+						Handler: v1.Handler{
+							HTTPGet: &v1.HTTPGetAction{
+								Path:   "/readiness",
+								Port:   5555,
+								Scheme: "HTTP",
+							},
+						},
+						InitialDelaySeconds: 5,
+						PeriodSeconds:       3,
+					},
 				},
 				{
 					Name:            "nsmd-k8s",

--- a/test/kube_testing/pods/vppagent_dataplane.go
+++ b/test/kube_testing/pods/vppagent_dataplane.go
@@ -1,8 +1,9 @@
 package pods
 
 import (
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	v12 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 func VPPDataplanePod(name string, node *v1.Node) *v1.Pod {
@@ -61,7 +62,7 @@ func VPPDataplanePod(name string, node *v1.Node) *v1.Pod {
 						Handler: v1.Handler{
 							HTTPGet: &v1.HTTPGetAction{
 								Path:   "/liveness",
-								Port:   5555,
+								Port:   intstr.IntOrString{Type: 0, IntVal: 5555, StrVal: ""},
 								Scheme: "HTTP",
 							},
 						},
@@ -72,7 +73,7 @@ func VPPDataplanePod(name string, node *v1.Node) *v1.Pod {
 						Handler: v1.Handler{
 							HTTPGet: &v1.HTTPGetAction{
 								Path:   "/readiness",
-								Port:   5555,
+								Port:   intstr.IntOrString{Type: 0, IntVal: 5555, StrVal: ""},
 								Scheme: "HTTP",
 							},
 						},

--- a/test/kube_testing/pods/vppagent_dataplane.go
+++ b/test/kube_testing/pods/vppagent_dataplane.go
@@ -57,6 +57,28 @@ func VPPDataplanePod(name string, node *v1.Node) *v1.Pod {
 					SecurityContext: &v1.SecurityContext{
 						Privileged: &priv,
 					},
+					LivenessProbe: &v1.Probe{
+						Handler: v1.Handler{
+							HTTPGet: &v1.HTTPGetAction{
+								Path:   "/liveness",
+								Port:   5555,
+								Scheme: "HTTP",
+							},
+						},
+						InitialDelaySeconds: 3,
+						PeriodSeconds:       3,
+					},
+					ReadinessProbe: &v1.Probe{
+						Handler: v1.Handler{
+							HTTPGet: &v1.HTTPGetAction{
+								Path:   "/readiness",
+								Port:   5555,
+								Scheme: "HTTP",
+							},
+						},
+						InitialDelaySeconds: 5,
+						PeriodSeconds:       3,
+					},
 				},
 			},
 		},

--- a/test/kube_testing/pods/vppagent_dataplane.go
+++ b/test/kube_testing/pods/vppagent_dataplane.go
@@ -66,8 +66,9 @@ func VPPDataplanePod(name string, node *v1.Node) *v1.Pod {
 								Scheme: "HTTP",
 							},
 						},
-						InitialDelaySeconds: 3,
-						PeriodSeconds:       3,
+						InitialDelaySeconds: 10,
+						PeriodSeconds:       10,
+						TimeoutSeconds:      3,
 					},
 					ReadinessProbe: &v1.Probe{
 						Handler: v1.Handler{
@@ -77,8 +78,9 @@ func VPPDataplanePod(name string, node *v1.Node) *v1.Pod {
 								Scheme: "HTTP",
 							},
 						},
-						InitialDelaySeconds: 5,
-						PeriodSeconds:       3,
+						InitialDelaySeconds: 10,
+						PeriodSeconds:       10,
+						TimeoutSeconds:      3,
 					},
 				},
 			},


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add liveness/readiness probes for nsmd and vppagent-dataplane. The changes consist of:
* Created `/liveness` and `/readiness` HTTP handlers for both components
* Each component sets specific flags stating if its dependencies initialized okay or not
* Updated the `kube-testing` description files to take into account these changes
* Updated the Kubernetes configuration files to enable liveness/readiness probing

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Related to #711

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [X] Covered by existing integration testing
- [x] Added integration testing to cover
- [x] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.