### PR TITLE
Make push-latest simpler

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -320,9 +320,15 @@ jobs:
       - run:
           command: |
             export COMMIT="${CIRCLE_SHA1:8:8}"
+            export PULL_TAG="circle-${COMMIT}"
             export TAG="latest"
+            export REPO="networkservicemesh"
             export CONTAINERS=(nsmd nsmd-k8s nsmdp crossconnect-monitor icmp-responder-nse vppagent-icmp-responder-nse vppagent-nsc nsc vppagent-dataplane)
-            for c in ${CONTAINERS[@]}; do make docker-${c}-build docker-${c}-push; done
+            for c in ${CONTAINERS[@]}; do
+              docker pull ${REPO}/${c}:${PULL_TAG}
+              docker tag ${REPO}/${c}:${PULL_TAG} ${REPO}/${c}:${TAG}
+              docker push ${REPO}/${c}:${TAG}
+            done
 
 workflows:
   version: 2


### PR DESCRIPTION
## Description
Shift push-latest from rebuilding the images to simply pulling, tagging, and re-pushing.

## Motivation and Context
No need to rebuild the images, we can just push them.

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [x] Covered by existing integration testing
- [ ] Added integration testing to cover
- [ ] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.