### PR TITLE
tests integration: improve testing infrastructure and disable failing tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ jobs:
           path: ~/junit
 
     environment:
-      GO111MODULE: 'on'
+      GO111MODULE: "on"
 
   build:
     working_directory: /go/src/github.com/networkservicemesh/networkservicemesh
@@ -65,7 +65,6 @@ jobs:
                 --data build_parameters[CIRCLE_WORKFLOW_ID]=${CIRCLE_WORKFLOW_ID} \
                 --data revision=$CIRCLE_SHA1 \
                 https://circleci.com/api/v1.1/project/github/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME/tree/$CIRCLE_BRANCH
-
 
   packet-deploy:
     docker:
@@ -124,12 +123,12 @@ jobs:
             echo "Downloading go deps"
             go mod download
             echo "Running integration tests"
-            gotestsum --junitfile ~/junit/integration-tests.xml -f standard-verbose ./test/... -timeout 20m
+            gotestsum --junitfile ~/junit/integration-tests.xml -f standard-verbose ./test/... -timeout 30m -failfast
             echo "Finish running integration tests"
-          no_output_timeout: 30m
+          no_output_timeout: 40m
           environment:
             KUBECONFIG: /home/circleci/project/data/kubeconfig
-            GO111MODULE: 'on'
+            GO111MODULE: "on"
       - store_test_results:
           path: ~/junit
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,7 +119,7 @@ jobs:
             ./scripts/prepare-circle-integration-tests.sh
             export COMMIT="${CIRCLE_SHA1:8:8}"
             export CONTAINER_TAG="${COMMIT}"
-            export CONTAINER_FORCE_PULL="true"
+            # export CONTAINER_FORCE_PULL="true"
             mkdir -p ~/junit/
             echo "Downloading go deps"
             go mod download

--- a/.integration.mk
+++ b/.integration.mk
@@ -19,8 +19,8 @@ k8s-integration-config:
 
 .PHONY: k8s-integration-tests
 k8s-integration-tests: k8s-integration-config
-	@GO111MODULE=on go test -v ./test/... -failfast
+	@GO111MODULE=on BROKEN_TESTS_ENABLED=on go test -v ./test/... -failfast
 
 .PHONY: k8s-integration-%-test
 k8s-integration-%-test: k8s-integration-config
-	@GO111MODULE=on go test -v ./test/... -failfast -run $*
+	@GO111MODULE=on BROKEN_TESTS_ENABLED=on go test -v ./test/... -failfast -run $*

--- a/.integration.mk
+++ b/.integration.mk
@@ -19,7 +19,7 @@ k8s-integration-config:
 
 .PHONY: k8s-integration-tests
 k8s-integration-tests: k8s-integration-config
-	@GO111MODULE=on BROKEN_TESTS_ENABLED=on go test -v ./test/... -failfast
+	@GO111MODULE=on go test -v ./test/... -failfast
 
 .PHONY: k8s-integration-%-test
 k8s-integration-%-test: k8s-integration-config

--- a/.integration.mk
+++ b/.integration.mk
@@ -15,15 +15,7 @@
 
 .PHONY: k8s-integration-config
 k8s-integration-config:
-	@kubectl label --overwrite --all=true nodes app=nsmd-ds
-	@kubectl apply -f k8s/conf/cluster-role-admin.yaml
-	@kubectl apply -f k8s/conf/cluster-role-binding.yaml
-	@kubectl apply -f k8s/conf/crd-networkservices.yaml
-	@kubectl apply -f k8s/conf/crd-networkserviceendpoints.yaml
-	@kubectl apply -f k8s/conf/crd-networkservicemanagers.yaml
-	@./scripts/webhook-create-cert.sh
-	@kubectl apply -f k8s/conf/admission-webhook.yaml
-	@cat ./k8s/conf/admission-webhook-cfg.yaml | ./scripts/webhook-patch-ca-bundle.sh | kubectl apply -f -
+	@./scripts/prepare-circle-integration-tests.sh
 
 .PHONY: k8s-integration-tests
 k8s-integration-tests: k8s-integration-config

--- a/.integration.mk
+++ b/.integration.mk
@@ -19,8 +19,8 @@ k8s-integration-config:
 
 .PHONY: k8s-integration-tests
 k8s-integration-tests: k8s-integration-config
-	@GO111MODULE=on go test -v ./test/...
+	@GO111MODULE=on go test -v ./test/... -failfast
 
 .PHONY: k8s-integration-%-test
 k8s-integration-%-test: k8s-integration-config
-	@GO111MODULE=on go test -v ./test/... -run $*
+	@GO111MODULE=on go test -v ./test/... -failfast -run $*

--- a/.integration.mk
+++ b/.integration.mk
@@ -19,7 +19,7 @@ k8s-integration-config:
 
 .PHONY: k8s-integration-tests
 k8s-integration-tests: k8s-integration-config
-	@GO111MODULE=on go test -v ./test/... -failfast
+	@GO111MODULE=on go test -v ./test/... -failfast -timeout 30m
 
 .PHONY: k8s-integration-%-test
 k8s-integration-%-test: k8s-integration-config

--- a/scripts/prepare-circle-integration-tests.sh
+++ b/scripts/prepare-circle-integration-tests.sh
@@ -17,11 +17,13 @@
 
 set -xe
 
-KUBECTL_VERSION=v1.11.3
+KUBECTL_VERSION=v1.13.3
 
 # Install kubectl
-curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/"${KUBECTL_VERSION}"/bin/linux/amd64/kubectl && \
- 	chmod +x "kubectl" && sudo mv "kubectl" /usr/local/bin/
+if ! command -v kubectl > /dev/null 2>&1; then
+	curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/"${KUBECTL_VERSION}"/bin/linux/amd64/kubectl && \
+		chmod +x "kubectl" && sudo mv "kubectl" /usr/local/bin/
+fi
 
 kubectl get nodes -o wide
 kubectl version

--- a/scripts/run_integration_tests.sh
+++ b/scripts/run_integration_tests.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+# Copyright 2019 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+all_tests=${1:-$(GO111MODULE=on go test ./test/... -list Test | grep Test | xargs)}
+
+for t in $all_tests
+do
+    GO111MODULE=on go test -v ./test/... -timeout 5m -run "$t"
+done

--- a/test/integration/const.go
+++ b/test/integration/const.go
@@ -1,0 +1,9 @@
+package nsmd_integration_tests
+
+import "time"
+
+const (
+	ciDelayCoefficient = 1
+	defaultTimeout     = 60 * time.Second * ciDelayCoefficient
+	fastTimeout        = defaultTimeout / 5
+)

--- a/test/integration/death_handling_test.go
+++ b/test/integration/death_handling_test.go
@@ -1,14 +1,15 @@
 package nsmd_integration_tests
 
 import (
+	"strings"
+	"testing"
+	"time"
+
 	"github.com/networkservicemesh/networkservicemesh/test/integration/nsmd_test_utils"
 	"github.com/networkservicemesh/networkservicemesh/test/kube_testing"
 	. "github.com/onsi/gomega"
 	"github.com/sirupsen/logrus"
-	"k8s.io/api/core/v1"
-	"strings"
-	"testing"
-	"time"
+	v1 "k8s.io/api/core/v1"
 )
 
 func TestNscDiesSingleNode(t *testing.T) {
@@ -64,10 +65,10 @@ func testDie(t *testing.T, killSrc bool, nodesCount int) {
 	k8s.Prepare("nsmd", "nsc", "nsmd-dataplane", "icmp-responder-nse")
 	logrus.Printf("Cleanup done: %v", time.Since(s1))
 
-	nodes := nsmd_test_utils.SetupNodes(k8s, nodesCount)
+	nodes := nsmd_test_utils.SetupNodes(k8s, nodesCount, defaultTimeout)
 
-	icmp := nsmd_test_utils.DeployIcmp(k8s, nodes[nodesCount-1].Node, "icmp-responder-nse1")
-	nsc := nsmd_test_utils.DeployNsc(k8s, nodes[0].Node, "nsc1")
+	icmp := nsmd_test_utils.DeployIcmp(k8s, nodes[nodesCount-1].Node, "icmp-responder-nse1", defaultTimeout)
+	nsc := nsmd_test_utils.DeployNsc(k8s, nodes[0].Node, "nsc1", defaultTimeout)
 
 	failures := InterceptGomegaFailures(func() {
 		ipResponse, errOut, err := k8s.Exec(nsc, nsc.Spec.Containers[0].Name, "ip", "addr")

--- a/test/integration/monitor_crossconnect_test.go
+++ b/test/integration/monitor_crossconnect_test.go
@@ -33,9 +33,9 @@ func TestSingleCrossConnect(t *testing.T) {
 
 	nodesCount := 2
 
-	nodes := nsmd_test_utils.SetupNodes(k8s, nodesCount)
-	nsmd_test_utils.DeployIcmp(k8s, nodes[nodesCount-1].Node, "icmp-responder-nse1")
-	nsmd_test_utils.DeployNsc(k8s, nodes[0].Node, "nsc1")
+	nodes := nsmd_test_utils.SetupNodes(k8s, nodesCount, defaultTimeout)
+	nsmd_test_utils.DeployIcmp(k8s, nodes[nodesCount-1].Node, "icmp-responder-nse1", defaultTimeout)
+	nsmd_test_utils.DeployNsc(k8s, nodes[0].Node, "nsc1", defaultTimeout)
 
 	fwd, err := k8s.NewPortForwarder(nodes[0].Nsmd, 5001)
 	Expect(err).To(BeNil())
@@ -56,9 +56,9 @@ func TestSingleCrossConnect(t *testing.T) {
 	nsmdMonitor2, close2, cancel2 := createCrossConnectClient(fmt.Sprintf("localhost:%d", fwd2.ListenPort))
 	defer close2()
 
-	_, err = getCrossConnectsFromMonitor(nsmdMonitor1, cancel1, 1, 50*time.Second)
+	_, err = getCrossConnectsFromMonitor(nsmdMonitor1, cancel1, 1, fastTimeout)
 	Expect(err).To(BeNil())
-	_, err = getCrossConnectsFromMonitor(nsmdMonitor2, cancel2, 1, 50*time.Second)
+	_, err = getCrossConnectsFromMonitor(nsmdMonitor2, cancel2, 1, fastTimeout)
 	Expect(err).To(BeNil())
 }
 
@@ -80,7 +80,7 @@ func TestSingleCrossConnectMonitorBeforeXcons(t *testing.T) {
 
 	nodesCount := 2
 
-	nodes := nsmd_test_utils.SetupNodes(k8s, nodesCount)
+	nodes := nsmd_test_utils.SetupNodes(k8s, nodesCount, defaultTimeout)
 
 	fwd, err := k8s.NewPortForwarder(nodes[0].Nsmd, 5001)
 	Expect(err).To(BeNil())
@@ -101,12 +101,12 @@ func TestSingleCrossConnectMonitorBeforeXcons(t *testing.T) {
 	nsmdMonitor2, close2, cancel2 := createCrossConnectClient(fmt.Sprintf("localhost:%d", fwd2.ListenPort))
 	defer close2()
 
-	nsmd_test_utils.DeployIcmp(k8s, nodes[nodesCount-1].Node, "icmp-responder-nse1")
-	nsmd_test_utils.DeployNsc(k8s, nodes[0].Node, "nsc1")
+	nsmd_test_utils.DeployIcmp(k8s, nodes[nodesCount-1].Node, "icmp-responder-nse1", defaultTimeout)
+	nsmd_test_utils.DeployNsc(k8s, nodes[0].Node, "nsc1", defaultTimeout)
 
-	_, err = getCrossConnectsFromMonitor(nsmdMonitor1, cancel1, 1, 50*time.Second)
+	_, err = getCrossConnectsFromMonitor(nsmdMonitor1, cancel1, 1, fastTimeout)
 	Expect(err).To(BeNil())
-	_, err = getCrossConnectsFromMonitor(nsmdMonitor2, cancel2, 1, 50*time.Second)
+	_, err = getCrossConnectsFromMonitor(nsmdMonitor2, cancel2, 1, fastTimeout)
 	Expect(err).To(BeNil())
 }
 
@@ -128,10 +128,10 @@ func TestSeveralCrossConnects(t *testing.T) {
 
 	nodesCount := 2
 
-	nodes := nsmd_test_utils.SetupNodes(k8s, nodesCount)
-	nsmd_test_utils.DeployIcmp(k8s, nodes[nodesCount-1].Node,"icmp-responder-nse1")
-	nsmd_test_utils.DeployNsc(k8s, nodes[0].Node, "nsc1")
-	nsmd_test_utils.DeployNsc(k8s, nodes[0].Node, "nsc2")
+	nodes := nsmd_test_utils.SetupNodes(k8s, nodesCount, defaultTimeout)
+	nsmd_test_utils.DeployIcmp(k8s, nodes[nodesCount-1].Node, "icmp-responder-nse1", defaultTimeout)
+	nsmd_test_utils.DeployNsc(k8s, nodes[0].Node, "nsc1", defaultTimeout)
+	nsmd_test_utils.DeployNsc(k8s, nodes[0].Node, "nsc2", defaultTimeout)
 
 	fwd, err := k8s.NewPortForwarder(nodes[0].Nsmd, 5001)
 	Expect(err).To(BeNil())
@@ -153,9 +153,9 @@ func TestSeveralCrossConnects(t *testing.T) {
 	nsmdMonitor2, close2, cancel2 := createCrossConnectClient(fmt.Sprintf("localhost:%d", fwd2.ListenPort))
 	defer close2()
 
-	_, err = getCrossConnectsFromMonitor(nsmdMonitor1, cancel1, 2, 5*time.Second)
+	_, err = getCrossConnectsFromMonitor(nsmdMonitor1, cancel1, 2, fastTimeout)
 	Expect(err).To(BeNil())
-	_, err = getCrossConnectsFromMonitor(nsmdMonitor2, cancel2, 2, 5*time.Second)
+	_, err = getCrossConnectsFromMonitor(nsmdMonitor2, cancel2, 2, fastTimeout)
 	Expect(err).To(BeNil())
 }
 func TestCrossConnectMonitorRestart(t *testing.T) {
@@ -176,10 +176,10 @@ func TestCrossConnectMonitorRestart(t *testing.T) {
 
 	nodesCount := 2
 
-	nodes := nsmd_test_utils.SetupNodes(k8s, nodesCount)
-	nsmd_test_utils.DeployIcmp(k8s, nodes[nodesCount-1].Node, "icmp-responder-nse1")
-	nsmd_test_utils.DeployNsc(k8s, nodes[0].Node, "nsc1")
-	nsmd_test_utils.DeployNsc(k8s, nodes[0].Node, "nsc2")
+	nodes := nsmd_test_utils.SetupNodes(k8s, nodesCount, defaultTimeout)
+	nsmd_test_utils.DeployIcmp(k8s, nodes[nodesCount-1].Node, "icmp-responder-nse1", defaultTimeout)
+	nsmd_test_utils.DeployNsc(k8s, nodes[0].Node, "nsc1", defaultTimeout)
+	nsmd_test_utils.DeployNsc(k8s, nodes[0].Node, "nsc2", defaultTimeout)
 
 	fwd, err := k8s.NewPortForwarder(nodes[0].Nsmd, 5001)
 	Expect(err).To(BeNil())
@@ -189,14 +189,14 @@ func TestCrossConnectMonitorRestart(t *testing.T) {
 	Expect(err).To(BeNil())
 
 	nsmdMonitor, closeFunc, cancel := createCrossConnectClient(fmt.Sprintf("localhost:%d", fwd.ListenPort))
-	_, err = getCrossConnectsFromMonitor(nsmdMonitor, cancel, 2, 5*time.Second)
+	_, err = getCrossConnectsFromMonitor(nsmdMonitor, cancel, 2, fastTimeout)
 	Expect(err).To(BeNil())
 	closeFunc()
 
 	logrus.Info("Restarting monitor")
 	nsmdMonitor, closeFunc, cancel = createCrossConnectClient(fmt.Sprintf("localhost:%d", fwd.ListenPort))
 	defer closeFunc()
-	_, err = getCrossConnectsFromMonitor(nsmdMonitor, cancel, 2, 5*time.Second)
+	_, err = getCrossConnectsFromMonitor(nsmdMonitor, cancel, 2, fastTimeout)
 	Expect(err).To(BeNil())
 }
 

--- a/test/integration/nsc_deploy_test.go
+++ b/test/integration/nsc_deploy_test.go
@@ -1,10 +1,10 @@
 package nsmd_integration_tests
 
 import (
+	"testing"
+
 	"github.com/networkservicemesh/networkservicemesh/test/kube_testing"
 	"github.com/networkservicemesh/networkservicemesh/test/kube_testing/pods"
-	"testing"
-	"time"
 
 	. "github.com/onsi/gomega"
 	"github.com/sirupsen/logrus"
@@ -26,7 +26,7 @@ func TestDeployPodIntoInvalidEnv(t *testing.T) {
 	Expect(err).To(BeNil())
 
 	k8s.Prepare("nsmd", "nsc") // Be sure where is no NSMD
-	nodes := k8s.GetNodesWait(1, time.Second*60)
+	nodes := k8s.GetNodesWait(1, defaultTimeout)
 
 	if len(nodes) < 1 {
 		logrus.Printf("At least two kubernetes nodes are required for this test")
@@ -34,7 +34,7 @@ func TestDeployPodIntoInvalidEnv(t *testing.T) {
 		return
 	}
 
-	nsmdPodNode1, err := k8s.CreatePodsRaw(10*time.Second, false, pods.NSCPod("nsc1", &nodes[0], map[string]string{}))
+	nsmdPodNode1, err := k8s.CreatePodsRaw(fastTimeout, false, pods.NSCPod("nsc1", &nodes[0], map[string]string{}))
 	Expect(len(nsmdPodNode1)).To(Equal(1))
 
 	k8s.DeletePods(nsmdPodNode1...)

--- a/test/integration/nsc_icmp_configuration_test.go
+++ b/test/integration/nsc_icmp_configuration_test.go
@@ -44,7 +44,20 @@ func TestNSCAndICMPRemote(t *testing.T) {
 	testNSCAndICMP(t, 2, createNscPod)
 }
 
-func TestNSCAndICMPWebhook(t *testing.T) {
+func TestNSCAndICMPWebhookLocal(t *testing.T) {
+	RegisterTestingT(t)
+
+	if testing.Short() {
+		t.Skip("Skip, please run without -short")
+		return
+	}
+
+	testNSCAndICMP(t, 1, func(node *v1.Node) *v1.Pod {
+		return pods.NSCPodWebhook("nsc1", node)
+	})
+}
+
+func TestNSCAndICMPWebhookRemote(t *testing.T) {
 	RegisterTestingT(t)
 
 	if testing.Short() {

--- a/test/integration/nsc_icmp_configuration_test.go
+++ b/test/integration/nsc_icmp_configuration_test.go
@@ -5,12 +5,11 @@ import (
 	"time"
 
 	"github.com/networkservicemesh/networkservicemesh/test/integration/nsmd_test_utils"
-	"github.com/networkservicemesh/networkservicemesh/test/kube_testing/pods"
-	v1 "k8s.io/api/core/v1"
-
 	"github.com/networkservicemesh/networkservicemesh/test/kube_testing"
+	"github.com/networkservicemesh/networkservicemesh/test/kube_testing/pods"
 	. "github.com/onsi/gomega"
 	"github.com/sirupsen/logrus"
+	v1 "k8s.io/api/core/v1"
 )
 
 func createNscPod(node *v1.Node) *v1.Pod {
@@ -47,6 +46,10 @@ func TestNSCAndICMPRemote(t *testing.T) {
 func TestNSCAndICMPWebhookLocal(t *testing.T) {
 	RegisterTestingT(t)
 
+	if !nsmd_test_utils.IsBrokeTestsEnabled() {
+		t.Skip("Marked as broken.")
+	}
+
 	if testing.Short() {
 		t.Skip("Skip, please run without -short")
 		return
@@ -59,6 +62,10 @@ func TestNSCAndICMPWebhookLocal(t *testing.T) {
 
 func TestNSCAndICMPWebhookRemote(t *testing.T) {
 	RegisterTestingT(t)
+
+	if !nsmd_test_utils.IsBrokeTestsEnabled() {
+		t.Skip("Marked as broken.")
+	}
 
 	if testing.Short() {
 		t.Skip("Skip, please run without -short")

--- a/test/integration/nsc_icmp_configuration_test.go
+++ b/test/integration/nsc_icmp_configuration_test.go
@@ -1,18 +1,17 @@
 package nsmd_integration_tests
 
 import (
-	"github.com/networkservicemesh/networkservicemesh/test/integration/nsmd_test_utils"
-	"github.com/networkservicemesh/networkservicemesh/test/kube_testing/pods"
-	"k8s.io/api/core/v1"
 	"testing"
 	"time"
+
+	"github.com/networkservicemesh/networkservicemesh/test/integration/nsmd_test_utils"
+	"github.com/networkservicemesh/networkservicemesh/test/kube_testing/pods"
+	v1 "k8s.io/api/core/v1"
 
 	"github.com/networkservicemesh/networkservicemesh/test/kube_testing"
 	. "github.com/onsi/gomega"
 	"github.com/sirupsen/logrus"
 )
-
-const defaultTimeout = 60 * time.Second
 
 func createNscPod(node *v1.Node) *v1.Pod {
 	return pods.NSCPod("nsc1", node,
@@ -71,12 +70,12 @@ func testNSCAndICMP(t *testing.T, nodesCount int, nscPodFactory func(*v1.Node) *
 	k8s.Prepare("nsmd", "nsc", "nsmd-dataplane", "icmp-responder-nse")
 	logrus.Printf("Cleanup done: %v", time.Since(s1))
 
-	nodes_setup := nsmd_test_utils.SetupNodes(k8s, nodesCount )
+	nodes_setup := nsmd_test_utils.SetupNodes(k8s, nodesCount, defaultTimeout)
 
 	// Run ICMP on latest node
-	_ = nsmd_test_utils.DeployIcmp(k8s, nodes_setup[nodesCount-1].Node, "icmp-responder-nse1")
+	_ = nsmd_test_utils.DeployIcmp(k8s, nodes_setup[nodesCount-1].Node, "icmp-responder-nse1", defaultTimeout)
 
-	nscPodNode := nsmd_test_utils.DeployNsc(k8s, nodes_setup[0].Node, "nsc1")
+	nscPodNode := nsmd_test_utils.DeployNsc(k8s, nodes_setup[0].Node, "nsc1", defaultTimeout)
 
 	var nscInfo *nsmd_test_utils.NSCCheckInfo
 
@@ -86,7 +85,7 @@ func testNSCAndICMP(t *testing.T, nodesCount int, nscPodFactory func(*v1.Node) *
 	// Do dumping of container state to dig into what is happened.
 	if len(failures) > 0 {
 		logrus.Errorf("Failues: %v", failures)
-		nsmd_test_utils.PrintLogs(k8s, nodes_setup);
+		nsmd_test_utils.PrintLogs(k8s, nodes_setup)
 		nscInfo.PrintLogs()
 
 		t.Fail()

--- a/test/integration/nsc_icmp_configuration_test.go
+++ b/test/integration/nsc_icmp_configuration_test.go
@@ -46,10 +46,6 @@ func TestNSCAndICMPRemote(t *testing.T) {
 func TestNSCAndICMPWebhookLocal(t *testing.T) {
 	RegisterTestingT(t)
 
-	if !nsmd_test_utils.IsBrokeTestsEnabled() {
-		t.Skip("Marked as broken.")
-	}
-
 	if testing.Short() {
 		t.Skip("Skip, please run without -short")
 		return
@@ -62,10 +58,6 @@ func TestNSCAndICMPWebhookLocal(t *testing.T) {
 
 func TestNSCAndICMPWebhookRemote(t *testing.T) {
 	RegisterTestingT(t)
-
-	if !nsmd_test_utils.IsBrokeTestsEnabled() {
-		t.Skip("Marked as broken.")
-	}
 
 	if testing.Short() {
 		t.Skip("Skip, please run without -short")

--- a/test/integration/nse_dataplane_heal_test.go
+++ b/test/integration/nse_dataplane_heal_test.go
@@ -66,7 +66,7 @@ func testDataplaneHeal(t *testing.T, nodesCount int) {
 	k8s.DeletePods(nodes_setup[nodesCount-1].Dataplane)
 
 	logrus.Infof("Wait NSMD is waiting for dataplane recovery")
-	k8s.WaitLogsContains(nodes_setup[nodesCount-1].Nsmd, "nsmd", "Waiting for Dataplane to recovery...", 60*time.Second)
+	k8s.WaitLogsContains(nodes_setup[nodesCount-1].Nsmd, "nsmd", "Waiting for Dataplane to recovery...", defaultTimeout)
 	// Now are are in dataplane dead state, and in Heal procedure waiting for dataplane.
 	dpName := fmt.Sprintf("nsmd-dataplane-recovered-%d", nodesCount-1)
 
@@ -79,10 +79,10 @@ func testDataplaneHeal(t *testing.T, nodesCount int) {
 
 	logrus.Infof("Waiting for connection recovery...")
 	if nodesCount > 1 {
-		k8s.WaitLogsContains(nodes_setup[nodesCount-1].Nsmd, "nsmd", "Healing will be continued on source side...", 60*time.Second)
-		k8s.WaitLogsContains(nodes_setup[0].Nsmd, "nsmd", "Heal: Connection recovered:", 60*time.Second)
+		k8s.WaitLogsContains(nodes_setup[nodesCount-1].Nsmd, "nsmd", "Healing will be continued on source side...", defaultTimeout)
+		k8s.WaitLogsContains(nodes_setup[0].Nsmd, "nsmd", "Heal: Connection recovered:", defaultTimeout)
 	} else {
-		k8s.WaitLogsContains(nodes_setup[nodesCount-1].Nsmd, "nsmd", "Heal: Connection recovered:", 60*time.Second)
+		k8s.WaitLogsContains(nodes_setup[nodesCount-1].Nsmd, "nsmd", "Heal: Connection recovered:", defaultTimeout)
 	}
 	logrus.Infof("Waiting for connection recovery Done...")
 

--- a/test/integration/nse_dataplane_heal_test.go
+++ b/test/integration/nse_dataplane_heal_test.go
@@ -2,10 +2,11 @@ package nsmd_integration_tests
 
 import (
 	"fmt"
-	"github.com/networkservicemesh/networkservicemesh/test/integration/nsmd_test_utils"
-	"github.com/networkservicemesh/networkservicemesh/test/kube_testing/pods"
 	"testing"
 	"time"
+
+	"github.com/networkservicemesh/networkservicemesh/test/integration/nsmd_test_utils"
+	"github.com/networkservicemesh/networkservicemesh/test/kube_testing/pods"
 
 	"github.com/networkservicemesh/networkservicemesh/test/kube_testing"
 	. "github.com/onsi/gomega"
@@ -48,12 +49,12 @@ func testDataplaneHeal(t *testing.T, nodesCount int) {
 	logrus.Printf("Cleanup done: %v", time.Since(s1))
 
 	// Deploy open tracing to see what happening.
-	nodes_setup := nsmd_test_utils.SetupNodes(k8s, nodesCount )
+	nodes_setup := nsmd_test_utils.SetupNodes(k8s, nodesCount, defaultTimeout)
 
 	// Run ICMP on latest node
-	_ = nsmd_test_utils.DeployIcmp(k8s, nodes_setup[nodesCount-1].Node, "icmp-responder-nse1")
+	_ = nsmd_test_utils.DeployIcmp(k8s, nodes_setup[nodesCount-1].Node, "icmp-responder-nse1", defaultTimeout)
 
-	nscPodNode := nsmd_test_utils.DeployNsc(k8s, nodes_setup[0].Node, "nsc1")
+	nscPodNode := nsmd_test_utils.DeployNsc(k8s, nodes_setup[0].Node, "nsc1", defaultTimeout)
 	var nscInfo *nsmd_test_utils.NSCCheckInfo
 	failures := InterceptGomegaFailures(func() {
 		nscInfo = nsmd_test_utils.CheckNSC(k8s, t, nscPodNode)

--- a/test/integration/nse_heal_test.go
+++ b/test/integration/nse_heal_test.go
@@ -69,7 +69,7 @@ func testNSEHeal(t *testing.T, nodesCount int) {
 
 	logrus.Infof("Waiting for connection recovery...")
 	failures = InterceptGomegaFailures(func() {
-		k8s.WaitLogsContains(nodes_setup[0].Nsmd, "nsmd", "Heal: Connection recovered:", 60*time.Second)
+		k8s.WaitLogsContains(nodes_setup[0].Nsmd, "nsmd", "Heal: Connection recovered:", defaultTimeout)
 	})
 	if len(failures) > 0 {
 		printErrors(failures, k8s, nodes_setup, nscInfo, t)

--- a/test/integration/nse_heal_test.go
+++ b/test/integration/nse_heal_test.go
@@ -1,10 +1,11 @@
 package nsmd_integration_tests
 
 import (
-	"github.com/networkservicemesh/networkservicemesh/test/integration/nsmd_test_utils"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/networkservicemesh/networkservicemesh/test/integration/nsmd_test_utils"
 
 	"github.com/networkservicemesh/networkservicemesh/test/kube_testing"
 	. "github.com/onsi/gomega"
@@ -47,12 +48,12 @@ func testNSEHeal(t *testing.T, nodesCount int) {
 	logrus.Printf("Cleanup done: %v", time.Since(s1))
 
 	// Deploy open tracing to see what happening.
-	nodes_setup := nsmd_test_utils.SetupNodes(k8s, nodesCount )
+	nodes_setup := nsmd_test_utils.SetupNodes(k8s, nodesCount, defaultTimeout)
 
 	// Run ICMP on latest node
-	nse1 := nsmd_test_utils.DeployIcmp(k8s, nodes_setup[nodesCount-1].Node, "icmp-responder-nse1")
+	nse1 := nsmd_test_utils.DeployIcmp(k8s, nodes_setup[nodesCount-1].Node, "icmp-responder-nse1", defaultTimeout)
 
-	nscPodNode := nsmd_test_utils.DeployNsc(k8s, nodes_setup[0].Node, "nsc1")
+	nscPodNode := nsmd_test_utils.DeployNsc(k8s, nodes_setup[0].Node, "nsc1", defaultTimeout)
 	var nscInfo *nsmd_test_utils.NSCCheckInfo
 	failures := InterceptGomegaFailures(func() {
 		nscInfo = nsmd_test_utils.CheckNSC(k8s, t, nscPodNode)
@@ -61,7 +62,7 @@ func testNSEHeal(t *testing.T, nodesCount int) {
 	printErrors(failures, k8s, nodes_setup, nscInfo, t)
 
 	// Since all is fine now, we need to add new ICMP responder and delete previous one.
-	_ = nsmd_test_utils.DeployIcmp(k8s, nodes_setup[nodesCount-1].Node, "icmp-responder-nse2")
+	_ = nsmd_test_utils.DeployIcmp(k8s, nodes_setup[nodesCount-1].Node, "icmp-responder-nse2", defaultTimeout)
 
 	logrus.Infof("Delete first NSE")
 	k8s.DeletePods(nse1)
@@ -91,7 +92,7 @@ func testNSEHeal(t *testing.T, nodesCount int) {
 func printErrors(failures []string, k8s *kube_testing.K8s, nodes_setup []*nsmd_test_utils.NodeConf, nscInfo *nsmd_test_utils.NSCCheckInfo, t *testing.T) {
 	if len(failures) > 0 {
 		logrus.Errorf("Failures: %v", failures)
-		nsmd_test_utils.PrintLogs(k8s, nodes_setup);
+		nsmd_test_utils.PrintLogs(k8s, nodes_setup)
 		nscInfo.PrintLogs()
 
 		t.Fail()

--- a/test/integration/nsmd_deploy_test.go
+++ b/test/integration/nsmd_deploy_test.go
@@ -1,11 +1,11 @@
 package nsmd_integration_tests
 
 import (
-	"github.com/networkservicemesh/networkservicemesh/test/kube_testing"
-	"github.com/networkservicemesh/networkservicemesh/test/kube_testing/pods"
 	"strings"
 	"testing"
-	"time"
+
+	"github.com/networkservicemesh/networkservicemesh/test/kube_testing"
+	"github.com/networkservicemesh/networkservicemesh/test/kube_testing/pods"
 
 	. "github.com/onsi/gomega"
 	"github.com/sirupsen/logrus"
@@ -28,7 +28,7 @@ func TestNSMDDdataplabeDeploy(t *testing.T) {
 	Expect(err).To(BeNil())
 
 	k8s.Prepare("nsmd")
-	nodes := k8s.GetNodesWait(2, time.Second*60)
+	nodes := k8s.GetNodesWait(2, defaultTimeout)
 
 	if len(nodes) < 2 {
 		logrus.Printf("At least two kubernetes nodes are required for this test")

--- a/test/integration/nsmd_k8s_test.go
+++ b/test/integration/nsmd_k8s_test.go
@@ -37,7 +37,7 @@ func TestNSMDDRegistryNSE(t *testing.T) {
 
 	// We need to wait unti it is started
 
-	k8s.WaitLogsContains(nsmd, "nsmd-k8s", "Registering networkservicemanagers.networkservicemesh.io", fastTimeout)
+	k8s.WaitLogsContains(nsmd, "nsmd-k8s", "nsmd-k8s intialized and waiting for connection", fastTimeout)
 	logs, err := k8s.GetLogs(nsmd, "nsmd-k8s")
 	logrus.Printf("%s", logs)
 

--- a/test/integration/nsmd_k8s_test.go
+++ b/test/integration/nsmd_k8s_test.go
@@ -37,7 +37,7 @@ func TestNSMDDRegistryNSE(t *testing.T) {
 
 	// We need to wait unti it is started
 
-	k8s.WaitLogsContains(nsmd, "nsmd-k8s", "Registering networkservicemanagers.networkservicemesh.io", 10*time.Second)
+	k8s.WaitLogsContains(nsmd, "nsmd-k8s", "Registering networkservicemanagers.networkservicemesh.io", fastTimeout)
 	logs, err := k8s.GetLogs(nsmd, "nsmd-k8s")
 	logrus.Printf("%s", logs)
 

--- a/test/integration/nsmd_test_utils/test_utils.go
+++ b/test/integration/nsmd_test_utils/test_utils.go
@@ -2,6 +2,7 @@ package nsmd_test_utils
 
 import (
 	"fmt"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -153,4 +154,9 @@ func CheckNSC(k8s *kube_testing.K8s, t *testing.T, nscPodNode *v1.Pod) *NSCCheck
 	Expect(strings.Contains(info.pingResponse, "5 packets transmitted, 5 packets received, 0% packet loss")).To(Equal(true))
 	logrus.Printf("NSC Ping is success:%s", info.pingResponse)
 	return info
+}
+
+func IsBrokeTestsEnabled() bool {
+	_, ok := os.LookupEnv("BROKEN_TESTS_ENABLED")
+	return ok
 }

--- a/test/integration/vpn_test.go
+++ b/test/integration/vpn_test.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	nsapiv1 "github.com/networkservicemesh/networkservicemesh/k8s/pkg/apis/networkservice/v1"
-	"github.com/networkservicemesh/networkservicemesh/test/integration/nsmd_test_utils"
 	"github.com/networkservicemesh/networkservicemesh/test/kube_testing"
 	"github.com/networkservicemesh/networkservicemesh/test/kube_testing/crds"
 	"github.com/networkservicemesh/networkservicemesh/test/kube_testing/pods"
@@ -34,10 +33,6 @@ func TestVPNLocal(t *testing.T) {
 func TestVPNFirewallRemote(t *testing.T) {
 	RegisterTestingT(t)
 
-	if !nsmd_test_utils.IsBrokeTestsEnabled() {
-		t.Skip("Marked as broken.")
-	}
-
 	if testing.Short() {
 		t.Skip("Skip, please run without -short")
 		return
@@ -53,10 +48,6 @@ func TestVPNFirewallRemote(t *testing.T) {
 func TestVPNNSERemote(t *testing.T) {
 	RegisterTestingT(t)
 
-	if !nsmd_test_utils.IsBrokeTestsEnabled() {
-		t.Skip("Marked as broken.")
-	}
-
 	if testing.Short() {
 		t.Skip("Skip, please run without -short")
 		return
@@ -71,10 +62,6 @@ func TestVPNNSERemote(t *testing.T) {
 
 func TestVPNNSCRemote(t *testing.T) {
 	RegisterTestingT(t)
-
-	if !nsmd_test_utils.IsBrokeTestsEnabled() {
-		t.Skip("Marked as broken.")
-	}
 
 	if testing.Short() {
 		t.Skip("Skip, please run without -short")

--- a/test/integration/vpn_test.go
+++ b/test/integration/vpn_test.go
@@ -104,7 +104,7 @@ func testVPN(t *testing.T, nodesCount int, affinity map[string]int, verbose bool
 	s1 := time.Now()
 	k8s.Prepare("nsmd", "nsmd-dataplane", "vppagent-firewall-nse", "vpn-gateway-nse", "vpn-gateway-nsc")
 	logrus.Printf("Cleanup done: %v", time.Since(s1))
-	nodes := k8s.GetNodesWait(nodesCount, time.Second*60)
+	nodes := k8s.GetNodesWait(nodesCount, defaultTimeout)
 	if len(nodes) < nodesCount {
 		logrus.Printf("At least one kubernetes node are required for this test")
 		Expect(len(nodes)).To(Equal(nodesCount))
@@ -159,7 +159,7 @@ func testVPN(t *testing.T, nodesCount int, affinity map[string]int, verbose bool
 	))
 	Expect(vppagentFirewallNode.Name).To(Equal("vppagent-firewall-nse1"))
 
-	k8s.WaitLogsContains(vppagentFirewallNode, "", "NSE: channel has been successfully advertised, waiting for connection from NSM...", time.Second)
+	k8s.WaitLogsContains(vppagentFirewallNode, "", "NSE: channel has been successfully advertised, waiting for connection from NSM...", fastTimeout)
 
 	logrus.Printf("VPN Gateway started done: %v", time.Since(s1))
 
@@ -175,7 +175,7 @@ func testVPN(t *testing.T, nodesCount int, affinity map[string]int, verbose bool
 	))
 	Expect(vpnGatewayPodNode.Name).To(Equal("vpn-gateway-nse1"))
 
-	k8s.WaitLogsContains(vpnGatewayPodNode, "vpn-gateway", "NSE: channel has been successfully advertised, waiting for connection from NSM...", time.Second)
+	k8s.WaitLogsContains(vpnGatewayPodNode, "vpn-gateway", "NSE: channel has been successfully advertised, waiting for connection from NSM...", fastTimeout)
 
 	logrus.Printf("VPN Gateway started done: %v", time.Since(s1))
 

--- a/test/integration/vpn_test.go
+++ b/test/integration/vpn_test.go
@@ -2,12 +2,12 @@ package nsmd_integration_tests
 
 import (
 	"fmt"
-	"os"
 	"strings"
 	"testing"
 	"time"
 
 	nsapiv1 "github.com/networkservicemesh/networkservicemesh/k8s/pkg/apis/networkservice/v1"
+	"github.com/networkservicemesh/networkservicemesh/test/integration/nsmd_test_utils"
 	"github.com/networkservicemesh/networkservicemesh/test/kube_testing"
 	"github.com/networkservicemesh/networkservicemesh/test/kube_testing/crds"
 	"github.com/networkservicemesh/networkservicemesh/test/kube_testing/pods"
@@ -34,8 +34,8 @@ func TestVPNLocal(t *testing.T) {
 func TestVPNFirewallRemote(t *testing.T) {
 	RegisterTestingT(t)
 
-	if !isVPNRemoteEnabled() {
-		t.Skip("VPN_REMOTE_ENABLED not defined.")
+	if !nsmd_test_utils.IsBrokeTestsEnabled() {
+		t.Skip("Marked as broken.")
 	}
 
 	if testing.Short() {
@@ -53,8 +53,8 @@ func TestVPNFirewallRemote(t *testing.T) {
 func TestVPNNSERemote(t *testing.T) {
 	RegisterTestingT(t)
 
-	if !isVPNRemoteEnabled() {
-		t.Skip("VPN_REMOTE_ENABLED not defined.")
+	if !nsmd_test_utils.IsBrokeTestsEnabled() {
+		t.Skip("Marked as broken.")
 	}
 
 	if testing.Short() {
@@ -72,8 +72,8 @@ func TestVPNNSERemote(t *testing.T) {
 func TestVPNNSCRemote(t *testing.T) {
 	RegisterTestingT(t)
 
-	if !isVPNRemoteEnabled() {
-		t.Skip("VPN_REMOTE_ENABLED not defined.")
+	if !nsmd_test_utils.IsBrokeTestsEnabled() {
+		t.Skip("Marked as broken.")
 	}
 
 	if testing.Short() {
@@ -86,11 +86,6 @@ func TestVPNNSCRemote(t *testing.T) {
 		"vpn-gateway-nse1":       0,
 		"vpn-gateway-nsc1":       1,
 	}, false)
-}
-
-func isVPNRemoteEnabled() bool {
-	_, ok := os.LookupEnv("VPN_REMOTE_ENABLED")
-	return ok
 }
 
 func testVPN(t *testing.T, nodesCount int, affinity map[string]int, verbose bool) {

--- a/test/kube_testing/k8s.go
+++ b/test/kube_testing/k8s.go
@@ -20,10 +20,10 @@ import (
 )
 
 const (
-	podStartTimeout  = 5 * time.Minute
-	podDeleteTimeout = 5 * time.Minute
-	podExecTimeout	 = 3 * time.Minute
-	podGetLogTimeout = 3 * time.Minute
+	podStartTimeout  = 1 * time.Minute
+	podDeleteTimeout = 1 * time.Minute
+	podExecTimeout   = 1 * time.Minute
+	podGetLogTimeout = 1 * time.Minute
 )
 
 type PodDeployResult struct {
@@ -86,7 +86,7 @@ func (l *K8s) createAndBlock(client kubernetes.Interface, config *rest.Config, n
 		}(pod)
 	}
 
-	if !waitTimeout(fmt.Sprintf("createAndBlock with pods: %v", pods ), &wg, timeout) {
+	if !waitTimeout(fmt.Sprintf("createAndBlock with pods: %v", pods), &wg, timeout) {
 		logrus.Errorf("Failed to deploy pod, trying to get any information")
 		results := []*PodDeployResult{}
 		for _, p := range pods {
@@ -144,7 +144,7 @@ func blockUntilPodReady(client kubernetes.Interface, timeout time.Duration, sour
 			break
 		}
 
-		if time.Since(st) > timeout / 2 {
+		if time.Since(st) > timeout/2 {
 			logrus.Infof("Pod deploy half time passed: %v", pod)
 		}
 
@@ -429,7 +429,7 @@ func (o *K8s) WaitLogsContains(pod *v1.Pod, container string, pattern string, ti
 			logrus.Printf("Error on get logs: %v retrying", error)
 		}
 		if !strings.Contains(logs, pattern) {
-			<- time.Tick(100 * time.Millisecond)
+			<-time.Tick(100 * time.Millisecond)
 		} else {
 			break
 		}

--- a/test/kube_testing/k8s.go
+++ b/test/kube_testing/k8s.go
@@ -307,20 +307,23 @@ func (o *K8s) ListPods() []v1.Pod {
 }
 
 func (o *K8s) CleanupCRDs() {
-	managers, err := o.versionedClientSet.Networkservicemesh().NetworkServiceManagers("default").List(metaV1.ListOptions{})
-	Expect(err).To(BeNil())
-	for _, mgr := range managers.Items {
-		_ = o.versionedClientSet.Networkservicemesh().NetworkServiceManagers("default").Delete(mgr.Name, &metaV1.DeleteOptions{})
+
+	// Clean up Network Services
+	services, _ := o.versionedClientSet.Networkservicemesh().NetworkServices("default").List(metaV1.ListOptions{})
+	for _, service := range services.Items {
+		_ = o.versionedClientSet.Networkservicemesh().NetworkServices("default").Delete(service.Name, &metaV1.DeleteOptions{})
 	}
-	endpoints, err := o.versionedClientSet.Networkservicemesh().NetworkServiceEndpoints("default").List(metaV1.ListOptions{})
-	Expect(err).To(BeNil())
+
+	// Clean up Network Service Endpoints
+	endpoints, _ := o.versionedClientSet.Networkservicemesh().NetworkServiceEndpoints("default").List(metaV1.ListOptions{})
 	for _, ep := range endpoints.Items {
 		_ = o.versionedClientSet.Networkservicemesh().NetworkServiceEndpoints("default").Delete(ep.Name, &metaV1.DeleteOptions{})
 	}
-	services, err := o.versionedClientSet.Networkservicemesh().NetworkServices("default").List(metaV1.ListOptions{})
-	Expect(err).To(BeNil())
-	for _, service := range services.Items {
-		_ = o.versionedClientSet.Networkservicemesh().NetworkServices("default").Delete(service.Name, &metaV1.DeleteOptions{})
+
+	// Clean up Network Service Managers
+	managers, _ := o.versionedClientSet.Networkservicemesh().NetworkServiceManagers("default").List(metaV1.ListOptions{})
+	for _, mgr := range managers.Items {
+		_ = o.versionedClientSet.Networkservicemesh().NetworkServiceManagers("default").Delete(mgr.Name, &metaV1.DeleteOptions{})
 	}
 }
 

--- a/test/kube_testing/pods/nsmd.go
+++ b/test/kube_testing/pods/nsmd.go
@@ -3,7 +3,6 @@ package pods
 import (
 	v1 "k8s.io/api/core/v1"
 	v12 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 func newNSMMount() v1.VolumeMount {
@@ -21,6 +20,14 @@ func newDevMount() v1.VolumeMount {
 }
 
 func NSMDPod(name string, node *v1.Node) *v1.Pod {
+	return createdNSMDPod(name, node, nil, nil)
+}
+
+func NSMDPodLiveCheck(name string, node *v1.Node) *v1.Pod {
+	return createdNSMDPod(name, node, createProbe("/liveness"), createProbe("/readines"))
+}
+
+func createdNSMDPod(name string, node *v1.Node, liveness, readiness *v1.Probe) *v1.Pod {
 	ht := new(v1.HostPathType)
 	*ht = v1.HostPathDirectoryOrCreate
 
@@ -70,30 +77,8 @@ func NSMDPod(name string, node *v1.Node) *v1.Pod {
 					Image:           "networkservicemesh/nsmd",
 					ImagePullPolicy: v1.PullIfNotPresent,
 					VolumeMounts:    []v1.VolumeMount{newNSMMount()},
-					LivenessProbe: &v1.Probe{
-						Handler: v1.Handler{
-							HTTPGet: &v1.HTTPGetAction{
-								Path:   "/liveness",
-								Port:   intstr.IntOrString{Type: 0, IntVal: 5555, StrVal: ""},
-								Scheme: "HTTP",
-							},
-						},
-						InitialDelaySeconds: 10,
-						PeriodSeconds:       10,
-						TimeoutSeconds:      3,
-					},
-					ReadinessProbe: &v1.Probe{
-						Handler: v1.Handler{
-							HTTPGet: &v1.HTTPGetAction{
-								Path:   "/readiness",
-								Port:   intstr.IntOrString{Type: 0, IntVal: 5555, StrVal: ""},
-								Scheme: "HTTP",
-							},
-						},
-						InitialDelaySeconds: 10,
-						PeriodSeconds:       10,
-						TimeoutSeconds:      3,
-					},
+					LivenessProbe:   liveness,
+					ReadinessProbe:  readiness,
 				}),
 				containerMod(&v1.Container{
 					Name:            "nsmd-k8s",

--- a/test/kube_testing/pods/nsmd.go
+++ b/test/kube_testing/pods/nsmd.go
@@ -24,7 +24,7 @@ func NSMDPod(name string, node *v1.Node) *v1.Pod {
 }
 
 func NSMDPodLiveCheck(name string, node *v1.Node) *v1.Pod {
-	return createdNSMDPod(name, node, createProbe("/liveness"), createProbe("/readines"))
+	return createdNSMDPod(name, node, createProbe("/liveness"), createProbe("/readiness"))
 }
 
 func createdNSMDPod(name string, node *v1.Node, liveness, readiness *v1.Probe) *v1.Pod {

--- a/test/kube_testing/pods/utils.go
+++ b/test/kube_testing/pods/utils.go
@@ -1,0 +1,21 @@
+package pods
+
+import (
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+func createProbe(path string) *v1.Probe {
+	return &v1.Probe{
+		Handler: v1.Handler{
+			HTTPGet: &v1.HTTPGetAction{
+				Path:   path,
+				Port:   intstr.IntOrString{Type: 0, IntVal: 5555, StrVal: ""},
+				Scheme: "HTTP",
+			},
+		},
+		InitialDelaySeconds: 1,
+		PeriodSeconds:       3,
+		TimeoutSeconds:      10,
+	}
+}

--- a/test/kube_testing/pods/vppagent_dataplane.go
+++ b/test/kube_testing/pods/vppagent_dataplane.go
@@ -3,10 +3,17 @@ package pods
 import (
 	v1 "k8s.io/api/core/v1"
 	v12 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 func VPPDataplanePod(name string, node *v1.Node) *v1.Pod {
+	return createVPPDataplanePod(name, node, nil, nil)
+}
+
+func VPPDataplanePodLiveCheck(name string, node *v1.Node) *v1.Pod {
+	return createVPPDataplanePod(name, node, createProbe("/liveness"), createProbe("/readines"))
+}
+
+func createVPPDataplanePod(name string, node *v1.Node, liveness, readiness *v1.Probe) *v1.Pod {
 	ht := new(v1.HostPathType)
 	*ht = v1.HostPathDirectoryOrCreate
 
@@ -58,30 +65,8 @@ func VPPDataplanePod(name string, node *v1.Node) *v1.Pod {
 					SecurityContext: &v1.SecurityContext{
 						Privileged: &priv,
 					},
-					LivenessProbe: &v1.Probe{
-						Handler: v1.Handler{
-							HTTPGet: &v1.HTTPGetAction{
-								Path:   "/liveness",
-								Port:   intstr.IntOrString{Type: 0, IntVal: 5555, StrVal: ""},
-								Scheme: "HTTP",
-							},
-						},
-						InitialDelaySeconds: 10,
-						PeriodSeconds:       10,
-						TimeoutSeconds:      3,
-					},
-					ReadinessProbe: &v1.Probe{
-						Handler: v1.Handler{
-							HTTPGet: &v1.HTTPGetAction{
-								Path:   "/readiness",
-								Port:   intstr.IntOrString{Type: 0, IntVal: 5555, StrVal: ""},
-								Scheme: "HTTP",
-							},
-						},
-						InitialDelaySeconds: 10,
-						PeriodSeconds:       10,
-						TimeoutSeconds:      3,
-					},
+					LivenessProbe:  liveness,
+					ReadinessProbe: readiness,
 				}),
 			},
 		},

--- a/test/kube_testing/pods/vppagent_dataplane.go
+++ b/test/kube_testing/pods/vppagent_dataplane.go
@@ -10,7 +10,7 @@ func VPPDataplanePod(name string, node *v1.Node) *v1.Pod {
 }
 
 func VPPDataplanePodLiveCheck(name string, node *v1.Node) *v1.Pod {
-	return createVPPDataplanePod(name, node, createProbe("/liveness"), createProbe("/readines"))
+	return createVPPDataplanePod(name, node, createProbe("/liveness"), createProbe("/readiness"))
 }
 
 func createVPPDataplanePod(name string, node *v1.Node, liveness, readiness *v1.Probe) *v1.Pod {


### PR DESCRIPTION
Signed-off-by: Nikolay Nikolaev <nnikolay@vmware.com>

Improve testing infrastructure for faster testing and fixing tests.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
Integration tests are failing strangely. We add the following patches to improve:

 * Mark broken tests and enable them with BROKEN_TESTS_ENABLED
 * Disable forcing image pull
 * Use global timeout definitions
 * Increase gotest timeout to 30m
 * Lower liveness/readiness probe times to speedup testing

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [X] Covered by existing integration testing
- [X] Added integration testing to cover
- [X] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.