### PR TITLE
Replace nsm.ligato.io/socket

### DIFF
--- a/k8s/cmd/admission-webhook/main.go
+++ b/k8s/cmd/admission-webhook/main.go
@@ -4,9 +4,14 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+
 	"github.com/networkservicemesh/networkservicemesh/pkg/tools"
 	"github.com/sirupsen/logrus"
-	"io/ioutil"
 	"k8s.io/api/admission/v1beta1"
 	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	appsv1 "k8s.io/api/apps/v1"
@@ -15,10 +20,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/kubernetes/pkg/apis/core/v1"
-	"net/http"
-	"os"
-	"os/signal"
-	"syscall"
 )
 
 const (
@@ -115,7 +116,7 @@ func createPatch(annotationValue string, path string) ([]byte, error) {
 			},
 			"resources": map[string]interface{}{
 				"limits": map[string]interface{}{
-					"nsm.ligato.io/socket": 1,
+					"networkservicemesh.io/socket": 1,
 				},
 			},
 		},

--- a/k8s/cmd/nsmdp/nsmdp.go
+++ b/k8s/cmd/nsmdp/nsmdp.go
@@ -39,9 +39,9 @@ import (
 
 const (
 	// SocketBaseDir defines the location of NSM client socket
-	resourceName = "nsm.ligato.io/socket"
+	resourceName = "networkservicemesh.io/socket"
 	// ServerSock defines the name of NSM client socket
-	ServerSock = "nsm.ligato.io.sock"
+	ServerSock = "networkservicemesh.io.sock"
 )
 
 type nsmClientEndpoints struct {

--- a/k8s/conf/icmp-responder-nse.yaml
+++ b/k8s/conf/icmp-responder-nse.yaml
@@ -38,7 +38,7 @@ spec:
               value: "10.20.1.0/24"
           resources:
             limits:
-              nsm.ligato.io/socket: 1
+              networkservicemesh.io/socket: 1
 metadata:
   name: icmp-responder-nse
   namespace: default

--- a/k8s/conf/vpn-gateway-nsc.yaml
+++ b/k8s/conf/vpn-gateway-nsc.yaml
@@ -25,7 +25,7 @@ spec:
               value: "secure-intranet-connectivity"
           resources:
             limits:
-              nsm.ligato.io/socket: 1
+              networkservicemesh.io/socket: 1
 metadata:
   name: vpn-gateway-nsc
   namespace: default

--- a/k8s/conf/vpn-gateway-nse.yaml
+++ b/k8s/conf/vpn-gateway-nse.yaml
@@ -34,7 +34,7 @@ spec:
               value: "10.60.1.0/24"
           resources:
             limits:
-              nsm.ligato.io/socket: 1
+              networkservicemesh.io/socket: 1
         - name: nginx
           image: networkservicemesh/nginx
 metadata:

--- a/k8s/conf/vppagent-firewall-nse.yaml
+++ b/k8s/conf/vppagent-firewall-nse.yaml
@@ -26,7 +26,7 @@ spec:
               value: "true"
           resources:
             limits:
-              nsm.ligato.io/socket: 1
+              networkservicemesh.io/socket: 1
 metadata:
   name: vppagent-firewall-nse
   namespace: default

--- a/k8s/conf/vppagent-icmp-responder-nse.yaml
+++ b/k8s/conf/vppagent-icmp-responder-nse.yaml
@@ -38,7 +38,7 @@ spec:
               value: "10.30.1.1"
           resources:
             limits:
-              nsm.ligato.io/socket: 1
+              networkservicemesh.io/socket: 1
 metadata:
   name: vppagent-icmp-responder-nse
   namespace: default

--- a/k8s/conf/vppagent-nsc.yaml
+++ b/k8s/conf/vppagent-nsc.yaml
@@ -21,7 +21,7 @@ spec:
               value: "icmp-responder"
           resources:
             limits:
-              nsm.ligato.io/socket: 1
+              networkservicemesh.io/socket: 1
 metadata:
   name: vppagent-nsc
   namespace: default

--- a/test/kube_testing/pods/icmp_responder.go
+++ b/test/kube_testing/pods/icmp_responder.go
@@ -16,7 +16,7 @@ func ICMPResponderPod(name string, node *v1.Node, env map[string]string) *v1.Pod
 		ImagePullPolicy: v1.PullIfNotPresent,
 		Resources: v1.ResourceRequirements{
 			Limits: v1.ResourceList{
-				"nsm.ligato.io/socket": resource.NewQuantity(1, resource.DecimalSI).DeepCopy(),
+				"networkservicemesh.io/socket": resource.NewQuantity(1, resource.DecimalSI).DeepCopy(),
 			},
 			Requests: nil,
 		},

--- a/test/kube_testing/pods/nsc.go
+++ b/test/kube_testing/pods/nsc.go
@@ -48,7 +48,7 @@ func NSCPod(name string, node *v1.Node, env map[string]string) *v1.Pod {
 		ImagePullPolicy: v1.PullIfNotPresent,
 		Resources: v1.ResourceRequirements{
 			Limits: v1.ResourceList{
-				"nsm.ligato.io/socket": resource.NewQuantity(1, resource.DecimalSI).DeepCopy(),
+				"networkservicemesh.io/socket": resource.NewQuantity(1, resource.DecimalSI).DeepCopy(),
 			},
 			Requests: nil,
 		},

--- a/test/kube_testing/pods/vpn-gateway-nse.go
+++ b/test/kube_testing/pods/vpn-gateway-nse.go
@@ -34,7 +34,7 @@ func VPNGatewayNSEPod(name string, node *v1.Node, env map[string]string) *v1.Pod
 					ImagePullPolicy: v1.PullIfNotPresent,
 					Resources: v1.ResourceRequirements{
 						Limits: v1.ResourceList{
-							"nsm.ligato.io/socket": resource.NewQuantity(1, resource.DecimalSI).DeepCopy(),
+							"networkservicemesh.io/socket": resource.NewQuantity(1, resource.DecimalSI).DeepCopy(),
 						},
 						Requests: nil,
 					},

--- a/test/kube_testing/pods/vppagent-firewall-nse.go
+++ b/test/kube_testing/pods/vppagent-firewall-nse.go
@@ -34,7 +34,7 @@ func VppAgentFirewallNSEPod(name string, node *v1.Node, env map[string]string) *
 					ImagePullPolicy: v1.PullIfNotPresent,
 					Resources: v1.ResourceRequirements{
 						Limits: v1.ResourceList{
-							"nsm.ligato.io/socket": resource.NewQuantity(1, resource.DecimalSI).DeepCopy(),
+							"networkservicemesh.io/socket": resource.NewQuantity(1, resource.DecimalSI).DeepCopy(),
 						},
 						Requests: nil,
 					},


### PR DESCRIPTION
`nsm.ligato.io` is an outdated name of the location of the NSM client socket, historically comming from the old organisation name. Changing to `networkservicemesh.io/socket` to keep it up-to-date and more descriptive

Signed-off-by: Ivana Yovcheva <iyovcheva@vmware.com>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Closes #755

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [x] Covered by existing integration testing
- [ ] Added integration testing to cover
- [x] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->
All tests are passing locally with `make k8s-integration-tests`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
