### PR TITLE
Admission Webhook handle pods

### DIFF
--- a/k8s/conf/admission-webhook-cfg.yaml
+++ b/k8s/conf/admission-webhook-cfg.yaml
@@ -16,4 +16,4 @@ webhooks:
       - operations: ["CREATE"]
         apiGroups: ["apps", "extensions", ""]
         apiVersions: ["v1", "v1beta1"]
-        resources: ["deployments", "services"]
+        resources: ["deployments", "pods"]


### PR DESCRIPTION
Signed-off-by: Andrey Platov <andrey@xored.com>

Initial admission webhook implementation mutate `deployments` only. This PR also let mutate `pods`

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [ ] Covered by existing integration testing
- [ ] Added integration testing to cover
- [ ] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
