### PR TITLE
Bug: Add check of cmdline during resolving namespace by inode

### DIFF
--- a/controlplane/pkg/apis/local/connection/mechanism_helpers.go
+++ b/controlplane/pkg/apis/local/connection/mechanism_helpers.go
@@ -95,7 +95,7 @@ func (m *Mechanism) NetNsFileName() (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("Mechanism.Parameters[%s] must be an unsigned int, instead was: %s: %v", NetNsInodeKey, m.Parameters[NetNsInodeKey], m)
 	}
-	filename, err := fs.FindFileInProc(inodeNum, "/ns/net")
+	filename, err := fs.ResolvePodNsByInode(inodeNum)
 	if err != nil {
 		return "", fmt.Errorf("No file found in /proc/*/ns/net with inode %d: %v", inodeNum, err)
 	}

--- a/utils/fs/fsutils.go
+++ b/utils/fs/fsutils.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
+	"strings"
 	"syscall"
 	"unicode"
 )
@@ -52,7 +53,9 @@ func FindFileInProc(inode uint64, suffix string) (string, error) {
 				continue
 			}
 			if tryInode == inode {
-				return filename, nil
+				if cmdline, err := GetCmdline(name); err == nil && strings.Contains(cmdline, "pause") {
+					return filename, nil
+				}
 			}
 		}
 	}
@@ -78,4 +81,12 @@ func GetAllNetNs() ([]uint64, error) {
 		}
 	}
 	return inodes, nil
+}
+
+func GetCmdline(pid string) (string, error) {
+	data, err := ioutil.ReadFile(path.Join("/proc/", pid, "cmdline"))
+	if err != nil {
+		return "", err
+	}
+	return string(data), nil
 }

--- a/utils/fs/fsutils.go
+++ b/utils/fs/fsutils.go
@@ -33,10 +33,9 @@ func GetInode(file string) (uint64, error) {
 	return stat.Ino, nil
 }
 
-// FindFileInProc Traverse /proc/<pid>/<suffix> files,
+// ResolvePodNsByInode Traverse /proc/<pid>/<suffix> files,
 // compare their inodes with inode parameter and returns file if inode matches
-// use FindProcInode(xxx, "/ns/net") for example
-func FindFileInProc(inode uint64, suffix string) (string, error) {
+func ResolvePodNsByInode(inode uint64) (string, error) {
 	files, err := ioutil.ReadDir("/proc")
 	if err != nil {
 		return "", fmt.Errorf("can't read /proc directory: %+v", err)
@@ -45,7 +44,7 @@ func FindFileInProc(inode uint64, suffix string) (string, error) {
 	for _, f := range files {
 		name := f.Name()
 		if isDigits(name) {
-			filename := "/proc/" + name + suffix
+			filename := path.Join("/proc", name, "/ns/net")
 			tryInode, err := GetInode(filename)
 			if err != nil {
 				// Just report into log, do not exit


### PR DESCRIPTION
Signed-off-by: Ilya Lobkov <lobkovilya@yandex.ru>

Dataplane chose the first netns by inode that it finds in /proc directory. But sometimes it can be init-container's netns, so vppagent can't resolve it later. Now it checks that netns located in pause-container process directory.

## Motivation and Context
[Issue #725](https://github.com/networkservicemesh/networkservicemesh/issues/725)

## How Has This Been Tested?
- [X] Covered by existing integration testing
- [ ] Added integration testing to cover
- [ ] Tested locally
- [ ] Have not tested

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
