### PR TITLE
Convert to using hostNetworking:true

### DIFF
--- a/dataplane/vppagent/build/Dockerfile.vppagent-dataplane
+++ b/dataplane/vppagent/build/Dockerfile.vppagent-dataplane
@@ -11,7 +11,7 @@ RUN go mod download
 ADD [".","/root/networkservicemesh"]
 RUN CGO_ENABLED=0 GOOS=linux go build -ldflags '-extldflags "-static"' -o /go/bin/vppagent-dataplane ./dataplane/vppagent/cmd/vppagent-dataplane.go
 
-FROM edwarnicke/vpp-agent:v1.8.1 as runtime
+FROM edwarnicke/vpp-agent:v1.8.1-debug as runtime
 COPY --from=build /go/bin/vppagent-dataplane /bin/vppagent-dataplane
 RUN rm /opt/vpp-agent/dev/etcd.conf /opt/vpp-agent/dev/kafka.conf; echo 'Endpoint: "localhost:9111"' > /opt/vpp-agent/dev/grpc.conf
 COPY dataplane/vppagent/conf/vpp/startup.conf /etc/vpp/vpp.conf

--- a/dataplane/vppagent/build/Dockerfile.vppagent-dataplane
+++ b/dataplane/vppagent/build/Dockerfile.vppagent-dataplane
@@ -11,7 +11,7 @@ RUN go mod download
 ADD [".","/root/networkservicemesh"]
 RUN CGO_ENABLED=0 GOOS=linux go build -ldflags '-extldflags "-static"' -o /go/bin/vppagent-dataplane ./dataplane/vppagent/cmd/vppagent-dataplane.go
 
-FROM ligato/vpp-agent:v1.8 as runtime
+FROM edwarnicke/vpp-agent:v1.8.1 as runtime
 COPY --from=build /go/bin/vppagent-dataplane /bin/vppagent-dataplane
 RUN rm /opt/vpp-agent/dev/etcd.conf /opt/vpp-agent/dev/kafka.conf; echo 'Endpoint: "localhost:9111"' > /opt/vpp-agent/dev/grpc.conf
 COPY dataplane/vppagent/conf/vpp/startup.conf /etc/vpp/vpp.conf

--- a/dataplane/vppagent/cmd/vppagent-dataplane.go
+++ b/dataplane/vppagent/cmd/vppagent-dataplane.go
@@ -16,7 +16,6 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"net"
 	"os"
 	"os/signal"
@@ -107,12 +106,15 @@ func main() {
 		logrus.Fatalf("Env variable %s must be set to a valid IP address, was set to %s", SrcIpEnvKey, srcIpStr)
 		vppagent.SetValidIPFailed()
 	}
-	ifaceName, srcIpNet, hwAddr, err := MgmtIface(srcIp)
+	egressInterface, err := vppagent.NewEgressInterface(srcIp)
+	if err != nil {
+		logrus.Fatalf("Unable to find egress Interface: %s", err)
+	}
 	if err != nil {
 		logrus.Fatalf("Unable to extract interface name for SrcIP: %s", srcIp)
 		vppagent.SetExtractIFNameFailed()
 	}
-	logrus.Infof("SrcIP: %s, IfaceName: %s, SrcIPNet: %s", srcIp, ifaceName, srcIpNet)
+	logrus.Infof("SrcIP: %s, IfaceName: %s, SrcIPNet: %s", srcIp, egressInterface.Name, egressInterface.SrcIPNet())
 
 	logrus.Infof("dataplaneName: %s", dataplaneName)
 
@@ -128,7 +130,7 @@ func main() {
 	}
 
 	logrus.Info("Creating vppagent server")
-	server := vppagent.NewServer(vppAgentEndpoint, nsmBaseDir, srcIp, *srcIpNet, ifaceName, hwAddr)
+	server := vppagent.NewServer(vppAgentEndpoint, nsmBaseDir, egressInterface)
 	go server.Serve(ln)
 	logrus.Info("vppagent server serving")
 
@@ -145,28 +147,4 @@ func main() {
 		logrus.Info("Closing Dataplane Registration")
 		registration.Close()
 	}
-}
-
-func MgmtIface(srcIp net.IP) (string, *net.IPNet, net.HardwareAddr, error) {
-	ifaces, err := net.Interfaces()
-	if err != nil {
-		return "", nil, nil, err
-	}
-	for _, iface := range ifaces {
-		addrs, err := iface.Addrs()
-		if err != nil {
-			return "", nil, nil, err
-		}
-		for _, addr := range addrs {
-			switch v := addr.(type) {
-			case *net.IPNet:
-				if v.IP.Equal(srcIp) {
-					return iface.Name, v, iface.HardwareAddr, nil
-				}
-			default:
-				return "", nil, nil, fmt.Errorf("Type of addr not net.IPNET")
-			}
-		}
-	}
-	return "", nil, nil, nil
 }

--- a/dataplane/vppagent/pkg/vppagent/egress_interface.go
+++ b/dataplane/vppagent/pkg/vppagent/egress_interface.go
@@ -1,0 +1,59 @@
+// Copyright (c) 2019 Cisco and/or its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vppagent
+
+import (
+	"fmt"
+	"net"
+)
+
+type EgressInterface struct {
+	*net.Interface
+	srcNet *net.IPNet
+}
+
+func NewEgressInterface(srcIp net.IP) (*EgressInterface, error) {
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		return nil, err
+	}
+	for _, iface := range ifaces {
+		addrs, err := iface.Addrs()
+		if err != nil {
+			return nil, err
+		}
+		for _, addr := range addrs {
+			switch v := addr.(type) {
+			case *net.IPNet:
+				if v.IP.Equal(srcIp) {
+					return &EgressInterface{
+						srcNet:    v,
+						Interface: &iface,
+					}, nil
+				}
+			default:
+				return nil, fmt.Errorf("Type of addr not net.IPNET")
+			}
+		}
+	}
+	return nil, fmt.Errorf("Unable to find interface with IP: %s", srcIp)
+}
+
+func (e *EgressInterface) SrcIPNet() *net.IPNet {
+	if e == nil {
+		return nil
+	}
+	return e.srcNet
+}

--- a/dataplane/vppagent/pkg/vppagent/server.go
+++ b/dataplane/vppagent/pkg/vppagent/server.go
@@ -15,8 +15,6 @@
 package vppagent
 
 import (
-	"net"
-
 	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/monitor/crossconnect_monitor"
 
 	"github.com/grpc-ecosystem/grpc-opentracing/go/otgrpc"
@@ -27,7 +25,7 @@ import (
 	"google.golang.org/grpc"
 )
 
-func NewServer(vppAgentEndpoint string, baseDir string, srcIp net.IP, srcIPNet net.IPNet, mgmtIfaceName string, mgmtHWAddress net.HardwareAddr) *grpc.Server {
+func NewServer(vppAgentEndpoint string, baseDir string, egressInterface *EgressInterface) *grpc.Server {
 	tracer := opentracing.GlobalTracer()
 	server := grpc.NewServer(
 		grpc.UnaryInterceptor(
@@ -38,7 +36,7 @@ func NewServer(vppAgentEndpoint string, baseDir string, srcIp net.IP, srcIPNet n
 	monitor := crossconnect_monitor.NewCrossConnectMonitor()
 	crossconnect.RegisterMonitorCrossConnectServer(server, monitor)
 
-	vppagent := NewVPPAgent(vppAgentEndpoint, monitor, baseDir, srcIp, srcIPNet, mgmtIfaceName, mgmtHWAddress)
+	vppagent := NewVPPAgent(vppAgentEndpoint, monitor, baseDir, egressInterface)
 	monitor_crossconnect_server.NewMonitorNetNsInodeServer(monitor)
 	dataplane.RegisterDataplaneServer(server, vppagent)
 	return server

--- a/dataplane/vppagent/pkg/vppagent/server.go
+++ b/dataplane/vppagent/pkg/vppagent/server.go
@@ -15,8 +15,9 @@
 package vppagent
 
 import (
-	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/monitor/crossconnect_monitor"
 	"net"
+
+	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/monitor/crossconnect_monitor"
 
 	"github.com/grpc-ecosystem/grpc-opentracing/go/otgrpc"
 	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/crossconnect"
@@ -26,7 +27,7 @@ import (
 	"google.golang.org/grpc"
 )
 
-func NewServer(vppAgentEndpoint string, baseDir string, srcIp net.IP, srcIPNet net.IPNet, mgmtIfaceName string) *grpc.Server {
+func NewServer(vppAgentEndpoint string, baseDir string, srcIp net.IP, srcIPNet net.IPNet, mgmtIfaceName string, mgmtHWAddress net.HardwareAddr) *grpc.Server {
 	tracer := opentracing.GlobalTracer()
 	server := grpc.NewServer(
 		grpc.UnaryInterceptor(
@@ -37,7 +38,7 @@ func NewServer(vppAgentEndpoint string, baseDir string, srcIp net.IP, srcIPNet n
 	monitor := crossconnect_monitor.NewCrossConnectMonitor()
 	crossconnect.RegisterMonitorCrossConnectServer(server, monitor)
 
-	vppagent := NewVPPAgent(vppAgentEndpoint, monitor, baseDir, srcIp, srcIPNet, mgmtIfaceName)
+	vppagent := NewVPPAgent(vppAgentEndpoint, monitor, baseDir, srcIp, srcIPNet, mgmtIfaceName, mgmtHWAddress)
 	monitor_crossconnect_server.NewMonitorNetNsInodeServer(monitor)
 	dataplane.RegisterDataplaneServer(server, vppagent)
 	return server

--- a/dataplane/vppagent/pkg/vppagent/vppagent.go
+++ b/dataplane/vppagent/pkg/vppagent/vppagent.go
@@ -16,12 +16,14 @@ package vppagent
 
 import (
 	"context"
-	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/monitor/crossconnect_monitor"
 	"net"
 	"time"
 
+	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/monitor/crossconnect_monitor"
+
 	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/grpc-ecosystem/grpc-opentracing/go/otgrpc"
+	"github.com/ligato/vpp-agent/plugins/vpp/model/acl"
 	"github.com/ligato/vpp-agent/plugins/vpp/model/interfaces"
 	"github.com/ligato/vpp-agent/plugins/vpp/model/rpc"
 	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/crossconnect"
@@ -49,10 +51,11 @@ type VPPAgent struct {
 	srcIP                net.IP
 	srcIPNet             net.IPNet
 	mgmtIfaceName        string
+	mgmtHWAddress        net.HardwareAddr
 	directMemifConnector *memif.DirectMemifConnector
 }
 
-func NewVPPAgent(vppAgentEndpoint string, monitor *crossconnect_monitor.CrossConnectMonitor, baseDir string, srcIP net.IP, srcIPNet net.IPNet, mgmtIfaceName string) *VPPAgent {
+func NewVPPAgent(vppAgentEndpoint string, monitor *crossconnect_monitor.CrossConnectMonitor, baseDir string, srcIP net.IP, srcIPNet net.IPNet, mgmtIfaceName string, mgmtHwAddress net.HardwareAddr) *VPPAgent {
 	// TODO provide some validations here for inputs
 	rv := &VPPAgent{
 		updateCh:         make(chan *Mechanisms, 1),
@@ -61,6 +64,7 @@ func NewVPPAgent(vppAgentEndpoint string, monitor *crossconnect_monitor.CrossCon
 		srcIP:            srcIP,
 		srcIPNet:         srcIPNet,
 		mgmtIfaceName:    mgmtIfaceName,
+		mgmtHWAddress:    mgmtHwAddress,
 		monitor:          monitor,
 		mechanisms: &Mechanisms{
 			localMechanisms: []*local.Mechanism{
@@ -220,8 +224,42 @@ func (v *VPPAgent) programMgmtInterface() error {
 				Type:        interfaces.InterfaceType_AF_PACKET_INTERFACE,
 				Enabled:     true,
 				IpAddresses: []string{v.srcIPNet.String()},
+				PhysAddress: v.mgmtHWAddress.String(),
 				Afpacket: &interfaces.Interfaces_Interface_Afpacket{
 					HostIfName: v.mgmtIfaceName,
+				},
+			},
+		},
+	}
+
+	dataRequest.AccessLists = []*acl.AccessLists_Acl{
+		&acl.AccessLists_Acl{
+			AclName: "NSMmgmtInterfaceACL",
+			Interfaces: &acl.AccessLists_Acl_Interfaces{
+				Ingress: []string{dataRequest.Interfaces[0].Name},
+			},
+			Rules: []*acl.AccessLists_Acl_Rule{
+				&acl.AccessLists_Acl_Rule{
+					RuleName:  "NSMmgmtInterfaceACL permit VXLAN dst",
+					AclAction: acl.AclAction_PERMIT,
+					Match: &acl.AccessLists_Acl_Rule_Match{
+						IpRule: &acl.AccessLists_Acl_Rule_Match_IpRule{
+							Ip: &acl.AccessLists_Acl_Rule_Match_IpRule_Ip{
+								DestinationNetwork: v.srcIP.String() + "/32",
+								SourceNetwork:      "0.0.0.0/0",
+							},
+							Udp: &acl.AccessLists_Acl_Rule_Match_IpRule_Udp{
+								DestinationPortRange: &acl.AccessLists_Acl_Rule_Match_IpRule_PortRange{
+									LowerPort: 4789,
+									UpperPort: 4789,
+								},
+								SourcePortRange: &acl.AccessLists_Acl_Rule_Match_IpRule_PortRange{
+									LowerPort: 0,
+									UpperPort: 65535,
+								},
+							},
+						},
+					},
 				},
 			},
 		},

--- a/dataplane/vppagent/pkg/vppagent/vppagent.go
+++ b/dataplane/vppagent/pkg/vppagent/vppagent.go
@@ -231,7 +231,14 @@ func (v *VPPAgent) programMgmtInterface() error {
 			},
 		},
 	}
-
+	// When using AF_PACKET, both the kernel, and vpp receive the packets.
+	// Since both vpp and the kernel have the same IP and hw address,
+	// vpp will send icmp port unreachable messages out for anything
+	// that is sent to that IP/mac address ... which screws up lots of things.
+	// This causes vpp to have an ACL on the management interface such that
+	// it drops anything that isn't destined for VXLAN (port 4789).
+	// This way it avoids sending icmp port unreachable messages out.
+	// This bug wasn't really obvious till we tried to switch to hostNetwork:true
 	dataRequest.AccessLists = []*acl.AccessLists_Acl{
 		&acl.AccessLists_Acl{
 			AclName: "NSMmgmtInterfaceACL",

--- a/docker/Dockerfile.vppagent-firewall-nse
+++ b/docker/Dockerfile.vppagent-firewall-nse
@@ -11,7 +11,7 @@ RUN go mod download
 ADD [".","/root/networkservicemesh"]
 RUN CGO_ENABLED=0 GOOS=linux go build -ldflags '-extldflags "-static"' -o /go/bin/vppagent-firewall-nse ./examples/cmd/vppagent-firewall-nse
 
-FROM ligato/vpp-agent:v1.8 as runtime
+FROM edwarnicke/vpp-agent:v1.8.1 as runtime
 COPY --from=build /go/bin/vppagent-firewall-nse /bin/vppagent-firewall-nse
 RUN rm /opt/vpp-agent/dev/etcd.conf /opt/vpp-agent/dev/kafka.conf; echo 'Endpoint: "0.0.0.0:9112"' > /opt/vpp-agent/dev/grpc.conf; echo "disabled: true" > /opt/vpp-agent/dev/linux-plugin.conf
 COPY dataplane/vppagent/conf/vpp/startup.conf /etc/vpp/vpp.conf

--- a/docker/Dockerfile.vppagent-icmp-responder-nse
+++ b/docker/Dockerfile.vppagent-icmp-responder-nse
@@ -11,7 +11,7 @@ RUN go mod download
 ADD [".","/root/networkservicemesh"]
 RUN CGO_ENABLED=0 GOOS=linux go build -ldflags '-extldflags "-static"' -o /go/bin/vppagent-icmp-responder-nse ./examples/cmd/vppagent-icmp-responder-nse
 
-FROM ligato/vpp-agent:v1.8 as runtime
+FROM edwarnicke/vpp-agent:v1.8.1 as runtime
 COPY --from=build /go/bin/vppagent-icmp-responder-nse /bin/vppagent-icmp-responder-nse
 RUN rm /opt/vpp-agent/dev/etcd.conf /opt/vpp-agent/dev/kafka.conf; echo 'Endpoint: "0.0.0.0:9112"' > /opt/vpp-agent/dev/grpc.conf; echo "disabled: true" > /opt/vpp-agent/dev/linux-plugin.conf
 COPY dataplane/vppagent/conf/vpp/startup.conf /etc/vpp/vpp.conf

--- a/docker/Dockerfile.vppagent-nsc
+++ b/docker/Dockerfile.vppagent-nsc
@@ -11,7 +11,7 @@ RUN go mod download
 ADD [".","/root/networkservicemesh"]
 RUN CGO_ENABLED=0 GOOS=linux go build -ldflags '-extldflags "-static"' -o /go/bin/vppagent-nsc ./examples/cmd/vppagent-nsc
 
-FROM ligato/vpp-agent:v1.8 as runtime
+FROM edwarnicke/vpp-agent:v1.8.1 as runtime
 COPY --from=build /go/bin/vppagent-nsc /bin/vppagent-nsc
 RUN rm /opt/vpp-agent/dev/etcd.conf /opt/vpp-agent/dev/kafka.conf; echo 'Endpoint: "0.0.0.0:9113"' > /opt/vpp-agent/dev/grpc.conf; echo "disabled: true" > /opt/vpp-agent/dev/linux-plugin.conf
 COPY dataplane/vppagent/conf/vpp/startup.conf /etc/vpp/vpp.conf

--- a/k8s/conf/vppagent-dataplane.yaml
+++ b/k8s/conf/vppagent-dataplane.yaml
@@ -8,6 +8,7 @@ spec:
         app: nsm-vpp-dataplane
     spec:
       hostPID: true
+      hostNetwork: true
       containers:
         - name: vppagent-dataplane
           securityContext:


### PR DESCRIPTION
This temporarily involves switching to edwarnicke/vpp-agent:v1.8.1 images
while the ligato team spins new updates with fixes in vpp to workaround
a kernel issue.

The basic kernel issue hit was this:

When running in hostNetwork:true, mmap for Hugepages returns without an error
(even though no Hugepages are available to be mmaped) and then the kernel
throws a SIGBUS when we try to use them.  This should *never* happen, but
does.  To work around it, we employ an alternate means to detect that
we don't actually have the pages involving mincore.



<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [ ] Covered by existing integration testing
- [ ] Added integration testing to cover
- [ ] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.