### PR TITLE
Enforce build to fail if code is not go fmt compliant

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,11 @@ jobs:
       - run: yamllint -c .yamllint.yml $(git ls-files '*.yaml' '*.yml')
       - run: go version
       - run: "! go fmt ./... 2>&1 | read"
+      - run:
+          name: golint
+          command: |
+            go get -u github.com/golang/lint/golint
+            golint ./...
       - run: make vet check
       - run: go install k8s.io/code-generator/cmd/deepcopy-gen
       - run: go install github.com/golang/protobuf/protoc-gen-go

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,7 @@ jobs:
             ./.circleci/install-shellcheck.sh
       - run: yamllint -c .yamllint.yml $(git ls-files '*.yaml' '*.yml')
       - run: go version
+      - run: "! go fmt ./... 2>&1 | read"
       - run: make vet check
       - run: go install k8s.io/code-generator/cmd/deepcopy-gen
       - run: go install github.com/golang/protobuf/protoc-gen-go

--- a/controlplane/pkg/apis/nsm/nsm.go
+++ b/controlplane/pkg/apis/nsm/nsm.go
@@ -49,10 +49,10 @@ type NetworkServiceClient interface {
 type HealState int32
 
 const (
-	HealState_DstDown       HealState = 1	// Destination is down, we need to restore it and re-program local Datplane.
-	HealState_SrcDown       HealState = 2	// Source is down, most probable will not happen yet.
-	HealState_DataplaneDown HealState = 3	// In case local Dataplane is down, we need to heal NSE/Remote NSM and Dataplane.
-	HealState_DstUpdate		HealState = 4	// Destination is updated, most probable because of Remote Dataplane is down, we need to re-program local dataplane.
+	HealState_DstDown       HealState = 1 // Destination is down, we need to restore it and re-program local Datplane.
+	HealState_SrcDown       HealState = 2 // Source is down, most probable will not happen yet.
+	HealState_DataplaneDown HealState = 3 // In case local Dataplane is down, we need to heal NSE/Remote NSM and Dataplane.
+	HealState_DstUpdate     HealState = 4 // Destination is updated, most probable because of Remote Dataplane is down, we need to re-program local dataplane.
 )
 
 type NetworkServiceManager interface {

--- a/controlplane/pkg/model/model.go
+++ b/controlplane/pkg/model/model.go
@@ -23,22 +23,23 @@ type Dataplane struct {
 	RemoteMechanisms []*remote.Mechanism
 }
 type ClientConnectionState int8
+
 const (
-	ClientConnection_Ready = 0
+	ClientConnection_Ready      = 0
 	ClientConnection_Requesting = 1
-	ClientConnection_Healing	= 2
-	ClientConnection_Closing	= 3
-	ClientConnection_Closed	= 4
+	ClientConnection_Healing    = 2
+	ClientConnection_Closing    = 3
+	ClientConnection_Closed     = 4
 )
 
 type ClientConnection struct {
-	ConnectionId string
-	Xcon         *crossconnect.CrossConnect
-	RemoteNsm    *registry.NetworkServiceManager
-	Endpoint     *registry.NSERegistration
-	Dataplane    *Dataplane
+	ConnectionId    string
+	Xcon            *crossconnect.CrossConnect
+	RemoteNsm       *registry.NetworkServiceManager
+	Endpoint        *registry.NSERegistration
+	Dataplane       *Dataplane
 	ConnectionState ClientConnectionState
-	Request      nsm.NSMRequest
+	Request         nsm.NSMRequest
 }
 
 func (cc *ClientConnection) GetId() string {

--- a/controlplane/pkg/nsm/nsm.go
+++ b/controlplane/pkg/nsm/nsm.go
@@ -67,7 +67,7 @@ func create_logid() (uuid string) {
 
 func (srv *networkServiceManager) request(ctx context.Context, request nsm.NSMRequest, existingConnection *model.ClientConnection) (nsm.NSMConnection, error) {
 	requestId := create_logid()
-	logrus.Infof("NSM:(%v) request: %v", requestId, request )
+	logrus.Infof("NSM:(%v) request: %v", requestId, request)
 
 	// 0. Make sure its a valid request
 	err := request.IsValid()
@@ -411,10 +411,10 @@ func (srv *networkServiceManager) performNSERequest(requestId string, ctx contex
 	// 7.2.6.2.5 create cross connection
 	dpApiConnection := srv.createCrossConnect(requestConnection, endpoint, request, nseConnection)
 	clientConnection := &model.ClientConnection{
-		ConnectionId: requestConnection.GetId(),
-		Xcon:         dpApiConnection,
-		Endpoint:     endpoint,
-		Dataplane:    dp,
+		ConnectionId:    requestConnection.GetId(),
+		Xcon:            dpApiConnection,
+		Endpoint:        endpoint,
+		Dataplane:       dp,
 		ConnectionState: model.ClientConnection_Requesting,
 	}
 	// 7.2.6.2.6 - It not a local NSE put remote NSM name in request

--- a/controlplane/pkg/nsm/nsm_heal.go
+++ b/controlplane/pkg/nsm/nsm_heal.go
@@ -18,7 +18,7 @@ func (srv *networkServiceManager) Heal(connection nsm.NSMClientConnection, healS
 		return
 	}
 
-	defer func(){
+	defer func() {
 		logrus.Infof("NSM_Heal(1.1-%v) Connection %v healing state is finished...", healId, clientConnection.GetId())
 		clientConnection.ConnectionState = model.ClientConnection_Ready
 	}()
@@ -86,7 +86,7 @@ func (srv *networkServiceManager) Heal(connection nsm.NSMClientConnection, healS
 		// Update request to contain a proper connection object from previous attempt.
 		request := clientConnection.Request.Clone()
 		request.SetConnection(clientConnection.GetConnectionSource())
-		srv.requestOrClose(fmt.Sprintf("NSM_Heal(3.4-%v) ", healId) ,ctx, request, clientConnection)
+		srv.requestOrClose(fmt.Sprintf("NSM_Heal(3.4-%v) ", healId), ctx, request, clientConnection)
 		return
 	case nsm.HealState_DstUpdate:
 		// Remote DST is updated.
@@ -110,7 +110,7 @@ func (srv *networkServiceManager) Heal(connection nsm.NSMClientConnection, healS
 }
 
 func (srv *networkServiceManager) requestOrClose(logPrefix string, ctx context.Context, request nsm.NSMRequest, clientConnection *model.ClientConnection) {
-	logrus.Infof("%v delegate to Request %v", logPrefix, request )
+	logrus.Infof("%v delegate to Request %v", logPrefix, request)
 	connection, err := srv.request(ctx, request, clientConnection)
 	if err != nil {
 		logrus.Errorf("%v Failed to heal connection: %v", logPrefix, err)

--- a/controlplane/pkg/prefix_pool/prefixpool.go
+++ b/controlplane/pkg/prefix_pool/prefixpool.go
@@ -58,7 +58,7 @@ func (impl *prefixPool) Extract(connectionId string, family connectioncontext.Ip
 		RequiredNumber:  1,
 		RequestedNumber: 1,
 		PrefixLen:       uint32(prefixLen),
-		AddrFamily:        &connectioncontext.IpFamily{Family: family},
+		AddrFamily:      &connectioncontext.IpFamily{Family: family},
 	})
 	if err != nil {
 		return nil, nil, nil, err
@@ -92,7 +92,7 @@ func (impl *prefixPool) Extract(connectionId string, family connectioncontext.Ip
 		ipNet:    ipNet,
 		prefixes: requested,
 	}
-	return &net.IPNet{ IP: src, Mask: ipNet.Mask }, &net.IPNet{ IP: dst, Mask: ipNet.Mask }, requested, nil
+	return &net.IPNet{IP: src, Mask: ipNet.Mask}, &net.IPNet{IP: dst, Mask: ipNet.Mask}, requested, nil
 }
 func (impl *prefixPool) Release(connectionId string) error {
 	impl.Lock()
@@ -118,7 +118,7 @@ func (impl *prefixPool) Release(connectionId string) error {
 	return nil
 }
 
-func (impl* prefixPool) GetConnectionInformation(connectionId string) (string, []string, error) {
+func (impl *prefixPool) GetConnectionInformation(connectionId string) (string, []string, error) {
 	impl.RLock()
 	defer impl.RUnlock()
 	conn := impl.connections[connectionId]

--- a/controlplane/pkg/prefix_pool/prefixpool_test.go
+++ b/controlplane/pkg/prefix_pool/prefixpool_test.go
@@ -76,7 +76,7 @@ func TestExtractPrefixes_1_ipv4(t *testing.T) {
 
 	newPrefixes, prefixes, err := ExtractPrefixes([]string{"10.10.1.0/24"},
 		&connectioncontext.ExtraPrefixRequest{
-			AddrFamily:        &connectioncontext.IpFamily{Family: connectioncontext.IpFamily_IPV4},
+			AddrFamily:      &connectioncontext.IpFamily{Family: connectioncontext.IpFamily_IPV4},
 			RequiredNumber:  10,
 			RequestedNumber: 20,
 			PrefixLen:       31,
@@ -93,7 +93,7 @@ func TestExtractPrefixes_1_ipv6(t *testing.T) {
 
 	newPrefixes, prefixes, err := ExtractPrefixes([]string{"100::/64"},
 		&connectioncontext.ExtraPrefixRequest{
-			AddrFamily:        &connectioncontext.IpFamily{Family: connectioncontext.IpFamily_IPV6},
+			AddrFamily:      &connectioncontext.IpFamily{Family: connectioncontext.IpFamily_IPV6},
 			RequiredNumber:  100,
 			RequestedNumber: 200,
 			PrefixLen:       128,

--- a/dataplane/vppagent/pkg/converter/acl_converter.go
+++ b/dataplane/vppagent/pkg/converter/acl_converter.go
@@ -17,9 +17,9 @@ package converter
 
 import (
 	"fmt"
-	"github.com/networkservicemesh/networkservicemesh/pkg/tools"
 	"github.com/ligato/vpp-agent/plugins/vpp/model/acl"
 	"github.com/ligato/vpp-agent/plugins/vpp/model/rpc"
+	"github.com/networkservicemesh/networkservicemesh/pkg/tools"
 	"github.com/sirupsen/logrus"
 	"net"
 	"strconv"

--- a/dataplane/vppagent/pkg/converter/memif_interface_converter.go
+++ b/dataplane/vppagent/pkg/converter/memif_interface_converter.go
@@ -20,9 +20,9 @@ import (
 	"os"
 	"path"
 
-	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/local/connection"
 	"github.com/ligato/vpp-agent/plugins/vpp/model/interfaces"
 	"github.com/ligato/vpp-agent/plugins/vpp/model/rpc"
+	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/local/connection"
 )
 
 type MemifInterfaceConverter struct {

--- a/dataplane/vppagent/pkg/converter/memif_interface_converter_test.go
+++ b/dataplane/vppagent/pkg/converter/memif_interface_converter_test.go
@@ -1,10 +1,10 @@
 package converter_test
 
 import (
+	"github.com/ligato/vpp-agent/plugins/vpp/model/interfaces"
 	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/connectioncontext"
 	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/local/connection"
 	. "github.com/networkservicemesh/networkservicemesh/dataplane/vppagent/pkg/converter"
-	"github.com/ligato/vpp-agent/plugins/vpp/model/interfaces"
 	. "github.com/onsi/gomega"
 	"os"
 	"path"

--- a/dataplane/vppagent/pkg/converter/remote_connection_converter.go
+++ b/dataplane/vppagent/pkg/converter/remote_connection_converter.go
@@ -17,9 +17,9 @@ package converter
 
 import (
 	"fmt"
-	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/remote/connection"
 	"github.com/ligato/vpp-agent/plugins/vpp/model/interfaces"
 	"github.com/ligato/vpp-agent/plugins/vpp/model/rpc"
+	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/remote/connection"
 	"github.com/sirupsen/logrus"
 )
 

--- a/examples/cmd/vppagent-firewall-nse/vppagent.go
+++ b/examples/cmd/vppagent-firewall-nse/vppagent.go
@@ -20,10 +20,10 @@ import (
 	"time"
 
 	"github.com/grpc-ecosystem/grpc-opentracing/go/otgrpc"
+	"github.com/ligato/vpp-agent/plugins/vpp/model/rpc"
 	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/crossconnect"
 	"github.com/networkservicemesh/networkservicemesh/dataplane/vppagent/pkg/converter"
 	"github.com/networkservicemesh/networkservicemesh/pkg/tools"
-	"github.com/ligato/vpp-agent/plugins/vpp/model/rpc"
 	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc"

--- a/examples/cmd/vppagent-icmp-responder-nse/vppagent.go
+++ b/examples/cmd/vppagent-icmp-responder-nse/vppagent.go
@@ -5,10 +5,10 @@ import (
 	"time"
 
 	"github.com/grpc-ecosystem/grpc-opentracing/go/otgrpc"
+	"github.com/ligato/vpp-agent/plugins/vpp/model/rpc"
 	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/local/connection"
 	"github.com/networkservicemesh/networkservicemesh/dataplane/vppagent/pkg/converter"
 	"github.com/networkservicemesh/networkservicemesh/pkg/tools"
-	"github.com/ligato/vpp-agent/plugins/vpp/model/rpc"
 	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc"

--- a/examples/cmd/vppagent-nsc/vppagent.go
+++ b/examples/cmd/vppagent-nsc/vppagent.go
@@ -5,10 +5,10 @@ import (
 	"time"
 
 	"github.com/grpc-ecosystem/grpc-opentracing/go/otgrpc"
+	"github.com/ligato/vpp-agent/plugins/vpp/model/rpc"
 	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/local/connection"
 	"github.com/networkservicemesh/networkservicemesh/dataplane/vppagent/pkg/converter"
 	"github.com/networkservicemesh/networkservicemesh/pkg/tools"
-	"github.com/ligato/vpp-agent/plugins/vpp/model/rpc"
 	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc"

--- a/test/kube_testing/pods/jaeger.go
+++ b/test/kube_testing/pods/jaeger.go
@@ -8,12 +8,12 @@ import (
 func JaegerService(pod *v1.Pod) *v1.Service {
 	return &v1.Service{
 		ObjectMeta: v12.ObjectMeta{
-			Name: pod.Name,
+			Name:   pod.Name,
 			Labels: map[string]string{"run": pod.Name},
 		},
-		Spec: v1.ServiceSpec {
+		Spec: v1.ServiceSpec{
 			Ports: []v1.ServicePort{
-				{Name:"http", Port: 16686, Protocol: "TCP"},
+				{Name: "http", Port: 16686, Protocol: "TCP"},
 				{Name: "jaeger", Port: 6831, Protocol: "UDP"},
 			},
 			Selector: map[string]string{"run": "jaeger"},
@@ -37,14 +37,13 @@ func Jaeger() *v1.Pod {
 					Name:            "jaeger",
 					Image:           "jaegertracing/all-in-one:latest",
 					ImagePullPolicy: v1.PullIfNotPresent,
-					Ports: []v1.ContainerPort {
-						{Name: "http", ContainerPort: 16686, Protocol:"TCP"},
-						{Name: "jaeger", ContainerPort: 6831, Protocol:"UDP"},
+					Ports: []v1.ContainerPort{
+						{Name: "http", ContainerPort: 16686, Protocol: "TCP"},
+						{Name: "jaeger", ContainerPort: 6831, Protocol: "UDP"},
 					},
 				},
 			},
 		},
-
 	}
 	return pod
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The changes consist of adding another check in the Circle CI configuration file to run a `go fmt` check and fail the build if it finds something that is not compliant.

The first commit is with the changes related to enabling that kind of check in the CI configuration and the second applies the result from running a `go fmt ./... or make format` locally.

**Update:**
Thought that it would be useful to add an additional `golint` run(not breaking the build if errors are found though).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Using `go fmt` makes the code easier to read and write and overall it helps to keep it in better shape.

Also most of the IDEs already have `go fmt` plugins that run upon saving which forces having the content of the file formatted.
## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [ ] Covered by existing integration testing
- [ ] Added integration testing to cover
- [x] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.