### PR TITLE
Adding VPN integration tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -296,6 +296,21 @@ jobs:
             export TAG="$BUILD_TAG"
             make docker-vppagent-dataplane-build
             make docker-vppagent-dataplane-push
+  build-vppagent-firewall-nse:
+    working_directory: /go/src/github.com/networkservicemesh/networkservicemesh/
+    docker:
+      - image: circleci/golang:1.11
+    steps:
+      - checkout
+      - setup_remote_docker:
+          docker_layer_caching: true
+      - run:
+          command: |
+            export COMMIT="${CIRCLE_SHA1:8:8}"
+            export BUILD_TAG="circle-${CIRCLE_BUILD_NUM}"
+            export TAG="$BUILD_TAG"
+            make docker-vppagent-firewall-nse-build
+            make docker-vppagent-firewall-nse-push
 workflows:
   version: 2
   build-and-test:
@@ -328,6 +343,9 @@ workflows:
       - build-vppagent-dataplane:
           requires:
             - sanity-check
+      - build-vppagent-firewall-nse:
+          requires:
+            - sanity-check
       - packet-deploy:
           requires:
             - sanity-check
@@ -341,6 +359,7 @@ workflows:
             - build-vppagent-icmp-responder-nse
             - build-vppagent-nsc
             - build-nsc
+            - build-vppagent-firewall-nse
             - packet-deploy
       - packet-destroy:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -115,6 +115,7 @@ jobs:
             ./scripts/prepare-circle-integration-tests.sh
             mkdir -p ~/junit/
             gotestsum --junitfile ~/junit/integration-tests.xml ./test/...
+          no_output_timeout: 30m
           environment:
             KUBECONFIG: /home/circleci/project/data/kubeconfig
             GO111MODULE: 'on'

--- a/.docker.mk
+++ b/.docker.mk
@@ -12,7 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-BUILD_CONTAINERS=nsc nsmd nsmdp nsmd-k8s icmp-responder-nse vppagent-dataplane devenv crossconnect-monitor
+BUILD_CONTAINERS=nsmd nsmdp nsmd-k8s vppagent-dataplane
+BUILD_CONTAINERS+=devenv crossconnect-monitor
+BUILD_CONTAINERS+=nsc icmp-responder-nse
+BUILD_CONTAINERS+=vppagent-firewall-nse
 RUN_CONTAINERS=$(BUILD_CONTAINERS)
 KILL_CONTAINERS=$(BUILD_CONTAINERS)
 LOG_CONTAINERS=$(KILL_CONTAINERS)

--- a/k8s/cmd/nsmd-k8s/main.go
+++ b/k8s/cmd/nsmd-k8s/main.go
@@ -82,6 +82,7 @@ func main() {
 		removeCRDs(clientset)
 	}()
 
+	logrus.Print("nsmd-k8s intialized and waiting for connection")
 	err = server.Serve(listener)
 	logrus.Fatalln(err)
 }

--- a/test/integration/vpn_test.go
+++ b/test/integration/vpn_test.go
@@ -2,6 +2,7 @@ package nsmd_integration_tests
 
 import (
 	"fmt"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -33,6 +34,10 @@ func TestVPNLocal(t *testing.T) {
 func TestVPNFirewallRemote(t *testing.T) {
 	RegisterTestingT(t)
 
+	if !isVPNRemoteEnabled() {
+		t.Skip("VPN_REMOTE_ENABLED not defined.")
+	}
+
 	if testing.Short() {
 		t.Skip("Skip, please run without -short")
 		return
@@ -47,6 +52,10 @@ func TestVPNFirewallRemote(t *testing.T) {
 
 func TestVPNNSERemote(t *testing.T) {
 	RegisterTestingT(t)
+
+	if !isVPNRemoteEnabled() {
+		t.Skip("VPN_REMOTE_ENABLED not defined.")
+	}
 
 	if testing.Short() {
 		t.Skip("Skip, please run without -short")
@@ -63,6 +72,10 @@ func TestVPNNSERemote(t *testing.T) {
 func TestVPNNSCRemote(t *testing.T) {
 	RegisterTestingT(t)
 
+	if !isVPNRemoteEnabled() {
+		t.Skip("VPN_REMOTE_ENABLED not defined.")
+	}
+
 	if testing.Short() {
 		t.Skip("Skip, please run without -short")
 		return
@@ -73,6 +86,11 @@ func TestVPNNSCRemote(t *testing.T) {
 		"vpn-gateway-nse1":       0,
 		"vpn-gateway-nsc1":       1,
 	}, false)
+}
+
+func isVPNRemoteEnabled() bool {
+	_, ok := os.LookupEnv("VPN_REMOTE_ENABLED")
+	return ok
 }
 
 func testVPN(t *testing.T, nodesCount int, affinity map[string]int, verbose bool) {

--- a/test/integration/vpn_test.go
+++ b/test/integration/vpn_test.go
@@ -1,0 +1,240 @@
+package nsmd_integration_tests
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	nsapiv1 "github.com/networkservicemesh/networkservicemesh/k8s/pkg/apis/networkservice/v1"
+	"github.com/networkservicemesh/networkservicemesh/test/kube_testing"
+	"github.com/networkservicemesh/networkservicemesh/test/kube_testing/crds"
+	"github.com/networkservicemesh/networkservicemesh/test/kube_testing/pods"
+	. "github.com/onsi/gomega"
+	"github.com/sirupsen/logrus"
+	v1 "k8s.io/api/core/v1"
+)
+
+func TestVPNLocal(t *testing.T) {
+	RegisterTestingT(t)
+
+	if testing.Short() {
+		t.Skip("Skip, please run without -short")
+		return
+	}
+
+	testVPN(t, 1, map[string]int{
+		"vppagent-firewall-nse1": 0,
+		"vpn-gateway-nse1":       0,
+		"vpn-gateway-nsc1":       0,
+	}, false)
+}
+
+func TestVPNFirewallRemote(t *testing.T) {
+	RegisterTestingT(t)
+
+	if testing.Short() {
+		t.Skip("Skip, please run without -short")
+		return
+	}
+
+	testVPN(t, 2, map[string]int{
+		"vppagent-firewall-nse1": 1,
+		"vpn-gateway-nse1":       0,
+		"vpn-gateway-nsc1":       0,
+	}, false)
+}
+
+func TestVPNNSERemote(t *testing.T) {
+	RegisterTestingT(t)
+
+	if testing.Short() {
+		t.Skip("Skip, please run without -short")
+		return
+	}
+
+	testVPN(t, 2, map[string]int{
+		"vppagent-firewall-nse1": 0,
+		"vpn-gateway-nse1":       1,
+		"vpn-gateway-nsc1":       0,
+	}, false)
+}
+
+func TestVPNNSCRemote(t *testing.T) {
+	RegisterTestingT(t)
+
+	if testing.Short() {
+		t.Skip("Skip, please run without -short")
+		return
+	}
+
+	testVPN(t, 2, map[string]int{
+		"vppagent-firewall-nse1": 0,
+		"vpn-gateway-nse1":       0,
+		"vpn-gateway-nsc1":       1,
+	}, false)
+}
+
+func testVPN(t *testing.T, nodesCount int, affinity map[string]int, verbose bool) {
+	RegisterTestingT(t)
+
+	k8s, err := kube_testing.NewK8s()
+	defer k8s.Cleanup()
+
+	Expect(err).To(BeNil())
+
+	s1 := time.Now()
+	k8s.Prepare("nsmd", "nsmd-dataplane", "vppagent-firewall-nse", "vpn-gateway-nse", "vpn-gateway-nsc")
+	logrus.Printf("Cleanup done: %v", time.Since(s1))
+	nodes := k8s.GetNodesWait(nodesCount, time.Second*60)
+	if len(nodes) < nodesCount {
+		logrus.Printf("At least one kubernetes node are required for this test")
+		Expect(len(nodes)).To(Equal(nodesCount))
+		return
+	}
+	nsmdPodNode := []*v1.Pod{}
+	nsmdDataplanePodNode := []*v1.Pod{}
+
+	s1 = time.Now()
+	for k := 0; k < nodesCount; k++ {
+		corePodName := fmt.Sprintf("nsmd%d", k)
+		dataPlanePodName := fmt.Sprintf("nsmd-dataplane%d", k)
+		corePods := k8s.CreatePods(pods.NSMDPod(corePodName, &nodes[k]), pods.VPPDataplanePod(dataPlanePodName, &nodes[k]))
+		logrus.Printf("Started NSMD/Dataplane: %v on node %d", time.Since(s1), k)
+		nsmdPodNode = append(nsmdPodNode, corePods[0])
+		nsmdDataplanePodNode = append(nsmdDataplanePodNode, corePods[1])
+
+		Expect(corePods[0].Name).To(Equal(corePodName))
+		Expect(corePods[1].Name).To(Equal(dataPlanePodName))
+
+		k8s.WaitLogsContains(nsmdDataplanePodNode[k], "", "Sending MonitorMechanisms update", defaultTimeout)
+		k8s.WaitLogsContains(nsmdPodNode[k], "nsmd", "Dataplane added", defaultTimeout)
+		k8s.WaitLogsContains(nsmdPodNode[k], "nsmd-k8s", "nsmd-k8s intialized and waiting for connection", defaultTimeout)
+		k8s.WaitLogsContains(nsmdPodNode[k], "nsmdp", "ListAndWatch was called with", defaultTimeout)
+	}
+
+	{
+		nscrd, err := crds.NewNSCRD()
+		Expect(err).To(BeNil())
+
+		nsSecureIntranetConnectivity := crds.SecureIntranetConnetivity()
+		logrus.Printf("About to insert: %v", nsSecureIntranetConnectivity)
+		var result *nsapiv1.NetworkService
+		result, err = nscrd.Create(nsSecureIntranetConnectivity)
+		Expect(err).To(BeNil())
+		logrus.Printf("CRD applied with result: %v", result)
+		result, err = nscrd.Get(nsSecureIntranetConnectivity.ObjectMeta.Name)
+		Expect(err).To(BeNil())
+		logrus.Printf("Registered CRD is: %v", result)
+	}
+
+	s1 = time.Now()
+	node := affinity["vppagent-firewall-nse1"]
+	logrus.Infof("Starting VppAgent Firewall NSE on node: %d", node)
+	vppagentFirewallNode := k8s.CreatePod(pods.VppAgentFirewallNSEPod("vppagent-firewall-nse1", &nodes[node],
+		map[string]string{
+			"ADVERTISE_NSE_NAME":   "secure-intranet-connectivity",
+			"ADVERTISE_NSE_LABELS": "app=firewall",
+			"OUTGOING_NSC_NAME":    "secure-intranet-connectivity",
+			"OUTGOING_NSC_LABELS":  "app=firewall",
+		},
+	))
+	Expect(vppagentFirewallNode.Name).To(Equal("vppagent-firewall-nse1"))
+
+	k8s.WaitLogsContains(vppagentFirewallNode, "", "NSE: channel has been successfully advertised, waiting for connection from NSM...", time.Second)
+
+	logrus.Printf("VPN Gateway started done: %v", time.Since(s1))
+
+	s1 = time.Now()
+	node = affinity["vpn-gateway-nse1"]
+	logrus.Infof("Starting VPN Gateway NSE on node: %d", node)
+	vpnGatewayPodNode := k8s.CreatePod(pods.VPNGatewayNSEPod("vpn-gateway-nse1", &nodes[node],
+		map[string]string{
+			"ADVERTISE_NSE_NAME":   "secure-intranet-connectivity",
+			"ADVERTISE_NSE_LABELS": "app=vpn-gateway",
+			"IP_ADDRESS":           "10.60.1.0/24",
+		},
+	))
+	Expect(vpnGatewayPodNode.Name).To(Equal("vpn-gateway-nse1"))
+
+	k8s.WaitLogsContains(vpnGatewayPodNode, "vpn-gateway", "NSE: channel has been successfully advertised, waiting for connection from NSM...", time.Second)
+
+	logrus.Printf("VPN Gateway started done: %v", time.Since(s1))
+
+	s1 = time.Now()
+	node = affinity["vpn-gateway-nsc1"]
+	nscPodNode := k8s.CreatePod(pods.NSCPod("vpn-gateway-nsc1", &nodes[node],
+		map[string]string{
+			"OUTGOING_NSC_NAME": "secure-intranet-connectivity",
+		},
+	))
+	Expect(nscPodNode.Name).To(Equal("vpn-gateway-nsc1"))
+
+	k8s.WaitLogsContains(nscPodNode, "nsc", "nsm client: initialization is completed successfully", defaultTimeout)
+	logrus.Printf("VPN Gateway NSC started done: %v", time.Since(s1))
+
+	var ipResponse string = ""
+	var routeResponse string = ""
+	var pingResponse string = ""
+	var errOut string = ""
+	var wgetResponse string
+	var failures []string
+
+	failures = InterceptGomegaFailures(func() {
+		ipResponse, errOut, err = k8s.Exec(nscPodNode, nscPodNode.Spec.Containers[0].Name, "ip", "addr")
+		Expect(err).To(BeNil())
+		Expect(errOut).To(Equal(""))
+		logrus.Printf("NSC IP status Ok")
+
+		Expect(strings.Contains(ipResponse, "10.60.1.1")).To(Equal(true))
+		Expect(strings.Contains(ipResponse, "nsm")).To(Equal(true))
+
+		routeResponse, errOut, err = k8s.Exec(nscPodNode, nscPodNode.Spec.Containers[0].Name, "ip", "route")
+		Expect(err).To(BeNil())
+		Expect(errOut).To(Equal(""))
+		logrus.Printf("NSC Route status, Ok")
+
+		Expect(strings.Contains(routeResponse, "8.8.8.8")).To(Equal(true))
+		Expect(strings.Contains(routeResponse, "nsm")).To(Equal(true))
+		for i := 1; i <= 1; i++ {
+			pingResponse, errOut, err = k8s.Exec(nscPodNode, nscPodNode.Spec.Containers[0].Name, "ping", "10.60.1.2", "-A", "-c", "10")
+			Expect(err).To(BeNil())
+			Expect(strings.Contains(pingResponse, "10 packets received")).To(Equal(true))
+			logrus.Printf("VPN NSC Ping succeeded:%s", pingResponse)
+
+			_, wgetResponse, err = k8s.Exec(nscPodNode, nscPodNode.Spec.Containers[0].Name, "wget", "-O", "/dev/null", "--timeout", "3", "http://10.60.1.2:80")
+			Expect(err).To(BeNil())
+			Expect(strings.Contains(wgetResponse, "100% |***")).To(Equal(true))
+			logrus.Printf("%d VPN NSC wget request succeeded: %s", i, wgetResponse)
+
+			_, wgetResponse, err = k8s.Exec(nscPodNode, nscPodNode.Spec.Containers[0].Name, "wget", "-O", "/dev/null", "--timeout", "3", "http://10.60.1.2:8080")
+			Expect(err).To(Not(BeNil()))
+			Expect(strings.Contains(wgetResponse, "download timed out")).To(Equal(true))
+			logrus.Printf("%d VPN NSC wget request succeeded: %s", i, wgetResponse)
+		}
+	})
+
+	// Do dumping of container state to dig into what is happened.
+	if len(failures) > 0 {
+		logrus.Errorf("Failues: %v", failures)
+
+		if verbose {
+			for k := 0; k < nodesCount; k++ {
+				nsmdLogs, _ := k8s.GetLogs(nsmdPodNode[k], "nsmd")
+				logrus.Errorf("===================== NSMD %d output since test is failing %v\n=====================", k, nsmdLogs)
+
+				nsmdk8sLogs, _ := k8s.GetLogs(nsmdPodNode[k], "nsmd-k8s")
+				logrus.Errorf("===================== NSMD K8S %d output since test is failing %v\n=====================", k, nsmdk8sLogs)
+
+				nsmdpLogs, _ := k8s.GetLogs(nsmdPodNode[k], "nsmdp")
+				logrus.Errorf("===================== NSMD K8S %d output since test is failing %v\n=====================", k, nsmdpLogs)
+
+				dataplaneLogs, _ := k8s.GetLogs(nsmdDataplanePodNode[k], "")
+				logrus.Errorf("===================== Dataplane %d output since test is failing %v\n=====================", k, dataplaneLogs)
+			}
+		}
+		logrus.Errorf("===================== VPN NSC WGET %v\n=====================", wgetResponse)
+
+		t.Fail()
+	}
+}

--- a/test/kube_testing/crds/networkservice.go
+++ b/test/kube_testing/crds/networkservice.go
@@ -1,0 +1,126 @@
+// Copyright 2019 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package crds
+
+import (
+	"os"
+
+	nsapiv1 "github.com/networkservicemesh/networkservicemesh/k8s/pkg/apis/networkservice/v1"
+	nscrd "github.com/networkservicemesh/networkservicemesh/k8s/pkg/networkservice/clientset/versioned"
+	. "github.com/onsi/gomega"
+	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v12 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+type NSCRD struct {
+	clientset nscrd.Interface
+	namespace string
+	resource  string
+	config    *rest.Config
+}
+
+func (nscrd *NSCRD) Create(obj *nsapiv1.NetworkService) (*nsapiv1.NetworkService, error) {
+	var result nsapiv1.NetworkService
+	err := nscrd.clientset.NetworkservicemeshV1().RESTClient().Post().
+		Namespace(nscrd.namespace).Resource(nscrd.resource).
+		Body(obj).Do().Into(&result)
+	return &result, err
+}
+
+func (nscrd *NSCRD) Update(obj *nsapiv1.NetworkService) (*nsapiv1.NetworkService, error) {
+	var result nsapiv1.NetworkService
+	err := nscrd.clientset.NetworkservicemeshV1().RESTClient().Put().
+		Namespace(nscrd.namespace).Resource(nscrd.resource).
+		Body(obj).Do().Into(&result)
+	return &result, err
+}
+
+func (nscrd *NSCRD) Delete(name string, options *metaV1.DeleteOptions) error {
+	return nscrd.clientset.NetworkservicemeshV1().RESTClient().Delete().
+		Namespace(nscrd.namespace).Resource(nscrd.resource).
+		Name(name).Body(options).Do().
+		Error()
+}
+
+func (nscrd *NSCRD) Get(name string) (*nsapiv1.NetworkService, error) {
+	var result nsapiv1.NetworkService
+	err := nscrd.clientset.NetworkservicemeshV1().RESTClient().Get().
+		Namespace(nscrd.namespace).Resource(nscrd.resource).
+		Name(name).Do().Into(&result)
+	return &result, err
+}
+
+func NewNSCRD() (*NSCRD, error) {
+
+	path := os.Getenv("KUBECONFIG")
+	if len(path) == 0 {
+		path = os.Getenv("HOME") + "/.kube/config"
+	}
+
+	config, err := clientcmd.BuildConfigFromFlags("", path)
+	Expect(err).To(BeNil())
+
+	client := NSCRD{
+		namespace: "default",
+		resource:  "networkservices",
+		config:    config,
+	}
+	client.clientset, err = nscrd.NewForConfig(config)
+
+	Expect(err).To(BeNil())
+
+	return &client, nil
+}
+
+func SecureIntranetConnetivity() *nsapiv1.NetworkService {
+	return &nsapiv1.NetworkService{
+		TypeMeta: v12.TypeMeta{
+			APIVersion: "networkservicemesh.io/v1",
+			Kind:       "NetworkService",
+		},
+		ObjectMeta: v12.ObjectMeta{
+			Name: "secure-intranet-connectivity",
+		},
+		Spec: nsapiv1.NetworkServiceSpec{
+			Payload: "IP",
+			Matches: []*nsapiv1.Match{
+				&nsapiv1.Match{
+					SourceSelector: map[string]string{
+						"app": "firewall",
+					},
+					Routes: []*nsapiv1.Destination{
+						&nsapiv1.Destination{
+							DestinationSelector: map[string]string{
+								"app": "vpn-gateway",
+							},
+						},
+					},
+				},
+				&nsapiv1.Match{
+					Routes: []*nsapiv1.Destination{
+						&nsapiv1.Destination{
+							DestinationSelector: map[string]string{
+								"app": "firewall",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}

--- a/test/kube_testing/k8s_exec.go.go
+++ b/test/kube_testing/k8s_exec.go.go
@@ -1,10 +1,11 @@
 package kube_testing
 
 import (
-	"k8s.io/api/core/v1"
+	"strings"
+
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/remotecommand"
-	"strings"
 )
 
 type Writer struct {

--- a/test/kube_testing/pods/vpn-gateway-nse.go
+++ b/test/kube_testing/pods/vpn-gateway-nse.go
@@ -6,23 +6,13 @@ import (
 	v12 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func NSCPod(name string, node *v1.Node, env map[string]string) *v1.Pod {
+func VPNGatewayNSEPod(name string, node *v1.Node, env map[string]string) *v1.Pod {
 	ht := new(v1.HostPathType)
 	*ht = v1.HostPathDirectoryOrCreate
 
-	nsc_container := v1.Container{
-		Name:            "nsc",
-		Image:           "networkservicemesh/nsc:latest",
-		ImagePullPolicy: v1.PullIfNotPresent,
-		Resources: v1.ResourceRequirements{
-			Limits: v1.ResourceList{
-				"nsm.ligato.io/socket": resource.NewQuantity(1, resource.DecimalSI).DeepCopy(),
-			},
-			Requests: nil,
-		},
-	}
+	var envVars []v1.EnvVar
 	for k, v := range env {
-		nsc_container.Env = append(nsc_container.Env,
+		envVars = append(envVars,
 			v1.EnvVar{
 				Name:  k,
 				Value: v,
@@ -39,16 +29,21 @@ func NSCPod(name string, node *v1.Node, env map[string]string) *v1.Pod {
 		Spec: v1.PodSpec{
 			Containers: []v1.Container{
 				{
-					Name:            "alpine-img",
-					Image:           "alpine:latest",
+					Name:            "vpn-gateway",
+					Image:           "networkservicemesh/icmp-responder-nse:latest",
 					ImagePullPolicy: v1.PullIfNotPresent,
-					Command: []string{
-						"tail", "-f", "/dev/null",
+					Resources: v1.ResourceRequirements{
+						Limits: v1.ResourceList{
+							"nsm.ligato.io/socket": resource.NewQuantity(1, resource.DecimalSI).DeepCopy(),
+						},
+						Requests: nil,
 					},
+					Env: envVars,
 				},
-			},
-			InitContainers: []v1.Container{
-				nsc_container,
+				{
+					Name:  "nginx",
+					Image: "networkservicemesh/nginx",
+				},
 			},
 		},
 	}


### PR DESCRIPTION
## Description
Add the `secure-intranet-connectivity` integration test.
This also adds testing capabilities to describe NetworkService enabling more complex real-world scenarios.

## Motivation and Context
This test exercises NSM's capabilities to implement NetwrokService CRD, link a couple of Endpoints and create complex deployments. It is setting a direction of increasing the number of integration tests and their coverage.

Currently only the simplest single host scenario is enabled. The remote test can be run  by defining `VPN_REMOTE_ENABLED`.

An option to run is:
VPN_REMOTE_ENABLED=1 make k8s-integration-TestVPN*-test

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [ ] Covered by existing integration testing
- [X] Added integration testing to cover
- [X] Tested locally
- [ ] Have not tested

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

Signed-off-by: Nikolay Nikolaev <nnikolay@vmware.com>