### PR TITLE
Adding a target to run local integration tests

### DIFF
--- a/.integration.mk
+++ b/.integration.mk
@@ -1,0 +1,28 @@
+# Copyright 2019 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+.PHONY: k8s-integration-config
+k8s-integration-config:
+	@kubectl label --overwrite --all=true nodes app=nsmd-ds
+	@kubectl apply -f k8s/conf/cluster-role-admin.yaml
+	@kubectl apply -f k8s/conf/cluster-role-binding.yaml
+
+.PHONY: k8s-integration-tests
+k8s-integration-tests: k8s-integration-config
+	@GO111MODULE=on go test -v ./test/...
+
+.PHONY: k8s-integration-%-test
+k8s-integration-%-test: k8s-integration-config
+	@GO111MODULE=on go test -v ./test/... -run $*

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,7 @@ include .k8s.mk
 include .skydive.mk
 include .jaeger.mk
 include .monitor.mk
+include .integration.mk
 
 GOPATH?=$(shell go env GOPATH 2>/dev/null)
 GOCMD=go


### PR DESCRIPTION
## Description
Add a make target to run the integration tests on a locally configured cluster.

## Motivation and Context
Today we use packet to run the integration testing. However one might want to be able to run these on
an arbitrary Kubernetes deployment.
This PR adds:
 * `make k8s-integration-tests` -> run all integration tests on the configured Kubernetes cluser
 * `make k8s-integration-%-test` -> run a single test, e.g `make k8s-integration-TestDeployPodIntoInvalidEnv-test`

## How Has This Been Tested?
- [ ] Covered by existing integration testing
- [ ] Added integration testing to cover
- [X] Tested locally
- [ ] Have not tested

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
We might want to put specify these new targets in the developer's docs.

Signed-off-by: Nikolay Nikolaev <nnikolay@vmware.com>