### PR TITLE
Collect vpp postmortem data (#738)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -128,7 +128,7 @@ jobs:
             export CONTAINER_TAG="${COMMIT}"
             # export CONTAINER_FORCE_PULL="true"
             mkdir -p ~/junit/
-            mkdir -p ~/postmortem
+            mkdir -p /home/circleci/postmortem
             go mod download
           no_output_timeout: 40m
           environment:
@@ -144,7 +144,7 @@ jobs:
           environment:
             KUBECONFIG: /home/circleci/project/data/kubeconfig
             GO111MODULE: "on"
-            POSTMORTEM_DATA_LOCATION: ~/postmortem
+            POSTMORTEM_DATA_LOCATION: /home/circleci/postmortem
       - run:
           name: Running integration tests - recover
           command: |
@@ -155,7 +155,7 @@ jobs:
           environment:
             KUBECONFIG: /home/circleci/project/data/kubeconfig
             GO111MODULE: "on"
-            POSTMORTEM_DATA_LOCATION: ~/postmortem
+            POSTMORTEM_DATA_LOCATION: /home/circleci/postmortem
       - run:
           name: Running integration tests - usecase
           command: |
@@ -166,13 +166,13 @@ jobs:
           environment:
             KUBECONFIG: /home/circleci/project/data/kubeconfig
             GO111MODULE: "on"
-            POSTMORTEM_DATA_LOCATION: ~/postmortem
+            POSTMORTEM_DATA_LOCATION: /home/circleci/postmortem
       - store_test_results:
           path: ~/junit
       - store_artifacts:
           path: ~/junit
       - store_artifacts:
-          path: ~/postmortem
+          path: /home/circleci/postmortem
       - run:
           when: always
           name: Dump K8s state

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -121,13 +121,14 @@ jobs:
       - restore_cache:
           key: cncf-data-{{.Environment.CIRCLE_WORKFLOW_ID}}
       - run:
-          name: Downloading go deps
+          name: Prepare integration tests
           command: |
             ./scripts/prepare-circle-integration-tests.sh
             export COMMIT="${CIRCLE_SHA1:8:8}"
             export CONTAINER_TAG="${COMMIT}"
             # export CONTAINER_FORCE_PULL="true"
             mkdir -p ~/junit/
+            mkdir -p ~/postmortem
             go mod download
           no_output_timeout: 40m
           environment:
@@ -143,6 +144,7 @@ jobs:
           environment:
             KUBECONFIG: /home/circleci/project/data/kubeconfig
             GO111MODULE: "on"
+            POSTMORTEM_DATA_LOCATION: ~/postmortem
       - run:
           name: Running integration tests - recover
           command: |
@@ -153,6 +155,7 @@ jobs:
           environment:
             KUBECONFIG: /home/circleci/project/data/kubeconfig
             GO111MODULE: "on"
+            POSTMORTEM_DATA_LOCATION: ~/postmortem
       - run:
           name: Running integration tests - usecase
           command: |
@@ -163,10 +166,13 @@ jobs:
           environment:
             KUBECONFIG: /home/circleci/project/data/kubeconfig
             GO111MODULE: "on"
+            POSTMORTEM_DATA_LOCATION: ~/postmortem
       - store_test_results:
           path: ~/junit
       - store_artifacts:
           path: ~/junit
+      - store_artifacts:
+          path: ~/postmortem
       - run:
           when: always
           name: Dump K8s state

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -347,6 +347,20 @@ jobs:
             export TAG="${COMMIT}"
             make docker-vppagent-dataplane-build
             make docker-vppagent-dataplane-push
+  build-vppagent-dataplane-dev:
+    working_directory: /go/src/github.com/networkservicemesh/networkservicemesh/
+    docker:
+      - image: circleci/golang:1.11
+    steps:
+      - checkout
+      - setup_remote_docker:
+          docker_layer_caching: true
+      - run:
+          command: |
+            export COMMIT="${CIRCLE_SHA1:8:8}"
+            export TAG="${COMMIT}"
+            make docker-vppagent-dataplane-dev-build
+            make docker-vppagent-dataplane-dev-push
   build-vppagent-firewall-nse:
     working_directory: /go/src/github.com/networkservicemesh/networkservicemesh/
     docker:
@@ -375,7 +389,7 @@ jobs:
             export PULL_TAG="${COMMIT}"
             export TAG="latest"
             export REPO="networkservicemesh"
-            export CONTAINERS=(nsmd nsmd-k8s nsmdp crossconnect-monitor icmp-responder-nse vppagent-icmp-responder-nse vppagent-nsc nsc vppagent-dataplane)
+            export CONTAINERS=(nsmd nsmd-k8s nsmdp crossconnect-monitor icmp-responder-nse vppagent-icmp-responder-nse vppagent-nsc nsc vppagent-dataplane vppagent-dataplane-dev)
             echo "${DOCKER_PASSWORD}" | docker login -u "${DOCKER_USERNAME}" --password-stdin
             for c in ${CONTAINERS[@]}; do
               docker pull ${REPO}/${c}:${PULL_TAG}
@@ -416,6 +430,9 @@ workflows:
           requires:
             - sanity-check
       - build-vppagent-dataplane:
+          requires:
+            - sanity-check
+      - build-vppagent-dataplane-dev:
           requires:
             - sanity-check
       - build-vppagent-firewall-nse:

--- a/.mk/docker.mk
+++ b/.mk/docker.mk
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-BUILD_CONTAINERS=nsmd nsmdp nsmd-k8s vppagent-dataplane
+BUILD_CONTAINERS=nsmd nsmdp nsmd-k8s vppagent-dataplane vppagent-dataplane-dev
 BUILD_CONTAINERS+=devenv crossconnect-monitor
 BUILD_CONTAINERS+=nsc icmp-responder-nse
 BUILD_CONTAINERS+=vppagent-firewall-nse

--- a/.mk/k8s.mk
+++ b/.mk/k8s.mk
@@ -168,7 +168,7 @@ k8s-nsmd-save:  $(addsuffix -save,$(addprefix ${CONTAINER_BUILD_PREFIX}-,$(NSMD_
 .PHONY: k8s-nsmd-load-images
 k8s-nsmd-load-images:  k8s-start $(addsuffix -load-images,$(addprefix ${CLUSTER_RULES_PREFIX}-,$(NSMD_CONTAINERS)))
 
-VPPAGENT_DATAPLANE_CONTAINERS = vppagent-dataplane
+VPPAGENT_DATAPLANE_CONTAINERS = vppagent-dataplane vppagent-dataplane-dev
 .PHONY: k8s-vppagent-dataplane-build
 k8s-vppagent-dataplane-build:  $(addsuffix -build,$(addprefix ${CONTAINER_BUILD_PREFIX}-,$(VPPAGENT_DATAPLANE_CONTAINERS)))
  .PHONY: k8s-vppagent-dataplane-save

--- a/dataplane/vppagent/build/Dockerfile.vppagent-dataplane-dev
+++ b/dataplane/vppagent/build/Dockerfile.vppagent-dataplane-dev
@@ -1,0 +1,26 @@
+FROM golang:alpine as build
+RUN apk --no-cache add git
+ENV PACKAGEPATH=github.com/networkservicemesh/networkservicemesh/
+ENV GO111MODULE=on
+
+RUN mkdir /root/networkservicemesh
+ADD ["go.mod","/root/networkservicemesh"]
+WORKDIR /root/networkservicemesh/
+RUN go mod download
+
+ADD [".","/root/networkservicemesh"]
+RUN CGO_ENABLED=0 GOOS=linux go build -ldflags '-extldflags "-static"' -o /go/bin/vppagent-dataplane ./dataplane/vppagent/cmd/vppagent-dataplane.go
+
+FROM ligato/dev-vpp-agent:v1.8 as runtime
+COPY --from=build /go/bin/vppagent-dataplane /bin/vppagent-dataplane
+RUN rm /opt/vpp-agent/dev/etcd.conf /opt/vpp-agent/dev/kafka.conf; echo 'Endpoint: "localhost:9111"' > /opt/vpp-agent/dev/grpc.conf
+COPY dataplane/vppagent/conf/vpp/startup.conf /etc/vpp/vpp.conf
+COPY dataplane/vppagent/conf/supervisord/supervisord-dev.conf /etc/supervisord/supervisord.conf
+
+COPY dataplane/vppagent/scripts/vpp_listener.py /usr/bin/vpp_listener.py
+COPY dataplane/vppagent/scripts/vpp_monitor.sh /usr/bin/vpp_monitor.sh
+COPY dataplane/vppagent/scripts/vpp_monitor_handlers.py /usr/bin/vpp_monitor_handlers.py
+
+ENV COLLECT_POSTMORTEM_DATA=true
+ENV SAVE_COREDUMP=false
+ENV POSTMORTEM_DATA_LOCATION=/var/tmp/nsm-postmortem/vpp-dataplane

--- a/dataplane/vppagent/build/Dockerfile.vppagent-dataplane-dev
+++ b/dataplane/vppagent/build/Dockerfile.vppagent-dataplane-dev
@@ -23,6 +23,8 @@ COPY dataplane/vppagent/scripts/vpp_monitor_handlers.py /usr/bin/vpp_monitor_han
 
 ENV COLLECT_POSTMORTEM_DATA=true
 ENV SAVE_COREDUMP=false
+ENV QUIT_GDB_ON_CRASH=true
+ENV EXIT_ON_CRASH=true
 ENV POSTMORTEM_DATA_LOCATION=/var/tmp/nsm-postmortem/vpp-dataplane
 
 RUN sed -ri 's/reply-timeout: [0-9]+/reply-timeout: 10000000000/' /opt/vpp-agent/dev/govpp.conf

--- a/dataplane/vppagent/build/Dockerfile.vppagent-dataplane-dev
+++ b/dataplane/vppagent/build/Dockerfile.vppagent-dataplane-dev
@@ -24,3 +24,5 @@ COPY dataplane/vppagent/scripts/vpp_monitor_handlers.py /usr/bin/vpp_monitor_han
 ENV COLLECT_POSTMORTEM_DATA=true
 ENV SAVE_COREDUMP=false
 ENV POSTMORTEM_DATA_LOCATION=/var/tmp/nsm-postmortem/vpp-dataplane
+
+RUN sed -ri 's/reply-timeout: [0-9]+/reply-timeout: 10000000000/' /opt/vpp-agent/dev/govpp.conf

--- a/dataplane/vppagent/build/Dockerfile.vppagent-dataplane-dev
+++ b/dataplane/vppagent/build/Dockerfile.vppagent-dataplane-dev
@@ -11,7 +11,21 @@ RUN go mod download
 ADD [".","/root/networkservicemesh"]
 RUN CGO_ENABLED=0 GOOS=linux go build -ldflags '-extldflags "-static"' -o /go/bin/vppagent-dataplane ./dataplane/vppagent/cmd/vppagent-dataplane.go
 
-FROM ligato/dev-vpp-agent:v1.8 as runtime
+FROM ligato/dev-vpp-agent:v1.8 as devimg
+
+FROM ligato/vpp-agent:v1.8 as runtime
+
+COPY --from=devimg \
+    /opt/vpp-agent/dev/vpp/build-root/vpp-dev_*.deb \
+    /opt/vpp-agent/dev/vpp/build-root/vpp-dbg_*.deb \
+    /opt/vpp-agent/dev/vpp/build-root/vpp-api-python_*.deb \
+ /opt/vpp/
+
+RUN apt-get update && apt-get install -y gdb python python-cffi python-enum34 \
+  && cd /opt/vpp/ \
+  && dpkg -i vpp-dev_*.deb vpp-dbg_*.deb vpp-api-python_*.deb \
+  && rm vpp*.deb
+
 COPY --from=build /go/bin/vppagent-dataplane /bin/vppagent-dataplane
 RUN rm /opt/vpp-agent/dev/etcd.conf /opt/vpp-agent/dev/kafka.conf; echo 'Endpoint: "localhost:9111"' > /opt/vpp-agent/dev/grpc.conf
 COPY dataplane/vppagent/conf/vpp/startup.conf /etc/vpp/vpp.conf

--- a/dataplane/vppagent/build/Dockerfile.vppagent-dataplane-dev
+++ b/dataplane/vppagent/build/Dockerfile.vppagent-dataplane-dev
@@ -11,9 +11,9 @@ RUN go mod download
 ADD [".","/root/networkservicemesh"]
 RUN CGO_ENABLED=0 GOOS=linux go build -ldflags '-extldflags "-static"' -o /go/bin/vppagent-dataplane ./dataplane/vppagent/cmd/vppagent-dataplane.go
 
-FROM ligato/dev-vpp-agent:v1.8 as devimg
+FROM ligato/dev-vpp-agent:v1.8.1 as devimg
 
-FROM ligato/vpp-agent:v1.8 as runtime
+FROM ligato/vpp-agent:v1.8.1 as runtime
 
 COPY --from=devimg \
     /opt/vpp-agent/dev/vpp/build-root/vpp-dev_*.deb \

--- a/dataplane/vppagent/conf/supervisord/supervisord-dev.conf
+++ b/dataplane/vppagent/conf/supervisord/supervisord-dev.conf
@@ -47,4 +47,5 @@ priority=4
 ; You should also set agent's autorestart=false.
 [eventlistener:vpp_listener]
 command=/usr/bin/vpp_listener.py
+autorestart=false
 events=PROCESS_STATE_EXITED

--- a/dataplane/vppagent/conf/supervisord/supervisord-dev.conf
+++ b/dataplane/vppagent/conf/supervisord/supervisord-dev.conf
@@ -1,0 +1,41 @@
+[supervisord]
+logfile=/var/log/supervisord.log
+loglevel=debug
+nodaemon=true
+pidfile=/run/supervisord.pid
+
+[program:vpp]
+command=/usr/bin/vpp -c /etc/vpp/vpp.conf
+autorestart=false
+redirect_stderr=true
+priority=1
+
+[program:agent]
+command=/usr/bin/exec_agent.sh
+startsecs=0
+autorestart=false
+redirect_stderr=true
+priority=2
+
+[program:monitor]
+command=/usr/bin/vpp_monitor.sh
+startsecs=0
+autorestart=false
+redirect_stderr=true
+priority=3
+
+[program:vppagent-dataplane]
+command=/bin/vppagent-dataplane
+startsecs=0
+autorestart=false
+redirect_stderr=true
+priority=3
+
+; This event listener waits for event of vpp or agent exiting.
+; Once received it performs postmortem data collection
+; and then kills supervisord process. This makes
+; subsequently the exit of docker container.
+; You should also set agent's autorestart=false.
+[eventlistener:vpp_listener]
+command=/usr/bin/vpp_listener.py
+events=PROCESS_STATE_EXITED

--- a/dataplane/vppagent/conf/supervisord/supervisord-dev.conf
+++ b/dataplane/vppagent/conf/supervisord/supervisord-dev.conf
@@ -4,6 +4,15 @@ loglevel=debug
 nodaemon=true
 pidfile=/run/supervisord.pid
 
+[unix_http_server]
+file = /tmp/supervisor.sock
+
+[supervisorctl]
+serverurl = unix:///tmp/supervisor.sock
+
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
+
 [program:vpp]
 command=/usr/bin/vpp -c /etc/vpp/vpp.conf
 autorestart=false
@@ -29,7 +38,7 @@ command=/bin/vppagent-dataplane
 startsecs=0
 autorestart=false
 redirect_stderr=true
-priority=3
+priority=4
 
 ; This event listener waits for event of vpp or agent exiting.
 ; Once received it performs postmortem data collection

--- a/dataplane/vppagent/conf/vpp/startup.conf
+++ b/dataplane/vppagent/conf/vpp/startup.conf
@@ -71,7 +71,7 @@ cpu {
 }
 
 # dpdk {
-	## Change default settings for all intefaces
+	## Change default settings for all interfaces
 	# dev default {
 		## Number of receive queues, enables RSS
 		## Default is 1

--- a/dataplane/vppagent/scripts/vpp_listener.py
+++ b/dataplane/vppagent/scripts/vpp_listener.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python
+
+import os
+import re
+import shutil
+import signal
+import sys
+import time
+import traceback
+
+POSTMORTEM_DATA_LOCATION = os.environ.get('POSTMORTEM_DATA_LOCATION', '/var/tmp/nsm-postmortem/vpp-dataplane')
+COLLECT_POSTMORTEM_DATA = os.environ.get('COLLECT_POSTMORTEM_DATA')
+
+
+def write_stdout(msg):
+    # only eventlistener protocol messages may be sent to stdout
+    sys.stdout.write(msg)
+    sys.stdout.flush()
+
+
+def write_stderr(msg):
+    sys.stderr.write(msg)
+    sys.stderr.flush()
+
+
+def acknowledge():
+    write_stdout('RESULT 2\nOK')
+
+
+def ready():
+    # transition from ACKNOWLEDGED to READY
+    write_stdout('READY\n')
+
+
+def parse_data(data):
+    # transition from READY to ACKNOWLEDGED
+    return dict([x.split(':') for x in data.split()])
+
+
+def receive_event():
+    # read header line and print it to stderr
+    line = sys.stdin.readline()
+    write_stderr('EVENT: ' + line)
+
+    # read event payload and print it to stderr
+    headers = parse_data(line)
+    data = sys.stdin.read(int(headers['len']))
+    write_stderr('DATA: ' + data + '\n')
+
+    # ignore non vpp events, skipping
+    parsed_data = parse_data(data)
+    return parsed_data
+
+
+def kill_supervisord():
+    try:
+        with open('/run/supervisord.pid', 'r') as pidfile:
+            pid = int(pidfile.readline())
+        write_stderr('Killing supervisord with pid: ' + str(pid) + '\n')
+        os.kill(pid, signal.SIGQUIT)
+    except Exception as e:
+        write_stderr('Could not kill supervisor: ' + str(e) + '\n')
+
+
+def collect(src_dir, pattern, dst_dir, timestamp):
+    try:
+        if not os.path.exists(dst_dir):
+            os.makedirs(dst_dir, exist_ok=True)
+
+        matcher = re.compile(pattern)
+        matched = [os.path.join(src_dir, filename) for filename in os.listdir(src_dir) if matcher.match(filename)]
+        matched_files = [src_path for src_path in matched if os.path.isfile(src_path)]
+
+        def destination_path(path):
+            basename = os.path.basename(path)
+            return os.path.join(dst_dir, "%d.%s" % (timestamp, basename))
+
+        for src_path in matched_files:
+            dst_path = destination_path(src_path)
+            write_stderr("Moving '%s' to '%s'" % (src_path, dst_path))
+            shutil.move(src_path, dst_path)
+
+    except (OSError, re.error):
+        traceback.print_exc()
+
+
+def collect_postmortem_data():
+    if COLLECT_POSTMORTEM_DATA != 'true':
+        write_stderr("Postmortem data collection is disabled (set COLLECT_POSTMORTEM_DATA=true to enable it)")
+        return
+    timestamp = int(time.time())
+    write_stderr("Collecting postmortem data...")
+    collect('/tmp', 'agent-stdout', POSTMORTEM_DATA_LOCATION, timestamp)
+    collect('/tmp', 'vpp-stdout', POSTMORTEM_DATA_LOCATION, timestamp)
+    collect('/tmp', 'vppagent-dataplane-stdout', POSTMORTEM_DATA_LOCATION, timestamp)
+    collect('/tmp', 'api_post_mortem', POSTMORTEM_DATA_LOCATION, timestamp)
+    collect('/tmp', 'vpp_backtrace', POSTMORTEM_DATA_LOCATION, timestamp)
+    collect('/var/log/vpp', 'vpp.log', POSTMORTEM_DATA_LOCATION, timestamp)
+    collect('/var/log', 'supervisord.log', POSTMORTEM_DATA_LOCATION, timestamp)
+    collect('/var/log', 'syslog', POSTMORTEM_DATA_LOCATION, timestamp)
+    collect(POSTMORTEM_DATA_LOCATION, 'core', POSTMORTEM_DATA_LOCATION, timestamp)
+    write_stderr("Postmortem data collection finished.")
+
+
+def handle_vpp_exit(event_data):
+    collect_postmortem_data()
+    kill_supervisord()
+
+
+# event loop
+
+def main():
+    while True:
+        ready()
+
+        event_data = receive_event()
+
+        # ignore unwanted processes
+        if event_data["processname"] not in ["vpp", "agent"]:
+            write_stderr('Ignoring event from ' + event_data["processname"] + '\n')
+            acknowledge()
+            continue
+
+        # ignore exits with expected exit codes
+        if event_data["expected"] == "1":
+            write_stderr('Exit state from ' + event_data["processname"] + ' was expected\n')
+            acknowledge()
+            continue
+
+        handle_vpp_exit(event_data)
+        acknowledge()
+        return
+
+
+if __name__ == '__main__':
+    main()

--- a/dataplane/vppagent/scripts/vpp_listener.py
+++ b/dataplane/vppagent/scripts/vpp_listener.py
@@ -12,6 +12,10 @@ POSTMORTEM_DATA_LOCATION = os.environ.get('POSTMORTEM_DATA_LOCATION', '/var/tmp/
 COLLECT_POSTMORTEM_DATA = os.environ.get('COLLECT_POSTMORTEM_DATA')
 
 
+def should_kill_supervisord():
+    return os.environ.get('EXIT_ON_CRASH') == 'true'
+
+
 def write_stdout(msg):
     # only eventlistener protocol messages may be sent to stdout
     sys.stdout.write(msg)
@@ -104,7 +108,8 @@ def collect_postmortem_data():
 
 def handle_vpp_exit(event_data):
     collect_postmortem_data()
-    kill_supervisord()
+    if should_kill_supervisord():
+        kill_supervisord()
 
 
 # event loop

--- a/dataplane/vppagent/scripts/vpp_monitor.sh
+++ b/dataplane/vppagent/scripts/vpp_monitor.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+# This script attaches the vpp process with the GDB
+# and stores core dump file in case of crash
+
+if [[ "$COLLECT_POSTMORTEM_DATA" != "true" ]]; then
+    echo "Postmortem data collection is disabled (set COLLECT_POSTMORTEM_DATA=true to enable it)"
+    exit 0
+fi
+
+# setup postmortem data location
+readonly DEFAULT_POSTMORTEM_DATA_LOCATION=/var/tmp/nsm-postmortem/vpp-dataplane
+readonly POSTMORTEM_DATA_LOCATION=${POSTMORTEM_DATA_LOCATION:-"$DEFAULT_POSTMORTEM_DATA_LOCATION"}
+
+# make sure postmortem data location exists
+mkdir -p "$POSTMORTEM_DATA_LOCATION"
+
+# attach to the vpp with a gdb monitor
+# and store a core dump in case of crash
+{
+    echo "set confirm off"
+    echo "set backtrace limit 200"
+    echo "handle SIGINT pass nostop"
+    echo "python"
+    cat "/usr/bin/vpp_monitor_handlers.py"
+    echo "end"
+    echo "cont"
+} | gdb attach "$(pgrep -f "vpp -c")"

--- a/dataplane/vppagent/scripts/vpp_monitor.sh
+++ b/dataplane/vppagent/scripts/vpp_monitor.sh
@@ -23,6 +23,7 @@ mkdir -p "$POSTMORTEM_DATA_LOCATION"
     echo "handle SIGINT pass nostop"
     echo "source /usr/bin/vpp_monitor_handlers.py"
     echo "attach $(supervisorctl -c /etc/supervisord/supervisord.conf pid vpp)"
+    echo 'echo GDB Monitor attached successfully\n'
     echo "cont"
 } > "$GDB_COMMANDS_FILE"
 

--- a/dataplane/vppagent/scripts/vpp_monitor.sh
+++ b/dataplane/vppagent/scripts/vpp_monitor.sh
@@ -11,18 +11,21 @@ fi
 # setup postmortem data location
 readonly DEFAULT_POSTMORTEM_DATA_LOCATION=/var/tmp/nsm-postmortem/vpp-dataplane
 readonly POSTMORTEM_DATA_LOCATION=${POSTMORTEM_DATA_LOCATION:-"$DEFAULT_POSTMORTEM_DATA_LOCATION"}
+readonly GDB_COMMANDS_FILE=/usr/bin/vpp_monitor_commands.gdb
 
 # make sure postmortem data location exists
 mkdir -p "$POSTMORTEM_DATA_LOCATION"
 
-# attach to the vpp with a gdb monitor
-# and store a core dump in case of crash
+# prepare gdb config
 {
     echo "set confirm off"
     echo "set backtrace limit 200"
     echo "handle SIGINT pass nostop"
-    echo "python"
-    cat "/usr/bin/vpp_monitor_handlers.py"
-    echo "end"
+    echo "source /usr/bin/vpp_monitor_handlers.py"
+    echo "attach $(supervisorctl -c /etc/supervisord/supervisord.conf pid vpp)"
     echo "cont"
-} | gdb attach "$(pgrep -f "vpp -c")"
+} > "$GDB_COMMANDS_FILE"
+
+# attach to the vpp with a gdb monitor
+# and store a core dump in case of crash
+gdb -x "$GDB_COMMANDS_FILE"

--- a/dataplane/vppagent/scripts/vpp_monitor.sh
+++ b/dataplane/vppagent/scripts/vpp_monitor.sh
@@ -23,6 +23,7 @@ mkdir -p "$POSTMORTEM_DATA_LOCATION"
     echo "handle SIGINT pass nostop"
     echo "source /usr/bin/vpp_monitor_handlers.py"
     echo "attach $(supervisorctl -c /etc/supervisord/supervisord.conf pid vpp)"
+    # shellcheck disable=SC2028
     echo 'echo GDB Monitor attached successfully\n'
     echo "cont"
 } > "$GDB_COMMANDS_FILE"

--- a/dataplane/vppagent/scripts/vpp_monitor_handlers.py
+++ b/dataplane/vppagent/scripts/vpp_monitor_handlers.py
@@ -1,0 +1,41 @@
+import os
+
+
+def should_save_core_dump():
+    return os.environ.get('SAVE_COREDUMP') == 'true'
+
+
+def core_dump_location():
+    return os.environ.get('POSTMORTEM_DATA_LOCATION', '/var/tmp/nsm-postmortem/vpp-dataplane')
+
+
+def save_stacktrace():
+    gdb.execute("cd /tmp")
+    gdb.execute("set logging file vpp_backtrace")
+    gdb.execute("set logging on")
+    gdb.execute("thread apply all bt")
+    gdb.execute("set logging off")
+
+
+def save_core_dump():
+    gdb.execute("cd " + core_dump_location())
+    gdb.execute("generate-core-file")
+
+
+def stop_handler(event):
+    if isinstance(event, gdb.SignalEvent):
+        if event.stop_signal in ["SIGSEGV"]:
+            save_stacktrace()
+            if should_save_core_dump():
+                save_core_dump()
+            gdb.execute("quit")
+        else:
+            gdb.execute("cont")
+
+
+def exit_handler(_):
+    gdb.execute("quit")
+
+
+gdb.events.stop.connect(stop_handler)
+gdb.events.exited.connect(exit_handler)

--- a/dataplane/vppagent/scripts/vpp_monitor_handlers.py
+++ b/dataplane/vppagent/scripts/vpp_monitor_handlers.py
@@ -9,6 +9,10 @@ def core_dump_location():
     return os.environ.get('POSTMORTEM_DATA_LOCATION', '/var/tmp/nsm-postmortem/vpp-dataplane')
 
 
+def should_quit():
+    return os.environ.get('QUIT_GDB_ON_CRASH') == 'true'
+
+
 def save_stacktrace():
     gdb.execute("cd /tmp")
     gdb.execute("set logging file vpp_backtrace")
@@ -28,7 +32,11 @@ def stop_handler(event):
             save_stacktrace()
             if should_save_core_dump():
                 save_core_dump()
-            gdb.execute("quit")
+            # if should_quit() evaluates to False
+            # the process will hang until integration-testing
+            # framework will explicitly shut-down container
+            if should_quit():
+                gdb.execute("quit")
         else:
             gdb.execute("cont")
 

--- a/docker/Dockerfile.vppagent-dataplane-dev
+++ b/docker/Dockerfile.vppagent-dataplane-dev
@@ -1,0 +1,1 @@
+../dataplane/vppagent/build/Dockerfile.vppagent-dataplane-dev

--- a/k8s/conf/vppagent-dataplane.yaml
+++ b/k8s/conf/vppagent-dataplane.yaml
@@ -24,6 +24,8 @@ spec:
             - name: workspace
               mountPath: /var/lib/networkservicemesh/
               mountPropagation: Bidirectional
+            - name: postmortem
+              mountPath: /var/tmp/nsm-postmortem/
           livenessProbe:
             httpGet:
               path: /liveness
@@ -43,6 +45,10 @@ spec:
             path: /var/lib/networkservicemesh
             type: DirectoryOrCreate
           name: workspace
+        - hostPath:
+            path: /var/tmp/nsm-postmortem/
+            type: DirectoryOrCreate
+          name: postmortem
 metadata:
   name: nsm-vppagent-dataplane
   namespace: default

--- a/test/integration/vpp_dataplane_test.go
+++ b/test/integration/vpp_dataplane_test.go
@@ -1,0 +1,82 @@
+package nsmd_integration_tests
+
+import (
+	"fmt"
+	"github.com/networkservicemesh/networkservicemesh/test/kube_testing"
+	"github.com/networkservicemesh/networkservicemesh/test/kube_testing/pods"
+	. "github.com/onsi/gomega"
+	"github.com/sirupsen/logrus"
+	"k8s.io/api/core/v1"
+	"strings"
+	"testing"
+	"time"
+)
+
+const (
+	vppContainer = ""
+)
+
+func TestVppPostmortemDataCollection(t *testing.T) {
+	RegisterTestingT(t)
+
+	k8s, dataplane := deployVppDataplane(defaultTimeout)
+
+	defer k8s.Cleanup()
+	defer clearPostmortemData(k8s, dataplane) // prevent false alarms
+
+	vpp := getVppPID(k8s, dataplane)
+	sendSignal(k8s, dataplane, vpp, "SIGSEGV")
+
+	k8s.WaitLogsContains(dataplane, vppContainer, "Postmortem data collection finished", defaultTimeout)
+
+	backtraces := postmortemFiles(k8s, dataplane)
+	Expect(backtraces).NotTo(BeEmpty())
+}
+
+func deployVppDataplane(timeout time.Duration) (*kube_testing.K8s, *v1.Pod) {
+	k8s, err := kube_testing.NewK8s()
+	Expect(err).To(BeNil())
+
+	s1 := time.Now()
+	k8s.Prepare("nsmd", "nsc", "nsmd-dataplane", "icmp-responder-nse", "jaeger")
+	logrus.Printf("Cleanup done: %v", time.Since(s1))
+
+	// prepare node
+	nodes := k8s.GetNodesWait(1, timeout)
+	Expect(len(nodes) >= 1).To(Equal(true), "At least one kubernetes node is required for this test")
+
+	// deploy vpp-dataplane pod
+	node := &nodes[0]
+	dataplaneName := fmt.Sprintf("nsmd-dataplane-%s", node.Name)
+	dataplane := k8s.CreatePod(pods.VPPDataplanePod(dataplaneName, node))
+
+	// wait gdb monitor is initialized and attached to the vpp
+	k8s.WaitLogsContains(dataplane, "", "GDB Monitor attached successfully", timeout)
+
+	return k8s, dataplane
+}
+
+func getVppPID(k8s *kube_testing.K8s, pod *v1.Pod) string {
+	getVppPidCommand := []string{"supervisorctl", "-c", "/etc/supervisord/supervisord.conf", "pid", "vpp"}
+
+	stdout, stderr, err := k8s.Exec(pod, vppContainer, getVppPidCommand...)
+	Expect(err).To(BeNil())
+	Expect(stderr).To(BeEmpty())
+	return strings.Trim(stdout, " \t\n")
+}
+
+func sendSignal(k8s *kube_testing.K8s, pod *v1.Pod, pid, signal string) {
+	command := []string{"kill", "-s", signal, pid}
+
+	_, stderr, err := k8s.Exec(pod, vppContainer, command...)
+	Expect(err).To(BeNil())
+	Expect(stderr).To(BeEmpty())
+}
+
+func postmortemFiles(k8s *kube_testing.K8s, dataplane *v1.Pod) []string {
+	return k8s.FindFiles(dataplane, vppContainer, pods.VppPostmortemDataLocation, pods.VppBacktracePattern)
+}
+
+func clearPostmortemData(k8s *kube_testing.K8s, dataplane *v1.Pod) {
+	_, _, _ = k8s.Exec(dataplane, vppContainer, "rm", "-rf", pods.VppPostmortemDataLocation)
+}

--- a/test/kube_testing/k8s.go
+++ b/test/kube_testing/k8s.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"time"
@@ -247,7 +248,7 @@ func NewK8s() (*K8s, error) {
 
 	path := os.Getenv("KUBECONFIG")
 	if len(path) == 0 {
-		path = os.Getenv("HOME") + "/.kube/config"
+		path = filepath.Join(os.Getenv("HOME"), ".kube", "config")
 	}
 
 	config, err := clientcmd.BuildConfigFromFlags("", path)

--- a/test/kube_testing/pods/vppagent_dataplane.go
+++ b/test/kube_testing/pods/vppagent_dataplane.go
@@ -39,16 +39,30 @@ func createVPPDataplanePod(name string, node *v1.Node, liveness, readiness *v1.P
 						},
 					},
 				},
+				{
+					Name: "postmortem",
+					VolumeSource: v1.VolumeSource{
+						HostPath: &v1.HostPathVolumeSource{
+							Type: ht,
+							Path: "/var/tmp/nsm-postmortem/",
+						},
+					},
+				},
 			},
 			Containers: []v1.Container{
 				containerMod(&v1.Container{
 					Name:            "vppagent-dataplane",
-					Image:           "networkservicemesh/vppagent-dataplane:latest",
+					Image:           "networkservicemesh/vppagent-dataplane-dev:latest",
 					ImagePullPolicy: v1.PullIfNotPresent,
 					VolumeMounts: []v1.VolumeMount{
 						v1.VolumeMount{
 							Name:             "workspace",
 							MountPath:        "/var/lib/networkservicemesh/",
+							MountPropagation: &mode,
+						},
+						v1.VolumeMount{
+							Name:             "postmortem",
+							MountPath:        "/var/tmp/nsm-postmortem/",
 							MountPropagation: &mode,
 						},
 					},


### PR DESCRIPTION
## Description
Automates vpp-dataplane postmortem data collection.  

If `networkservicemesh/vppagent-dataplane` is run with `-e COLLECT_POSTMORTEM_DATA=true` it will store vpp core dump, api traces and logs at `$POSTMORTEM_DATA_LOCATION` (default is `/var/tmp/nsm-postmortem/vpp-dataplane`)

## Motivation and Context
See #738 

## How Has This Been Tested?
- [ ] Covered by existing integration testing
- [x] Added integration testing to cover
- [x] Tested locally

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
