### PR TITLE
Workspace name was not specified for memif connections properly.

### DIFF
--- a/controlplane/pkg/nsm/nse_requests.go
+++ b/controlplane/pkg/nsm/nse_requests.go
@@ -39,7 +39,7 @@ func (srv *networkServiceManager) createLocalNSERequest(endpoint *registry.NSERe
 			Id:             srv.createConnectionId(),
 			NetworkService: endpoint.GetNetworkService().GetName(),
 			Context:        requestConnection.GetContext(),
-			Labels:         nil,
+			Labels:         requestConnection.GetLabels(),
 		},
 		MechanismPreferences: []*connection.Mechanism{
 			{

--- a/controlplane/pkg/nsm/nsm.go
+++ b/controlplane/pkg/nsm/nsm.go
@@ -330,11 +330,12 @@ func (srv *networkServiceManager) getNetworkServiceManagerName() string {
 }
 
 func (srv *networkServiceManager) updateConnectionParameters(nseConnection nsm.NSMConnection, endpoint *registry.NSERegistration) {
-	if srv.getNetworkServiceManagerName() == endpoint.GetNetworkserviceEndpoint().GetEndpointName() {
+	if srv.isLocalEndpoint(endpoint) {
 		workspace := nsmd.WorkSpaceRegistry().WorkspaceByEndpoint(endpoint.GetNetworkserviceEndpoint())
 		if workspace != nil { // In case of tests this could be empty
 			nseConnection.(*connection.Connection).GetMechanism().GetParameters()[connection.Workspace] = workspace.Name()
 		}
+		logrus.Infof("Update Local NSE connection parameters: %v", nseConnection.(*connection.Connection).GetMechanism())
 	}
 }
 

--- a/controlplane/pkg/nsmd/network_service_server.go
+++ b/controlplane/pkg/nsmd/network_service_server.go
@@ -36,6 +36,7 @@ func NewNetworkServiceServer(model model.Model, workspace *Workspace, manager ns
 }
 
 func (srv *networkServiceServer) Request(ctx context.Context, request *networkservice.NetworkServiceRequest) (*connection.Connection, error) {
+	logrus.Infof("Received request from client to connect to NetworkService: %v", request)
 	// This parameters will go into selected mechanism
 	params := map[string]string{}
 	params[connection.Workspace] = srv.workspace.Name()


### PR DESCRIPTION
Workspace name was not specified for Local NSE connections.
It is required by memif.

Signed-off-by: Andrey Sobolev <haiodo@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [ ] Covered by existing integration testing
- [ ] Added integration testing to cover
- [x] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
