### PR TITLE
Create Github issue templates for both "spec" and "bug" use-cases

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,8 @@
+Please switch to **Preview** and select one of the following links depending on your use-case:
+
+* [Feature](?template=spec.md)
+* [Bug](?template=bug.md)
+
+Once switched to the correct template, keep in mind that switching templates will remove all already entered data within this issue.
+
+Thank you for reaching out!

--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,30 @@
+## Expected Behavior
+
+<!--- Please describe the behavior you are expecting -->
+
+## Current Behavior
+
+<!--- What is the current behavior? -->
+
+## Failure Information (for bugs)
+
+<!--- Please help provide information about the failure if this is a bug. If it is not a bug, please remove the rest of this template. -->
+
+## Steps to Reproduce
+
+<!--- Please provide detailed steps for reproducing the issue: -->
+
+1. Step 1
+2. Step 2
+3. You get the idea...
+
+## Context
+
+<!--- Please provide any relevant information about your setup. This is important in case the issue is not reproducible except for under certain conditions. -->
+
+* Kubernetes Version:
+* etc.
+
+## Failure Logs
+
+<!--- Please include any relevant log snippets or files here. -->

--- a/.github/ISSUE_TEMPLATE/spec.md
+++ b/.github/ISSUE_TEMPLATE/spec.md
@@ -1,0 +1,11 @@
+## Overview
+
+<!--- Try to give a general description (optional if it overlaps with the content from the Google Docs file) -->
+
+## Link to the Google Docs document
+
+<!--- Please provide the link to the Google Docs document -->
+
+## References
+
+<!--- If present, you can share links to issues, PRs, etc.  -->


### PR DESCRIPTION
Signed-off-by: Radoslav Dimitrov <dimitrovr@vmware.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

* Add a Github issue template to ease the creation
* Leverage Github's support for multiple templates
* When creating an issue, the user will choose if it's a bug or a spec related and so it will be redirected to the corresponding template.

Alternative solutions:
* Decide if it makes more sense to have everything in a single template and let the user refactor the content by itself.
 
## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [ ] Covered by existing integration testing
- [ ] Added integration testing to cover
- [ ] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.