### PR TITLE
Specify namespace for NSM

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,6 +112,9 @@ jobs:
       gke_project_id:
         type: string
         default: "ci-management"
+      namespace:
+        type: string
+        default: "default"
     working_directory: /go/src/github.com/networkservicemesh/networkservicemesh
     docker:
       - image: circleci/golang
@@ -190,6 +193,7 @@ jobs:
       CLOUD_PROVIDER: "<< parameters.cloud_provider >>"
       KUBECONFIG: /home/circleci/project/data/kubeconfig
       GO111MODULE: "on"
+      NSM_NAMESPACE: "<< parameters.namespace >>"
 
   packet-destroy:
     docker:
@@ -446,6 +450,7 @@ workflows:
             - packet-deploy
       - integration-tests:
           name: "packet-test-basic-usecase"
+          namespace: "nsm-system-integration"
           cloud_provider: "packet"
           cluster_id: "1"
           test_tags: "basic usecase"
@@ -453,6 +458,7 @@ workflows:
             - packet-deploy-k8s-1
       - integration-tests:
           name: "packet-test-recover"
+          namespace: "nsm-system-integration"
           cloud_provider: "packet"
           cluster_id: "2"
           test_tags: "recover"
@@ -460,6 +466,7 @@ workflows:
             - packet-deploy-k8s-2
       - integration-tests:
           name: "packet-test-bench"
+          namespace: "nsm-system-integration"
           cloud_provider: "packet"
           cluster_id: "2"
           test_tags: "bench"

--- a/.mk/integration.mk
+++ b/.mk/integration.mk
@@ -13,14 +13,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+NSM_NAMESPACE?=nsm-system-integration
+
 .PHONY: k8s-integration-config
 k8s-integration-config:
 	@./scripts/prepare-circle-integration-tests.sh
 
 .PHONY: k8s-integration-tests
 k8s-integration-tests: k8s-integration-config
-	@GO111MODULE=on go test -v ./test/... -failfast -timeout 30m -tags="basic recover usecase"
+	@GO111MODULE=on NSM_NAMESPACE=${NSM_NAMESPACE} go test -v ./test/... -failfast -timeout 30m -tags="basic recover usecase"
 
 .PHONY: k8s-integration-%-test
 k8s-integration-%-test: k8s-integration-config
-	@GO111MODULE=on BROKEN_TESTS_ENABLED=on go test -v ./test/... -failfast -tags="basic recover usecase" -run $*
+	@GO111MODULE=on BROKEN_TESTS_ENABLED=on NSM_NAMESPACE=${NSM_NAMESPACE} go test -v ./test/... -failfast -tags="basic recover usecase" -run $*

--- a/.mk/k8s.mk
+++ b/.mk/k8s.mk
@@ -28,7 +28,10 @@ DEPLOYS = $(DEPLOY_INFRA) $(DEPLOY_ICMP) $(DEPLOY_VPN)
 
 CLUSTER_CONFIG_ROLE = cluster-role-admin cluster-role-binding cluster-role-view
 CLUSTER_CONFIG_CRD = crd-networkservices crd-networkserviceendpoints crd-networkservicemanagers
-CLUSTER_CONFIGS = $(CLUSTER_CONFIG_ROLE) $(CLUSTER_CONFIG_CRD)
+CLUSTER_CONFIG_NAMESPACE = namespace-nsm
+CLUSTER_CONFIGS = $(CLUSTER_CONFIG_ROLE) $(CLUSTER_CONFIG_CRD) $(CLUSTER_CONFIG_NAMESPACE)
+
+NSM_NAMESPACE = `cat "${K8S_CONF_DIR}/${CLUSTER_CONFIG_NAMESPACE}.yaml" | awk '/name:/ {print $$2}'`
 
 # All of the rules that use vagrant are intentionally written in such a way
 # That you could set the CLUSTER_RULES_PREFIX different and introduce
@@ -294,7 +297,7 @@ k8s-admission-webhook-load-images:  k8s-start $(addsuffix -load-images,$(addpref
 
 .PHONY: k8s-admission-webhook-create-cert
 k8s-admission-webhook-create-cert:
-	./scripts/webhook-create-cert.sh
+	@NSM_NAMESPACE=${NSM_NAMESPACE} ./scripts/webhook-create-cert.sh
 
 .PHONY: k8s-admission-webhook-delete-cert
 k8s-admission-webhook-delete-cert:

--- a/controllers/sriov-controller/README.md
+++ b/controllers/sriov-controller/README.md
@@ -68,7 +68,7 @@ metadata:
   labels:
     networkservicemesh.io/sriov: ""
   name: nsm-sriov-vf-list
-  namespace: default
+  namespace: nsm-system
 ```
 
 Here is example for a deployment requesting 4 SRIOV network services
@@ -103,5 +103,5 @@ spec:
               networkservicemesh.io/sriov-ns-4: 1    
 metadata:
    name: nsm-sriov
-   namespace: default
+   namespace: nsm-system
 ```

--- a/controllers/sriov-controller/sriov-client.yaml
+++ b/controllers/sriov-controller/sriov-client.yaml
@@ -37,4 +37,4 @@ spec:
                 - SYS_RESOURCE
 metadata:
   name: nsm-sriov-client
-  namespace: default
+  namespace: nsm-system

--- a/controllers/sriov-controller/sriov-controller.yaml
+++ b/controllers/sriov-controller/sriov-controller.yaml
@@ -19,7 +19,7 @@ metadata:
   name: sriov-controller-binding
 subjects:
   - kind: ServiceAccount
-    namespace: default
+    namespace: nsm-system
     name: sriov-controller
 roleRef:
   kind: ClusterRole
@@ -63,4 +63,4 @@ spec:
           name: sriov-controller-config
 metadata:
   name: sriov-controller
-  namespace: default
+  namespace: nsm-system

--- a/deployments/helm/icmp-responder/templates/icmp-responder-nse.tpl
+++ b/deployments/helm/icmp-responder/templates/icmp-responder-nse.tpl
@@ -45,4 +45,4 @@ spec:
               networkservicemesh.io/socket: 1
 metadata:
   name: icmp-responder-nse
-  namespace: default
+  namespace: nsm-system

--- a/deployments/helm/icmp-responder/templates/nsc.yaml
+++ b/deployments/helm/icmp-responder/templates/nsc.yaml
@@ -19,6 +19,6 @@ spec:
           command: ['tail', '-f', '/dev/null']
 metadata:
   name: nsc-vpp
-  namespace: default
+  namespace: nsm-system
   annotations:
     ns.networkservicemesh.io: icmp-responder?app=icmp

--- a/deployments/helm/nsm-monitoring/templates/crossconnect-monitor.tpl
+++ b/deployments/helm/nsm-monitoring/templates/crossconnect-monitor.tpl
@@ -16,4 +16,4 @@ spec:
           imagePullPolicy: {{ .Values.pullPolicy }}
 metadata:
   name: crossconnect-monitor
-  namespace: default
+  namespace: nsm-system

--- a/deployments/helm/nsm/charts/admission-webhook/templates/admission-webhook-secret.tpl
+++ b/deployments/helm/nsm/charts/admission-webhook/templates/admission-webhook-secret.tpl
@@ -8,6 +8,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: nsm-admission-webhook-certs
+  namespace: nsm-system
 type: Opaque
 data:
   key.pem: {{ $cert.Key | b64enc }}
@@ -17,6 +18,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: nsm-admission-webhook
+  namespace: nsm-system
   labels:
     app: nsm-admission-webhook
 spec:
@@ -46,6 +48,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: nsm-admission-webhook-svc
+  namespace: nsm-system
   labels:
     app: nsm-admission-webhook
 spec:
@@ -66,7 +69,7 @@ webhooks:
     clientConfig:
       service:
         name: nsm-admission-webhook-svc
-        namespace: default
+        namespace: nsm-system
         path: "/mutate"
       caBundle: {{ $ca.Cert | b64enc }}
     rules:

--- a/deployments/helm/nsm/templates/cluster-role-binding.yaml
+++ b/deployments/helm/nsm/templates/cluster-role-binding.yaml
@@ -10,4 +10,4 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: default
-    namespace: default
+    namespace: nsm-system

--- a/deployments/helm/nsm/templates/vppagent-dataplane.tpl
+++ b/deployments/helm/nsm/templates/vppagent-dataplane.tpl
@@ -48,4 +48,4 @@ spec:
           name: workspace
 metadata:
   name: nsm-vppagent-dataplane
-  namespace: default
+  namespace: nsm-system

--- a/deployments/helm/vpn/templates/vpn-gateway-nsc.tpl
+++ b/deployments/helm/vpn/templates/vpn-gateway-nsc.tpl
@@ -22,6 +22,6 @@ spec:
           command: ['tail', '-f', '/dev/null']
 metadata:
   name: vpn-gateway-nsc
-  namespace: default
+  namespace: nsm-system
   annotations:
     ns.networkservicemesh.io: secure-intranet-connectivity

--- a/deployments/helm/vpn/templates/vpn-gateway-nse.tpl
+++ b/deployments/helm/vpn/templates/vpn-gateway-nse.tpl
@@ -43,4 +43,4 @@ spec:
           image: {{ .Values.registry }}/networkservicemesh/nginx:{{ .Values.tag }}
 metadata:
   name: vpn-gateway-nse
-  namespace: default
+  namespace: nsm-system

--- a/deployments/helm/vpn/templates/vppagent-firewall-nse.tpl
+++ b/deployments/helm/vpn/templates/vppagent-firewall-nse.tpl
@@ -41,12 +41,13 @@ spec:
             name: vppagent-firewall-config-file
 metadata:
   name: vppagent-firewall-nse
-  namespace: default
+  namespace: nsm-system
 ---
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: vppagent-firewall-config-file
+  namespace: nsm-system
 data:
   config.yaml: |
     aclRules:

--- a/deployments/helm/vpp-icmp-responder/templates/vppagent-icmp-responder-nse.tpl
+++ b/deployments/helm/vpp-icmp-responder/templates/vppagent-icmp-responder-nse.tpl
@@ -45,4 +45,4 @@ spec:
               networkservicemesh.io/socket: 1
 metadata:
   name: vppagent-icmp-responder-nse
-  namespace: default
+  namespace: nsm-system

--- a/deployments/helm/vpp-icmp-responder/templates/vppagent-nsc.tpl
+++ b/deployments/helm/vpp-icmp-responder/templates/vppagent-nsc.tpl
@@ -28,4 +28,4 @@ spec:
               networkservicemesh.io/socket: 1
 metadata:
   name: vppagent-nsc
-  namespace: default
+  namespace: nsm-system

--- a/docs/guide-debug.md
+++ b/docs/guide-debug.md
@@ -121,7 +121,7 @@ In integration test please create NSMD with following options:
 
 ```go
 nodes := nsmd_test_utils.SetupNodesConfig(k8s, 1, defaultTimeout, []*pods.NSMgrPodConfig{
-    &pods.NSMgrPodConfig{Nsmd:pods.NSMgrContainerRun},
+    &pods.NSMgrPodConfig{Nsmd:pods.NSMgrContainerRun, Namespace: k8s.GetK8sNamespace()},
 })
 ```
 

--- a/docs/guide-quickstart.md
+++ b/docs/guide-quickstart.md
@@ -61,13 +61,13 @@ make k8s-infra-deploy
 The following check should show two `nsmgr`, two `nsm-vppagent-dataplane`, two `skydive-agent`, one `crossconnect-monitor` and one `skydive-analyzer` pods:
 
 ```bash
-kubectl get pods
+kubectl get pods -n nsm-system
 ```
 
 This will allow you to see your Network Service Mesh daemonset running:
 
 ```bash
-kubectl get daemonset nsmgr
+kubectl get daemonset nsmgr -n nsm-system
 
 
 NAME   DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR   AGE

--- a/k8s/cmd/crossconnect-monitor/crossconnect_monitor.go
+++ b/k8s/cmd/crossconnect-monitor/crossconnect_monitor.go
@@ -15,6 +15,7 @@ import (
 	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/crossconnect"
 	"github.com/networkservicemesh/networkservicemesh/k8s/pkg/networkservice/clientset/versioned"
+	"github.com/networkservicemesh/networkservicemesh/k8s/pkg/networkservice/namespace"
 	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -92,8 +93,9 @@ func lookForNSMServers() {
 		logrus.Fatalln("Unable to initialize nsmd-k8s", err)
 	}
 
+	nsmNamespace := namespace.GetNamespace()
 	for !closing {
-		result, err := nsmClientSet.Networkservicemesh().NetworkServiceManagers("default").List(metav1.ListOptions{})
+		result, err := nsmClientSet.Networkservicemesh().NetworkServiceManagers(nsmNamespace).List(metav1.ListOptions{})
 		if err != nil {
 			logrus.Fatalln("Unable to find NSMs", err)
 		}

--- a/k8s/conf/admission-webhook-cfg.yaml
+++ b/k8s/conf/admission-webhook-cfg.yaml
@@ -4,12 +4,13 @@ metadata:
   name: nsm-admission-webhook-cfg
   labels:
     app: nsm-admission-webhook
+  namespace: nsm-system
 webhooks:
   - name: admission-webhook.networkservicemesh.io
     clientConfig:
       service:
         name: nsm-admission-webhook-svc
-        namespace: default
+        namespace: nsm-system
         path: "/mutate"
       caBundle: ${CA_BUNDLE}
     rules:

--- a/k8s/conf/admission-webhook.yaml
+++ b/k8s/conf/admission-webhook.yaml
@@ -4,6 +4,7 @@ metadata:
   name: nsm-admission-webhook
   labels:
     app: nsm-admission-webhook
+  namespace: nsm-system
 spec:
   replicas: 1
   selector:
@@ -33,6 +34,7 @@ metadata:
   name: nsm-admission-webhook-svc
   labels:
     app: nsm-admission-webhook
+  namespace: nsm-system
 spec:
   ports:
     - port: 443

--- a/k8s/conf/cluster-role-binding.yaml
+++ b/k8s/conf/cluster-role-binding.yaml
@@ -10,4 +10,4 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: default
-    namespace: default
+    namespace: nsm-system

--- a/k8s/conf/crossconnect-monitor.yaml
+++ b/k8s/conf/crossconnect-monitor.yaml
@@ -16,4 +16,4 @@ spec:
           imagePullPolicy: IfNotPresent
 metadata:
   name: crossconnect-monitor
-  namespace: default
+  namespace: nsm-system

--- a/k8s/conf/icmp-responder-nse.yaml
+++ b/k8s/conf/icmp-responder-nse.yaml
@@ -45,4 +45,4 @@ spec:
               networkservicemesh.io/socket: 1
 metadata:
   name: icmp-responder-nse
-  namespace: default
+  namespace: nsm-system

--- a/k8s/conf/jaeger.yaml
+++ b/k8s/conf/jaeger.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: jaeger
+  namespace: nsm-system
 spec:
   selector:
     matchLabels:
@@ -29,6 +30,7 @@ metadata:
   name: jaeger
   labels:
     run: jaeger
+  namespace: nsm-system
 spec:
   ports:
     - name: http

--- a/k8s/conf/namespace-nsm.yaml
+++ b/k8s/conf/namespace-nsm.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: nsm-system

--- a/k8s/conf/nsc.yaml
+++ b/k8s/conf/nsc.yaml
@@ -17,6 +17,6 @@ spec:
           command: ['tail', '-f', '/dev/null']
 metadata:
   name: nsc-vpp
-  namespace: default
+  namespace: nsm-system
   annotations:
     ns.networkservicemesh.io: icmp-responder?app=icmp

--- a/k8s/conf/nsmgr.yaml
+++ b/k8s/conf/nsmgr.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: nsmgr
+  namespace: nsm-system
 spec:
   selector:
     matchLabels:

--- a/k8s/conf/skydive.yaml
+++ b/k8s/conf/skydive.yaml
@@ -4,6 +4,7 @@ metadata:
   name: skydive-analyzer
   labels:
     app: skydive-analyzer
+  namespace: nsm-system
 spec:
   type: NodePort
   ports:
@@ -24,6 +25,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: skydive-analyzer-config-file
+  namespace: nsm-system
 data:
   skydive.yml: |
     storage:
@@ -54,7 +56,7 @@ data:
     ui:
       topology:
         favorites:
-          nsm-filter: "G.V().Has('Type', 'container', 'Docker.Labels.io.kubernetes.pod.namespace', 'default').In('Type', 'netns').Descendants().As('namespaces').G.V().Has('Type', 'host').As('hosts').Select('namespaces', 'hosts')"
+          nsm-filter: "G.V().Has('Type', 'container', 'Docker.Labels.io.kubernetes.pod.namespace', 'nsm-system').In('Type', 'netns').Descendants().As('namespaces').G.V().Has('Type', 'host').As('hosts').Select('namespaces', 'hosts')"
           nsm-filter-secure-intranet-connectivity: "G.V().Has('Type', 'container', 'Docker.Labels.networkservicemesh.io/impl', 'secure-intranet-connectivity').In('Type', 'netns').Descendants().As('namespaces').G.V().Has('Type', 'host').As('hosts').Select('namespaces', 'hosts')"
           nsm-edges: "G.E().HasKey('NSM')"
 
@@ -65,6 +67,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: skydive-analyzer
+  namespace: nsm-system
 spec:
   selector:
     matchLabels:
@@ -109,6 +112,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: skydive-agent
+  namespace: nsm-system
 spec:
   selector:
     matchLabels:

--- a/k8s/conf/vpn-gateway-nsc.yaml
+++ b/k8s/conf/vpn-gateway-nsc.yaml
@@ -20,6 +20,6 @@ spec:
           command: ['tail', '-f', '/dev/null']
 metadata:
   name: vpn-gateway-nsc
-  namespace: default
+  namespace: nsm-system
   annotations:
     ns.networkservicemesh.io: secure-intranet-connectivity

--- a/k8s/conf/vpn-gateway-nse.yaml
+++ b/k8s/conf/vpn-gateway-nse.yaml
@@ -43,4 +43,4 @@ spec:
           image: networkservicemesh/nginx
 metadata:
   name: vpn-gateway-nse
-  namespace: default
+  namespace: nsm-system

--- a/k8s/conf/vppagent-dataplane.yaml
+++ b/k8s/conf/vppagent-dataplane.yaml
@@ -53,4 +53,4 @@ spec:
           name: workspace
 metadata:
   name: nsm-vppagent-dataplane
-  namespace: default
+  namespace: nsm-system

--- a/k8s/conf/vppagent-firewall-nse.yaml
+++ b/k8s/conf/vppagent-firewall-nse.yaml
@@ -41,12 +41,13 @@ spec:
             name: vppagent-firewall-config-file
 metadata:
   name: vppagent-firewall-nse
-  namespace: default
+  namespace: nsm-system
 ---
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: vppagent-firewall-config-file
+  namespace: nsm-system
 data:
   config.yaml: |
     aclRules:

--- a/k8s/conf/vppagent-icmp-responder-nse.yaml
+++ b/k8s/conf/vppagent-icmp-responder-nse.yaml
@@ -45,4 +45,4 @@ spec:
               networkservicemesh.io/socket: 1
 metadata:
   name: vppagent-icmp-responder-nse
-  namespace: default
+  namespace: nsm-system

--- a/k8s/conf/vppagent-nsc.yaml
+++ b/k8s/conf/vppagent-nsc.yaml
@@ -28,4 +28,4 @@ spec:
               networkservicemesh.io/socket: 1
 metadata:
   name: vppagent-nsc
-  namespace: default
+  namespace: nsm-system

--- a/k8s/pkg/networkservice/namespace/nsm.go
+++ b/k8s/pkg/networkservice/namespace/nsm.go
@@ -1,0 +1,28 @@
+// Copyright 2019 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package namespace
+
+import "os"
+
+const NsmNamespaceEnv = "NSM_NAMESPACE"
+
+func GetNamespace() string {
+	if ns := os.Getenv(NsmNamespaceEnv); len(ns) > 0 {
+		return ns
+	}
+
+	return "default"
+}

--- a/test/integration/basic_excluded_prefixes_test.go
+++ b/test/integration/basic_excluded_prefixes_test.go
@@ -38,15 +38,16 @@ func TestExcludePrefixCheck(t *testing.T) {
 	nodes := nsmd_test_utils.SetupNodesConfig(k8s, nodesCount, defaultTimeout, []*pods.NSMgrPodConfig{
 		{
 			Variables: variables,
+			Namespace: k8s.GetK8sNamespace(),
 		},
-	})
+	}, k8s.GetK8sNamespace())
 
 	icmp := nsmd_test_utils.DeployICMP(k8s, nodes[0].Node, "icmp-responder-nse-1", defaultTimeout)
 
 	clientset, err := k8s.GetClientSet()
 	Expect(err).To(BeNil())
 
-	_, err = clientset.CoreV1().Pods("default").Create(pods.NSCPod("nsc", nodes[0].Node,
+	_, err = clientset.CoreV1().Pods(k8s.GetK8sNamespace()).Create(pods.NSCPod("nsc", nodes[0].Node,
 		map[string]string{
 			"OUTGOING_NSC_LABELS": "app=icmp",
 			"OUTGOING_NSC_NAME":   "icmp-responder",

--- a/test/integration/basic_memif_test.go
+++ b/test/integration/basic_memif_test.go
@@ -3,11 +3,12 @@
 package nsmd_integration_tests
 
 import (
+	"testing"
+
 	"github.com/networkservicemesh/networkservicemesh/test/integration/nsmd_test_utils"
 	"github.com/networkservicemesh/networkservicemesh/test/kube_testing"
 	"github.com/networkservicemesh/networkservicemesh/test/kube_testing/pods"
 	. "github.com/onsi/gomega"
-	"testing"
 )
 
 func TestSimpleMemifConnection(t *testing.T) {
@@ -25,7 +26,7 @@ func TestSimpleMemifConnection(t *testing.T) {
 
 	k8s.PrepareDefault()
 
-	nodes := nsmd_test_utils.SetupNodesConfig(k8s, 1, defaultTimeout, []*pods.NSMgrPodConfig{})
+	nodes := nsmd_test_utils.SetupNodesConfig(k8s, 1, defaultTimeout, []*pods.NSMgrPodConfig{}, k8s.GetK8sNamespace())
 
 	nsmd_test_utils.DeployVppAgentICMP(k8s, nodes[0].Node, "icmp-responder", defaultTimeout)
 	vppagentNsc := nsmd_test_utils.DeployVppAgentNSC(k8s, nodes[0].Node, "vppagent-nsc", defaultTimeout)

--- a/test/integration/basic_namespace_test.go
+++ b/test/integration/basic_namespace_test.go
@@ -1,0 +1,25 @@
+// +build basic
+
+package nsmd_integration_tests
+
+import (
+	"testing"
+
+	"github.com/networkservicemesh/networkservicemesh/test/kube_testing"
+	"k8s.io/api/core/v1"
+
+	. "github.com/onsi/gomega"
+)
+
+func Test_createNSMNamespace(t *testing.T) {
+	RegisterTestingT(t)
+
+	k8s, err := kube_testing.NewK8s()
+	defer k8s.Cleanup()
+
+	namespaceName := k8s.GetK8sNamespace()
+	namespace, err := k8s.GetNamespace(namespaceName)
+
+	Expect(err).To(BeNil())
+	Expect(namespace.Status.Phase).To(Equal(v1.NamespaceActive))
+}

--- a/test/integration/basic_nsmd_deploy_test.go
+++ b/test/integration/basic_nsmd_deploy_test.go
@@ -24,7 +24,7 @@ func TestNSMgrDdataplaneDeployLiveCheck(t *testing.T) {
 	testNSMgrDdataplaneDeploy(t, pods.NSMgrPodLiveCheck, pods.VPPDataplanePodLiveCheck)
 }
 
-func testNSMgrDdataplaneDeploy(t *testing.T, nsmdPodFactory func(string, *v1.Node) *v1.Pod, dataplanePodFactory func(string, *v1.Node) *v1.Pod) {
+func testNSMgrDdataplaneDeploy(t *testing.T, nsmdPodFactory func(string, *v1.Node, string) *v1.Pod, dataplanePodFactory func(string, *v1.Node) *v1.Pod) {
 	RegisterTestingT(t)
 
 	if testing.Short() {

--- a/test/integration/basic_nsmd_k8s_test.go
+++ b/test/integration/basic_nsmd_k8s_test.go
@@ -5,10 +5,11 @@ package nsmd_integration_tests
 import (
 	"context"
 	"fmt"
-	"github.com/networkservicemesh/networkservicemesh/test/integration/nsmd_test_utils"
 	"net"
 	"testing"
 	"time"
+
+	"github.com/networkservicemesh/networkservicemesh/test/integration/nsmd_test_utils"
 
 	"github.com/golang/protobuf/ptypes/empty"
 
@@ -36,7 +37,7 @@ func TestNSMDDRegistryNSE(t *testing.T) {
 
 	k8s.PrepareDefault()
 
-	nsmd := k8s.CreatePod(pods.NSMgrPod("nsmgr-1", nil))
+	nsmd := k8s.CreatePod(pods.NSMgrPod("nsmgr-1", nil, k8s.GetK8sNamespace()))
 
 	k8s.WaitLogsContains(nsmd, "nsmd", "NSMD: Restore of NSE/Clients Complete...", defaultTimeout)
 
@@ -146,7 +147,7 @@ func TestUpdateNSM(t *testing.T) {
 	k8s.CleanupCRDs()
 
 	k8s.PrepareDefault()
-	nsmd := k8s.CreatePod(pods.NSMgrPod("nsmgr-1", nil))
+	nsmd := k8s.CreatePod(pods.NSMgrPod("nsmgr-1", nil, k8s.GetK8sNamespace()))
 
 	fwd, err := k8s.NewPortForwarder(nsmd, 5000)
 	Expect(err).To(BeNil())
@@ -370,7 +371,7 @@ func TestLostUpdate(t *testing.T) {
 	k8s.CleanupCRDs()
 
 	k8s.PrepareDefault()
-	nsmd := k8s.CreatePod(pods.NSMgrPod("nsmgr-1", nil))
+	nsmd := k8s.CreatePod(pods.NSMgrPod("nsmgr-1", nil, k8s.GetK8sNamespace()))
 
 	// We need to wait until it is started
 	k8s.WaitLogsContains(nsmd, "nsmd-k8s", "nsmd-k8s initialized and waiting for connection", fastTimeout)
@@ -420,7 +421,7 @@ func TestLostUpdate(t *testing.T) {
 
 	k8s.DeletePods(nsmd)
 	fwd.Stop()
-	nsmgr2 := k8s.CreatePod(pods.NSMgrPod("nsmgr-2", nil))
+	nsmgr2 := k8s.CreatePod(pods.NSMgrPod("nsmgr-2", nil, k8s.GetK8sNamespace()))
 
 	fwd, err = k8s.NewPortForwarder(nsmgr2, 5000)
 	Expect(err).To(BeNil())

--- a/test/integration/basic_nsmdp_test.go
+++ b/test/integration/basic_nsmdp_test.go
@@ -3,12 +3,13 @@
 package nsmd_integration_tests
 
 import (
+	"testing"
+	"time"
+
 	"github.com/networkservicemesh/networkservicemesh/test/integration/nsmd_test_utils"
 	"github.com/networkservicemesh/networkservicemesh/test/kube_testing"
 	"github.com/networkservicemesh/networkservicemesh/test/kube_testing/pods"
 	. "github.com/onsi/gomega"
-	"testing"
-	"time"
 )
 
 func TestNSMDDP(t *testing.T) {
@@ -26,14 +27,14 @@ func TestNSMDDP(t *testing.T) {
 
 	k8s.PrepareDefault()
 
-	nodes := nsmd_test_utils.SetupNodesConfig(k8s, 1, defaultTimeout, []*pods.NSMgrPodConfig{})
+	nodes := nsmd_test_utils.SetupNodesConfig(k8s, 1, defaultTimeout, []*pods.NSMgrPodConfig{}, k8s.GetK8sNamespace())
 	icmpPod := nsmd_test_utils.DeployICMP(k8s, nodes[0].Node, "icmp-responder-nse-1", defaultTimeout)
 
 	nsmdName := nodes[0].Nsmd.Name
 	k8s.DeletePods(nodes[0].Nsmd)
 	k8s.DeletePods(icmpPod)
 	time.Sleep(10 * time.Second)
-	nodes[0].Nsmd = k8s.CreatePod(pods.NSMgrPodWithConfig(nsmdName, nodes[0].Node, &pods.NSMgrPodConfig{})) // Recovery NSEs
+	nodes[0].Nsmd = k8s.CreatePod(pods.NSMgrPodWithConfig(nsmdName, nodes[0].Node, &pods.NSMgrPodConfig{Namespace: k8s.GetK8sNamespace()})) // Recovery NSEs
 	icmpPod = nsmd_test_utils.DeployICMP(k8s, nodes[0].Node, "icmp-responder-nse-2", defaultTimeout)
 	Expect(icmpPod).ToNot(BeNil())
 }
@@ -53,7 +54,7 @@ func TestNSMDRecoverNSE(t *testing.T) {
 
 	k8s.PrepareDefault()
 
-	nodes := nsmd_test_utils.SetupNodesConfig(k8s, 1, defaultTimeout, []*pods.NSMgrPodConfig{})
+	nodes := nsmd_test_utils.SetupNodesConfig(k8s, 1, defaultTimeout, []*pods.NSMgrPodConfig{}, k8s.GetK8sNamespace())
 	icmpPod := nsmd_test_utils.DeployICMP(k8s, nodes[0].Node, "icmp-responder-nse-1", defaultTimeout)
 
 	nsmdName := nodes[0].Nsmd.Name
@@ -61,7 +62,7 @@ func TestNSMDRecoverNSE(t *testing.T) {
 	k8s.DeletePods(icmpPod)
 	time.Sleep(10 * time.Second)
 
-	nodes[0].Nsmd = k8s.CreatePod(pods.NSMgrPodWithConfig(nsmdName, nodes[0].Node, &pods.NSMgrPodConfig{})) // Recovery NSEs
+	nodes[0].Nsmd = k8s.CreatePod(pods.NSMgrPodWithConfig(nsmdName, nodes[0].Node, &pods.NSMgrPodConfig{Namespace: k8s.GetK8sNamespace()})) // Recovery NSEs
 	icmpPod = nsmd_test_utils.DeployICMP(k8s, nodes[0].Node, "icmp-responder-nse-2", defaultTimeout)
 	Expect(icmpPod).ToNot(BeNil())
 }

--- a/test/integration/bench_memif_test.go
+++ b/test/integration/bench_memif_test.go
@@ -3,13 +3,14 @@
 package nsmd_integration_tests
 
 import (
+	"strconv"
+	"testing"
+
 	"github.com/networkservicemesh/networkservicemesh/test/integration/nsmd_test_utils"
 	"github.com/networkservicemesh/networkservicemesh/test/kube_testing"
 	"github.com/networkservicemesh/networkservicemesh/test/kube_testing/pods"
 	. "github.com/onsi/gomega"
 	"k8s.io/api/core/v1"
-	"strconv"
-	"testing"
 )
 
 const (
@@ -114,7 +115,7 @@ type nscPingResult struct {
 }
 
 func createNode(k8s *kube_testing.K8s) *v1.Node {
-	nodes := nsmd_test_utils.SetupNodesConfig(k8s, 1, defaultTimeout, []*pods.NSMgrPodConfig{})
+	nodes := nsmd_test_utils.SetupNodesConfig(k8s, 1, defaultTimeout, []*pods.NSMgrPodConfig{}, k8s.GetK8sNamespace())
 	Expect(len(nodes), 1)
 	return nodes[0].Node
 }

--- a/test/integration/recover_death_handling_test.go
+++ b/test/integration/recover_death_handling_test.go
@@ -3,12 +3,13 @@
 package nsmd_integration_tests
 
 import (
-	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/nsm"
-	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/nsmd"
-	"github.com/networkservicemesh/networkservicemesh/test/kube_testing/pods"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/nsm"
+	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/nsmd"
+	"github.com/networkservicemesh/networkservicemesh/test/kube_testing/pods"
 
 	"github.com/networkservicemesh/networkservicemesh/test/integration/nsmd_test_utils"
 	"github.com/networkservicemesh/networkservicemesh/test/kube_testing"
@@ -78,7 +79,9 @@ func testDie(t *testing.T, killSrc bool, nodesCount int) {
 	k8s.PrepareDefault()
 	logrus.Printf("Cleanup done: %v", time.Since(s1))
 
-	nodes := nsmd_test_utils.SetupNodesConfig(k8s, nodesCount, defaultTimeout, []*pods.NSMgrPodConfig{NSENoHeal, NSENoHeal})
+	NSENoHeal.Namespace = k8s.GetK8sNamespace()
+
+	nodes := nsmd_test_utils.SetupNodesConfig(k8s, nodesCount, defaultTimeout, []*pods.NSMgrPodConfig{NSENoHeal, NSENoHeal}, k8s.GetK8sNamespace())
 
 	failures := InterceptGomegaFailures(func() {
 		icmp := nsmd_test_utils.DeployICMP(k8s, nodes[nodesCount-1].Node, "icmp-responder-nse-1", defaultTimeout)

--- a/test/integration/recover_nse_nsm_heal_test.go
+++ b/test/integration/recover_nse_nsm_heal_test.go
@@ -4,10 +4,11 @@ package nsmd_integration_tests
 
 import (
 	"fmt"
-	"github.com/networkservicemesh/networkservicemesh/test/integration/nsmd_test_utils"
-	"github.com/networkservicemesh/networkservicemesh/test/kube_testing/pods"
 	"testing"
 	"time"
+
+	"github.com/networkservicemesh/networkservicemesh/test/integration/nsmd_test_utils"
+	"github.com/networkservicemesh/networkservicemesh/test/kube_testing/pods"
 
 	"github.com/networkservicemesh/networkservicemesh/test/kube_testing"
 	. "github.com/onsi/gomega"
@@ -56,7 +57,7 @@ func TestNSMHealLocalDieNSMD(t *testing.T) {
 
 	logrus.Infof("Starting recovered NSMD...")
 	startTime := time.Now()
-	nodes_setup[0].Nsmd = k8s.CreatePod(pods.NSMgrPodWithConfig(nsmdName, nodes_setup[0].Node, &pods.NSMgrPodConfig{})) // Recovery NSEs
+	nodes_setup[0].Nsmd = k8s.CreatePod(pods.NSMgrPodWithConfig(nsmdName, nodes_setup[0].Node, &pods.NSMgrPodConfig{Namespace: k8s.GetK8sNamespace()})) // Recovery NSEs
 	logrus.Printf("Started new NSMD: %v on node %s", time.Since(startTime), nodes_setup[0].Node.Name)
 
 	failures = InterceptGomegaFailures(func() {
@@ -122,7 +123,7 @@ func testNSMHealLocalDieNSMDOneNode(t *testing.T, deployNsc, deployNse nsmd_test
 
 	logrus.Infof("Starting recovered NSMD...")
 	startTime := time.Now()
-	nodes_setup[0].Nsmd = k8s.CreatePod(pods.NSMgrPodWithConfig(nsmdName, nodes_setup[0].Node, &pods.NSMgrPodConfig{})) // Recovery NSEs
+	nodes_setup[0].Nsmd = k8s.CreatePod(pods.NSMgrPodWithConfig(nsmdName, nodes_setup[0].Node, &pods.NSMgrPodConfig{Namespace: k8s.GetK8sNamespace()})) // Recovery NSEs
 	logrus.Printf("Started new NSMD: %v on node %s", time.Since(startTime), nodes_setup[0].Node.Name)
 
 	failures = InterceptGomegaFailures(func() {

--- a/test/integration/recover_remote_nse_nsm_heal_test.go
+++ b/test/integration/recover_remote_nse_nsm_heal_test.go
@@ -4,10 +4,11 @@ package nsmd_integration_tests
 
 import (
 	"fmt"
-	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/nsm"
-	"github.com/networkservicemesh/networkservicemesh/test/kube_testing/pods"
 	"testing"
 	"time"
+
+	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/nsm"
+	"github.com/networkservicemesh/networkservicemesh/test/kube_testing/pods"
 
 	"github.com/networkservicemesh/networkservicemesh/test/integration/nsmd_test_utils"
 
@@ -39,8 +40,12 @@ func TestNSMHealRemoteDieNSMD_NSE(t *testing.T) {
 			Variables: map[string]string{
 				nsm.NsmdHealDSTWaitTimeout: "60", // 60 second delay, since we know on CI it could not fit into delay.
 			},
-		}, {},
-	})
+			Namespace: k8s.GetK8sNamespace(),
+		},
+		{
+			Namespace: k8s.GetK8sNamespace(),
+		},
+	}, k8s.GetK8sNamespace())
 
 	// Run ICMP on latest node
 	icmpPod := nsmd_test_utils.DeployICMP(k8s, nodes_setup[1].Node, "icmp-responder-nse-1", defaultTimeout)
@@ -64,7 +69,7 @@ func TestNSMHealRemoteDieNSMD_NSE(t *testing.T) {
 
 	logrus.Infof("Starting recovered NSMD...")
 	startTime := time.Now()
-	nodes_setup[1].Nsmd = k8s.CreatePod(pods.NSMgrPodWithConfig(nsmdName, nodes_setup[1].Node, &pods.NSMgrPodConfig{})) // Recovery NSEs
+	nodes_setup[1].Nsmd = k8s.CreatePod(pods.NSMgrPodWithConfig(nsmdName, nodes_setup[1].Node, &pods.NSMgrPodConfig{Namespace: k8s.GetK8sNamespace()})) // Recovery NSEs
 	logrus.Printf("Started new NSMD: %v on node %s", time.Since(startTime), nodes_setup[1].Node.Name)
 
 	failures = InterceptGomegaFailures(func() {
@@ -122,7 +127,7 @@ func TestNSMHealRemoteDieNSMD(t *testing.T) {
 
 	logrus.Infof("Starting recovered NSMD...")
 	startTime := time.Now()
-	nodes_setup[1].Nsmd = k8s.CreatePod(pods.NSMgrPodWithConfig(nsmdName, nodes_setup[1].Node, &pods.NSMgrPodConfig{})) // Recovery NSEs
+	nodes_setup[1].Nsmd = k8s.CreatePod(pods.NSMgrPodWithConfig(nsmdName, nodes_setup[1].Node, &pods.NSMgrPodConfig{Namespace: k8s.GetK8sNamespace()})) // Recovery NSEs
 	logrus.Printf("Started new NSMD: %v on node %s", time.Since(startTime), nodes_setup[1].Node.Name)
 
 	failures = InterceptGomegaFailures(func() {

--- a/test/integration/usecase_vpn_test.go
+++ b/test/integration/usecase_vpn_test.go
@@ -122,7 +122,7 @@ func testVPN(t *testing.T, nodesCount int, affinity map[string]int, verbose bool
 	for k := 0; k < nodesCount; k++ {
 		corePodName := fmt.Sprintf("nsmgr-%d", k)
 		dataPlanePodName := fmt.Sprintf("nsmd-dataplane-%d", k)
-		corePods := k8s.CreatePods(pods.NSMgrPod(corePodName, &nodes[k]), pods.VPPDataplanePod(dataPlanePodName, &nodes[k]))
+		corePods := k8s.CreatePods(pods.NSMgrPod(corePodName, &nodes[k], k8s.GetK8sNamespace()), pods.VPPDataplanePod(dataPlanePodName, &nodes[k]))
 		logrus.Printf("Started NSMD/Dataplane: %v on node %d", time.Since(s1), k)
 		nsmdPodNode = append(nsmdPodNode, corePods[0])
 		nsmdDataplanePodNode = append(nsmdDataplanePodNode, corePods[1])
@@ -154,7 +154,7 @@ func testVPN(t *testing.T, nodesCount int, affinity map[string]int, verbose bool
 	s1 = time.Now()
 	node := affinity["vppagent-firewall-nse-1"]
 	logrus.Infof("Starting VPPAgent Firewall NSE on node: %d", node)
-	_, err = k8s.CreateConfigMap(pods.VppAgentFirewallNSEConfigMapIcmpHttp("vppagent-firewall-nse-1"))
+	_, err = k8s.CreateConfigMap(pods.VppAgentFirewallNSEConfigMapIcmpHttp("vppagent-firewall-nse-1", k8s.GetK8sNamespace()))
 	Expect(err).To(BeNil())
 	vppagentFirewallNode := k8s.CreatePod(pods.VppAgentFirewallNSEPodWithConfigMap("vppagent-firewall-nse-1", &nodes[node],
 		map[string]string{

--- a/test/kube_testing/crds/networkservice.go
+++ b/test/kube_testing/crds/networkservice.go
@@ -20,6 +20,7 @@ import (
 
 	nsapiv1 "github.com/networkservicemesh/networkservicemesh/k8s/pkg/apis/networkservice/v1"
 	nscrd "github.com/networkservicemesh/networkservicemesh/k8s/pkg/networkservice/clientset/versioned"
+	"github.com/networkservicemesh/networkservicemesh/k8s/pkg/networkservice/namespace"
 	. "github.com/onsi/gomega"
 	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v12 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -75,8 +76,9 @@ func NewNSCRD() (*NSCRD, error) {
 	config, err := clientcmd.BuildConfigFromFlags("", path)
 	Expect(err).To(BeNil())
 
+	nsmNamespace := namespace.GetNamespace()
 	client := NSCRD{
-		namespace: "default",
+		namespace: nsmNamespace,
 		resource:  "networkservices",
 		config:    config,
 	}

--- a/test/kube_testing/k8s_forward.go.go
+++ b/test/kube_testing/k8s_forward.go.go
@@ -3,14 +3,15 @@ package kube_testing
 import (
 	"fmt"
 	"io/ioutil"
+	"net"
+	"net/http"
+
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/httpstream"
 	spdy2 "k8s.io/apimachinery/pkg/util/httpstream/spdy"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/portforward"
 	"k8s.io/client-go/transport/spdy"
-	"net"
-	"net/http"
 )
 
 type PortForward struct {
@@ -103,10 +104,16 @@ func (p *PortForward) getFreePort() (int, error) {
 
 // Create an httpstream.Dialer for use with portforward.New
 func (p *PortForward) dialer() (httpstream.Dialer, error) {
+	podname := ""
+	if p.pod != nil {
+		podname = p.pod.Name
+	} else {
+		return nil, fmt.Errorf("Could not do POST request for a non-existing pod")
+	}
 	url := p.k8s.clientset.CoreV1().RESTClient().Post().
 		Resource("pods").
-		Namespace("default").
-		Name(p.pod.Name).
+		Namespace(p.k8s.GetK8sNamespace()).
+		Name(podname).
 		SubResource("portforward").URL()
 
 	transport, upgrader, err := roundTripperFor(p.k8s.config)

--- a/test/kube_testing/pods/vppagent-firewall-nse.go
+++ b/test/kube_testing/pods/vppagent-firewall-nse.go
@@ -6,12 +6,12 @@ import (
 	v12 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func VppAgentFirewallNSEConfigMapIcmpHttp(name string) *v1.ConfigMap {
+func VppAgentFirewallNSEConfigMapIcmpHttp(name string, namespace string) *v1.ConfigMap {
 
 	return &v1.ConfigMap{
 		ObjectMeta: v12.ObjectMeta{
 			Name:      name + "-config-file",
-			Namespace: "default",
+			Namespace: namespace,
 		},
 		TypeMeta: v12.TypeMeta{
 			Kind: "ConfigMap",

--- a/test/kube_testing/rbac/cluster_roles.go
+++ b/test/kube_testing/rbac/cluster_roles.go
@@ -1,3 +1,18 @@
+// Copyright 2019 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package rbac
 
 import (
@@ -50,7 +65,7 @@ func (r *ClusterRoleBinding) GetName() string {
 Roles is a map containing simplified roles names for external usage and mapping them to a function
 that creates object of the required type.
 */
-var Roles = map[string]func(string) Role{
+var Roles = map[string]func(string, string) Role{
 	"admin":   CreateRoleAdmin,
 	"view":    CreateRoleView,
 	"binding": CreateRoleBinding,
@@ -66,7 +81,7 @@ var RoleNames = map[string]string{
 	"binding": "nsm-role-binding",
 }
 
-func CreateRoleAdmin(name string) Role {
+func CreateRoleAdmin(name string, namespace string) Role {
 	roleAdmin := &ClusterRole{
 		ClusterRole: rbacv1.ClusterRole{
 			TypeMeta: metav1.TypeMeta{
@@ -105,7 +120,7 @@ func CreateRoleAdmin(name string) Role {
 	return roleAdmin
 }
 
-func CreateRoleView(name string) Role {
+func CreateRoleView(name string, namespace string) Role {
 	roleView := &ClusterRole{
 		ClusterRole: rbacv1.ClusterRole{
 			TypeMeta: metav1.TypeMeta{
@@ -129,7 +144,7 @@ func CreateRoleView(name string) Role {
 	return roleView
 }
 
-func CreateRoleBinding(name string) Role {
+func CreateRoleBinding(name string, namespace string) Role {
 	roleBinding := &ClusterRoleBinding{
 		ClusterRoleBinding: rbacv1.ClusterRoleBinding{
 			TypeMeta: metav1.TypeMeta{
@@ -148,7 +163,7 @@ func CreateRoleBinding(name string) Role {
 					Kind:      "ServiceAccount",
 					APIGroup:  "",
 					Name:      "default",
-					Namespace: "default",
+					Namespace: namespace,
 				},
 			},
 		},


### PR DESCRIPTION
Until now `default` namespace was used for all NSM resources.
Migrating to own `nsm-system` namespace as a first step to a possible multi-namespace update in future

Signed-off-by: Ivana Yovcheva <iyovcheva@vmware.com>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Closes #754 

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [ ] Covered by existing integration testing
- [ ] Added integration testing to cover
- [ ] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

Tested locally.

Integration tests pass 1 by one, but fail together.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.