### PR TITLE
Move CRDs to yaml

### DIFF
--- a/.integration.mk
+++ b/.integration.mk
@@ -18,6 +18,9 @@ k8s-integration-config:
 	@kubectl label --overwrite --all=true nodes app=nsmd-ds
 	@kubectl apply -f k8s/conf/cluster-role-admin.yaml
 	@kubectl apply -f k8s/conf/cluster-role-binding.yaml
+	@kubectl apply -f k8s/conf/crd-networkservices.yaml
+	@kubectl apply -f k8s/conf/crd-networkserviceendpoints.yaml
+	@kubectl apply -f k8s/conf/crd-networkservicemanagers.yaml
 
 .PHONY: k8s-integration-tests
 k8s-integration-tests: k8s-integration-config

--- a/.k8s.mk
+++ b/.k8s.mk
@@ -26,7 +26,9 @@ DEPLOY_ICMP = $(DEPLOY_ICMP_KERNEL) $(DEPLOY_ICMP_VPP)
 DEPLOY_VPN = secure-intranet-connectivity vppagent-firewall-nse vpn-gateway-nse vpn-gateway-nsc
 DEPLOYS = $(DEPLOY_INFRA) $(DEPLOY_ICMP) $(DEPLOY_VPN)
 
-CLUSTER_CONFIGS = cluster-role-admin cluster-role-binding cluster-role-view
+CLUSTER_CONFIG_ROLE = cluster-role-admin cluster-role-binding cluster-role-view
+CLUSTER_CONFIG_CRD = crd-networkservices crd-networkserviceendpoints crd-networkservicemanagers
+CLUSTER_CONFIGS = $(CLUSTER_CONFIG_ROLE) $(CLUSTER_CONFIG_CRD)
 
 # All of the rules that use vagrant are intentionally written in such a way
 # That you could set the CLUSTER_RULES_PREFIX different and introduce

--- a/docs/QUICK-START.md
+++ b/docs/QUICK-START.md
@@ -58,7 +58,7 @@ make k8s-infra-deploy
 A simple check should show two `nsmd`, two `nsm-vppagent-dataplane`, two `skydive-agent`, one `crossconnect-monitor` and one `skydive-analyzer` pods.
 
 ```bash
-kubect get pods
+kubectl get pods
 ```
 
 This will allow you to see your Network Service Mesh daemonset running:

--- a/k8s/conf/crd-networkserviceendpoints.yaml
+++ b/k8s/conf/crd-networkserviceendpoints.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: networkserviceendpoints.networkservicemesh.io
+spec:
+  conversion:
+    strategy: None
+  group: networkservicemesh.io
+  names:
+    kind: NetworkServiceEndpoint
+    listKind: NetworkServiceEndpointList
+    plural: networkserviceendpoints
+    shortNames:
+      - nse
+      - nses
+    singular: networkserviceendpoint
+  scope: Cluster
+  version: v1
+  versions:
+    - name: v1
+      served: true
+      storage: true

--- a/k8s/conf/crd-networkservicemanagers.yaml
+++ b/k8s/conf/crd-networkservicemanagers.yaml
@@ -21,4 +21,3 @@ spec:
     - name: v1
       served: true
       storage: true
-

--- a/k8s/conf/crd-networkservicemanagers.yaml
+++ b/k8s/conf/crd-networkservicemanagers.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: networkservicemanagers.networkservicemesh.io
+spec:
+  conversion:
+    strategy: None
+  group: networkservicemesh.io
+  names:
+    kind: NetworkServiceManager
+    listKind: NetworkServiceManagerList
+    plural: networkservicemanagers
+    shortNames:
+      - nsm
+      - nsms
+    singular: networkservicemanager
+  scope: Cluster
+  version: v1
+  versions:
+    - name: v1
+      served: true
+      storage: true
+

--- a/k8s/conf/crd-networkservices.yaml
+++ b/k8s/conf/crd-networkservices.yaml
@@ -21,4 +21,3 @@ spec:
     - name: v1
       served: true
       storage: true
-

--- a/k8s/conf/crd-networkservices.yaml
+++ b/k8s/conf/crd-networkservices.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: networkservices.networkservicemesh.io
+spec:
+  conversion:
+    strategy: None
+  group: networkservicemesh.io
+  names:
+    kind: NetworkService
+    listKind: NetworkServiceList
+    plural: networkservices
+    shortNames:
+      - netsvc
+      - netsvcs
+    singular: networkservice
+  scope: Cluster
+  version: v1
+  versions:
+    - name: v1
+      served: true
+      storage: true
+

--- a/scripts/prepare-circle-integration-tests.sh
+++ b/scripts/prepare-circle-integration-tests.sh
@@ -31,4 +31,8 @@ kubectl label --overwrite --all=true nodes app=nsmd-ds
 kubectl apply -f k8s/conf/cluster-role-admin.yaml
 kubectl apply -f k8s/conf/cluster-role-binding.yaml
 
+kubectl apply -f k8s/conf/crd-networkservices.yaml
+kubectl apply -f k8s/conf/crd-networkserviceendpoints.yaml
+kubectl apply -f k8s/conf/crd-networkservicemanagers.yaml
+
 # vim: sw=4 ts=4 et si

--- a/test/integration/nsmd_k8s_test.go
+++ b/test/integration/nsmd_k8s_test.go
@@ -3,16 +3,15 @@ package nsmd_integration_tests
 import (
 	"context"
 	"fmt"
+	"testing"
+	"time"
+
 	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/registry"
 	nsmd2 "github.com/networkservicemesh/networkservicemesh/controlplane/pkg/nsmd"
-	"github.com/networkservicemesh/networkservicemesh/k8s/pkg/networkservice/clientset/versioned"
 	"github.com/networkservicemesh/networkservicemesh/test/kube_testing"
 	"github.com/networkservicemesh/networkservicemesh/test/kube_testing/pods"
 	. "github.com/onsi/gomega"
 	"github.com/sirupsen/logrus"
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
-	"testing"
-	"time"
 )
 
 func TestNSMDDRegistryNSE(t *testing.T) {
@@ -65,11 +64,8 @@ func TestNSMDDRegistryNSE(t *testing.T) {
 	registryClient, err := serviceRegistry.RegistryClient()
 	Expect(err).To(BeNil())
 
-	versionedClientSet, err := versioned.NewForConfig(k8s.GetConfig())
-	Expect(err).To(BeNil())
-
 	// Cleanup all registered stuff
-	cleanupCRDs(versionedClientSet)
+	k8s.CleanupCRDs()
 
 	nses := []string{}
 	nme := "my-network-service"
@@ -128,22 +124,4 @@ func TestNSMDDRegistryNSE(t *testing.T) {
 	logs, err = k8s.GetLogs(nsmd, "nsmd-k8s")
 	logrus.Printf("%s", logs)
 
-}
-
-func cleanupCRDs(versionedClientSet *versioned.Clientset) {
-	managers, err := versionedClientSet.Networkservicemesh().NetworkServiceManagers("default").List(v1.ListOptions{})
-	Expect(err).To(BeNil())
-	for _, mgr := range managers.Items {
-		_ = versionedClientSet.Networkservicemesh().NetworkServiceManagers("default").Delete(mgr.Name, &v1.DeleteOptions{})
-	}
-	endpoints, err := versionedClientSet.Networkservicemesh().NetworkServiceEndpoints("default").List(v1.ListOptions{})
-	Expect(err).To(BeNil())
-	for _, ep := range endpoints.Items {
-		_ = versionedClientSet.Networkservicemesh().NetworkServiceEndpoints("default").Delete(ep.Name, &v1.DeleteOptions{})
-	}
-	services, err := versionedClientSet.Networkservicemesh().NetworkServices("default").List(v1.ListOptions{})
-	Expect(err).To(BeNil())
-	for _, service := range services.Items {
-		_ = versionedClientSet.Networkservicemesh().NetworkServices("default").Delete(service.Name, &v1.DeleteOptions{})
-	}
 }


### PR DESCRIPTION
This creates NSM CRD bundle yaml and removes CRD generation and cleanup from code

Signed-off-by: Ivana Yovcheva <iyovcheva@vmware.com>

<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Closes #736

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [ ] Covered by existing integration testing
- [ ] Added integration testing to cover
- [x] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

```
$ make k8s-icmp-delete
$ make k8s-vpn-delete

$ make k8s-save

$ make k8s-infra-deploy

$ make k8s-icmp-deploy
$ make k8s-vpn-deploy
$ make k8s-check
```
Check CRDs are updated
```
$ kubectl get crd
NAME                                            CREATED AT
networkserviceendpoints.networkservicemesh.io   2019-02-13T12:18:43Z
networkservicemanagers.networkservicemesh.io    2019-02-13T12:18:44Z
networkservices.networkservicemesh.io           2019-02-13T12:18:43Z
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.