### PR TITLE
Nsmd healing

### DIFF
--- a/controlplane/cmd/nsmd/nsmd.go
+++ b/controlplane/cmd/nsmd/nsmd.go
@@ -50,7 +50,7 @@ func main() {
 	defer server.Stop()
 
 	// Starting dataplene
-	logrus.Info("Staring Dataplane registration server...")
+	logrus.Info("Starting Dataplane registration server...")
 	if err := server.StartDataplaneRegistratorServer(); err != nil {
 		logrus.Fatalf("Error starting dataplane service: %+v", err)
 		nsmd.SetDPServerFailed()

--- a/controlplane/cmd/nsmd/nsmd.go
+++ b/controlplane/cmd/nsmd/nsmd.go
@@ -38,19 +38,37 @@ func main() {
 
 	defer serviceRegistry.Stop()
 
-	if err := nsmd.StartDataplaneRegistrarServer(model); err != nil {
+	manager := nsm.NewNetworkServiceManager(model, serviceRegistry, nsmd.GetExcludedPrefixes())
+
+	var server nsmd.NSMServer
+	var err error
+	// Start NSMD server first, laod local NSE/client registry and only then start dataplane/wait for it and recover active connections.
+	if server, err = nsmd.StartNSMServer(model, manager, serviceRegistry, apiRegistry); err != nil {
+		logrus.Fatalf("Error starting nsmd service: %+v", err)
+		nsmd.SetNSMServerFailed()
+	}
+	defer server.Stop()
+
+	// Starting dataplene
+	logrus.Info("Staring Dataplane registration server...")
+	if err := server.StartDataplaneRegistratorServer(); err != nil {
 		logrus.Fatalf("Error starting dataplane service: %+v", err)
 		nsmd.SetDPServerFailed()
 	}
 
-	manager := nsm.NewNetworkServiceManager(model, serviceRegistry, nsmd.GetExcludedPrefixes())
-
-	if err := nsmd.StartNSMServer(model, manager, serviceRegistry, apiRegistry); err != nil {
-		logrus.Fatalf("Error starting nsmd service: %+v", err)
-		nsmd.SetNSMServerFailed()
+	// Wait for dataplane to be connecting to us.
+	if err := manager.WaitForDataplane(nsmd.DataplaneTimeout); err != nil {
+		logrus.Errorf("Error waiting for dataplane")
 	}
 
-	if err := nsmd.StartAPIServer(model, manager, apiRegistry, serviceRegistry); err != nil {
+	// Choose a public API listener
+	sock, err := apiRegistry.NewPublicListener()
+	if err != nil {
+		logrus.Errorf("Failed to start Public API server...")
+		nsmd.SetAPIServerFailed()
+	}
+
+	if err := nsmd.StartAPIServerAt(server, sock); err != nil {
 		logrus.Fatalf("Error starting nsmd api service: %+v", err)
 		nsmd.SetAPIServerFailed()
 	}

--- a/controlplane/pkg/apis/local/connection/constants.go
+++ b/controlplane/pkg/apis/local/connection/constants.go
@@ -9,6 +9,7 @@ const (
 	Master                  = "master"
 	Slave                   = "slave"
 	Workspace               = "workspace"
+	WorkspaceNSEName        = "workspaceNseName"
 	MemifSocket             = "memif.sock"
 	NsmBaseDirEnv           = "NSM_BASE_DIR"
 )

--- a/controlplane/pkg/apis/nsm/heal_properties.go
+++ b/controlplane/pkg/apis/nsm/heal_properties.go
@@ -1,0 +1,56 @@
+package nsm
+
+import (
+	"github.com/sirupsen/logrus"
+	"os"
+	"strconv"
+	"time"
+)
+
+const (
+	NsmdHealEnabled        = "NSMD_HEAL_ENABLED"      // Does healing is enabled or not
+	NsmdHealDSTWaitTimeout = "NSMD_HEAL_DST_TIMEOUTs" // Wait timeout for DST in seconds
+)
+
+type HealTimeouts struct {
+	HealTimeout          time.Duration
+	HealCloseTimeout     time.Duration
+	HealRequestTimeout   time.Duration
+	HealDataplaneTimeout time.Duration
+
+	// Total DST heal timeout is 20 seconds.
+	HealDSTNSEWaitTimeout time.Duration
+	HealDSTNSEWaitTick    time.Duration
+
+	HealEnabled bool
+}
+
+func NewHealProperties() *HealTimeouts {
+	values := &HealTimeouts{
+		HealTimeout:          time.Minute * 1,
+		HealCloseTimeout:     time.Second * 5,
+		HealRequestTimeout:   time.Minute * 1,
+		HealDataplaneTimeout: time.Minute * 1,
+
+		// Total DST heal timeout is 20 seconds.
+		HealDSTNSEWaitTimeout: time.Second * 30,       // Maximum time to wait for NSMD/NSE to re-appear
+		HealDSTNSEWaitTick:    500 * time.Millisecond, // Wait timeout to appear of NSE
+		HealEnabled:           true,
+	}
+
+	// Parse few Environment variables.
+	if "false" == os.Getenv(NsmdHealEnabled) {
+		values.HealEnabled = false
+	}
+	dstWaitTimeout := os.Getenv(NsmdHealDSTWaitTimeout)
+	if len(dstWaitTimeout) > 0 {
+		logrus.Infof("Override HealDSTWaitTimeout: %s", dstWaitTimeout)
+		seconds, err := strconv.ParseInt(dstWaitTimeout, 10, 32)
+		if err == nil {
+			values.HealDSTNSEWaitTimeout = time.Second * time.Duration(seconds)
+		} else {
+			logrus.Errorf("Failed to parse DST wait timeout value... %v", err)
+		}
+	}
+	return values
+}

--- a/controlplane/pkg/apis/nsm/nsm.go
+++ b/controlplane/pkg/apis/nsm/nsm.go
@@ -64,4 +64,5 @@ type NetworkServiceManager interface {
 	RestoreConnections(xcons []*crossconnect.CrossConnect, dataplane string)
 	GetHealProperties() *HealTimeouts
 	WaitForDataplane(duration time.Duration) error
+	RemoteConnectionLost(clientConnection NSMClientConnection)
 }

--- a/controlplane/pkg/apis/nsm/nsm.go
+++ b/controlplane/pkg/apis/nsm/nsm.go
@@ -2,7 +2,9 @@ package nsm
 
 import (
 	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/connectioncontext"
+	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/crossconnect"
 	"golang.org/x/net/context"
+	"time"
 )
 
 /*
@@ -59,4 +61,7 @@ type NetworkServiceManager interface {
 	Request(ctx context.Context, request NSMRequest) (NSMConnection, error)
 	Close(ctx context.Context, clientConnection NSMClientConnection) error
 	Heal(connection NSMClientConnection, healState HealState)
+	RestoreConnections(xcons []*crossconnect.CrossConnect, dataplane string)
+	GetHealProperties() *HealTimeouts
+	WaitForDataplane(duration time.Duration) error
 }

--- a/controlplane/pkg/model/model.go
+++ b/controlplane/pkg/model/model.go
@@ -32,18 +32,18 @@ type Endpoint struct {
 type ClientConnectionState int8
 
 const (
-	ClientConnection_Ready      ClientConnectionState   = 0
-	ClientConnection_Requesting ClientConnectionState   = 1
-	ClientConnection_Healing    ClientConnectionState   = 2
-	ClientConnection_Closing    ClientConnectionState   = 3
+	ClientConnection_Ready      ClientConnectionState = 0
+	ClientConnection_Requesting ClientConnectionState = 1
+	ClientConnection_Healing    ClientConnectionState = 2
+	ClientConnection_Closing    ClientConnectionState = 3
 	ClientConnection_Closed     ClientConnectionState = 4
 )
 
 type DataplaneState int8
 
 const (
-	DataplaneState_None  = 0 // In case dataplane is not yet configured for connection
-	DataplaneState_Ready = 1 // In case dataplane is configured for connection.
+	DataplaneState_None  DataplaneState = 0 // In case dataplane is not yet configured for connection
+	DataplaneState_Ready DataplaneState = 1 // In case dataplane is configured for connection.
 )
 
 type ClientConnection struct {

--- a/controlplane/pkg/monitor/remote_connection_monitor/remote_connection_monitor_server.go
+++ b/controlplane/pkg/monitor/remote_connection_monitor/remote_connection_monitor_server.go
@@ -3,15 +3,18 @@ package remote_connection_monitor
 import (
 	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/remote/connection"
 	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/monitor"
+	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/services"
 )
 
 type RemoteConnectionMonitor struct {
 	monitor.MonitorServer
+	manager *services.ClientConnectionManager
 }
 
-func NewRemoteConnectionMonitor() *RemoteConnectionMonitor {
+func NewRemoteConnectionMonitor(manager *services.ClientConnectionManager) *RemoteConnectionMonitor {
 	rv := &RemoteConnectionMonitor{
 		MonitorServer: monitor.NewMonitorServer(&RemoteConnectionEventConverter{}),
+		manager: manager,
 	}
 	go rv.Serve()
 	return rv
@@ -19,5 +22,7 @@ func NewRemoteConnectionMonitor() *RemoteConnectionMonitor {
 
 func (m *RemoteConnectionMonitor) MonitorConnections(selector *connection.MonitorScopeSelector, recipient connection.MonitorConnection_MonitorConnectionsServer) error {
 	filtered := NewMonitorConnectionFilter(selector, recipient)
-	return m.MonitorEntities(filtered)
+	result := m.MonitorEntities(filtered)
+	m.manager.UpdateRemoteMonitorDone(selector.NetworkServiceManagerName)
+	return result
 }

--- a/controlplane/pkg/nseregistry/nse_registry.go
+++ b/controlplane/pkg/nseregistry/nse_registry.go
@@ -1,0 +1,225 @@
+package nseregistry
+
+import (
+	"bufio"
+	"encoding/base64"
+	"github.com/gogo/protobuf/proto"
+	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/registry"
+	"github.com/sirupsen/logrus"
+	"io"
+	"os"
+	"strings"
+	"sync"
+)
+const(
+	ClientRegistered = "CLE"
+	NSERegistered = "NSE"
+)
+type NSERegistry struct {
+	lock sync.Mutex
+	file string
+}
+
+type NSEEntry struct {
+	Workspace string
+	NseReg *registry.NSERegistration
+}
+
+func NewNSERegistry(file string) *NSERegistry {
+	return &NSERegistry{file: file}
+}
+
+func store(values ... string) string {
+	res := ""
+	for _, s := range(values) {
+		if len(res) > 0 {
+			res += "\t"
+		}
+		ss := strings.Replace(s, "\t", "\\t,", -1)
+		ss = strings.Replace(s, "\n", "\\n,", -1) // Just in case
+		ss = strings.Replace(s, "\r", "\\r,", -1) // Just in case
+		res += ss
+	}
+	return res
+}
+func unescape(s string) string {
+	s = strings.Replace(s, "\\t", "\t", -1)
+	s = strings.Replace(s, "\\n", "\n", -1)
+	s = strings.Replace(s, "\\r", "\r", -1)
+	return s
+}
+func restore(inputS string) []string {
+	ts := strings.TrimSpace(inputS)
+	segments := strings.SplitN(ts, "\t", -1)
+	for idx, sm := range(segments) {
+		segments[idx] = unescape(sm)
+	}
+	return segments
+}
+
+/**
+	We adding a registration for client.
+ */
+func (reg *NSERegistry) writeLine(op ...string) error {
+	reg.lock.Lock()
+	defer reg.lock.Unlock()
+	f, err := os.OpenFile(reg.file, os.O_APPEND|os.O_WRONLY|os.O_SYNC|os.O_CREATE, 0600)
+	if err != nil {
+		logrus.Errorf("Failed to store Client information")
+		return err
+	}
+
+	defer f.Close()
+
+	if _, err = f.WriteString(store(op...) + "\n"); err != nil {
+		return err
+	}
+	_ = f.Sync()
+	return nil
+}
+func (reg *NSERegistry) AppendClientRequest(workspace string) error {
+	return reg.writeLine(ClientRegistered, workspace)
+}
+
+func (reg *NSERegistry) AppendNSERegRequest(workspace string, nseReg *registry.NSERegistration) error {
+	return reg.writeLine(NSERegistered, nseReg.NetworkserviceEndpoint.EndpointName, workspace, reg.storeNSEBase64(nseReg)) // Few workspaces could contain few NSEs
+}
+
+func (reg *NSERegistry) storeNSEBase64(nseReg *registry.NSERegistration) string {
+	bytes, err := proto.Marshal(nseReg)
+	if err != nil {
+		logrus.Errorf("Failed to serialize NSE passed %v", err)
+	}
+	strData := base64.StdEncoding.EncodeToString(bytes)
+	return strData
+}
+
+func (reg *NSERegistry) DeleteNSE(endpointid string) error {
+	reg.lock.Lock()
+	defer reg.lock.Unlock()
+	clients, nses, err := reg.loadRegistry()
+	if err != nil {
+		return err
+	}
+	delete(nses, endpointid)
+
+	return reg.Save(clients, nses)
+}
+
+/**
+	Delete client workspace and all NSEs registered.
+ */
+func (reg *NSERegistry) DeleteClient(workspace string) error {
+	reg.lock.Lock()
+	defer reg.lock.Unlock()
+	clients, nses, err := reg.loadRegistry()
+	if err != nil {
+		return err
+	}
+	for idx, ws := range(clients) {
+		if ws == workspace {
+			clients = append(clients[:idx], clients[idx+1:]...)
+		}
+	}
+
+	for endpointId, entry := range(nses) {
+		if entry.Workspace == workspace {
+			delete(nses, endpointId)
+		}
+	}
+
+
+	return reg.Save(clients, nses)
+}
+
+func (reg *NSERegistry) LoadRegistry() (clients []string, nses map[string]NSEEntry, err error ) {
+	reg.lock.Lock()
+	defer reg.lock.Unlock()
+	return reg.loadRegistry()
+}
+
+func (reg *NSERegistry) loadRegistry() (clients []string, nses map[string]NSEEntry, res_err error ) {
+	nses = map[string]NSEEntry{}
+
+	f, err := os.OpenFile(reg.file, os.O_RDONLY, 0600)
+	if err != nil {
+		logrus.Infof("No stored registry file exists")
+		return
+	}
+	defer f.Close()
+
+	reader := bufio.NewReader(f)
+	for {
+		r, err := reader.ReadString('\n');
+		if err != nil {
+			if err != io.EOF {
+				res_err = err
+				return
+			}
+			// End of file
+			break
+		}
+		values := restore(r)
+		logrus.Printf("Values: %v", values)
+		if len(values) > 0 {
+			if values[0] == ClientRegistered && len(values) == 2 {
+				clients = append(clients, values[1])
+			} else if values[0] == NSERegistered && len(values) == 4 {
+				entry := NSEEntry{}
+				entry.Workspace = values[2]
+				strData := values[3]
+				bytes, err := base64.StdEncoding.DecodeString(strData)
+				if err != nil {
+					logrus.Errorf("Failed to decode NSE registration %v", err)
+				}
+				nseReg := &registry.NSERegistration{}
+				err = proto.Unmarshal(bytes, nseReg)
+				if err != nil {
+					logrus.Errorf("Failed to decode nse registration message %v", err)
+				}
+				entry.NseReg = nseReg
+				nses[values[1]] = entry
+			} else {
+				logrus.Errorf("Unknown registry file line: %v", r)
+			}
+		}
+	}
+	logrus.Infof("Clients: %v", clients)
+	logrus.Infof("NSEs: %v", nses)
+
+	return
+}
+
+/**
+	Saves memory model info file
+ */
+func (reg *NSERegistry) Save(clients []string, nses map[string]NSEEntry) error {
+	tmpFile := reg.file + "_tmp"
+	f, err := os.OpenFile(tmpFile, os.O_APPEND|os.O_WRONLY|os.O_TRUNC|os.O_CREATE, 0600)
+	if err != nil {
+		logrus.Errorf("Failed to store Client information")
+		return err
+	}
+
+	for _, workspace := range clients {
+		if _, err = f.WriteString(store(ClientRegistered, workspace) + "\n"); err != nil {
+			return err
+		}
+	}
+
+	for endpointId, entry := range nses {
+		if _, err = f.WriteString(store(NSERegistered, endpointId, entry.Workspace, reg.storeNSEBase64(entry.NseReg)) + "\n"); err != nil {
+			return err
+		}
+	}
+	if err = f.Close(); err != nil {
+		return err
+	}
+	// Now we need to replace existing file with new one.
+	return os.Rename(tmpFile, reg.file)
+}
+
+func (reg *NSERegistry) Delete() {
+	_ = os.Remove(reg.file)
+}
+

--- a/controlplane/pkg/nsm/heal_constants.go
+++ b/controlplane/pkg/nsm/heal_constants.go
@@ -1,8 +1,0 @@
-package nsm
-
-import "time"
-
-const (
-	HealTimeout          = time.Minute * 1
-	HealDataplaneTimeout = time.Minute * 1
-)

--- a/controlplane/pkg/nsm/nse_requests.go
+++ b/controlplane/pkg/nsm/nse_requests.go
@@ -17,7 +17,9 @@ func (srv *networkServiceManager) createRemoteNSMRequest(endpoint *registry.NSER
 		remoteM = append(remoteM, mechanism)
 	}
 	var message *remote_networkservice.NetworkServiceRequest
-	if existingConnection != nil {
+
+	// Try Heal only if endpoint are same as for existing connection.
+	if existingConnection != nil && endpoint == existingConnection.Endpoint {
 		remoteDst := existingConnection.Xcon.GetRemoteDestination()
 		message = &remote_networkservice.NetworkServiceRequest{
 

--- a/controlplane/pkg/nsm/nsm.go
+++ b/controlplane/pkg/nsm/nsm.go
@@ -210,7 +210,7 @@ func (srv *networkServiceManager) request(ctx context.Context, request nsm.NSMRe
 		//TODO: Remove when VPP Agent Dataplane will be stable.
 
 		logrus.Infof("NSM:(10.2-%v) Sending request to dataplane: %v retry: %v", requestId, clientConnection.Xcon, dpRetry)
-		clientConnection.Xcon, err = dataplaneClient.Request(ctx, clientConnection.Xcon)
+		newXcon, err := dataplaneClient.Request(ctx, clientConnection.Xcon)
 		if err != nil {
 			logrus.Errorf("NSM:(10.2.1-%v) Dataplane request failed: %v retry: %v", requestId, err, dpRetry)
 
@@ -232,6 +232,7 @@ func (srv *networkServiceManager) request(ctx context.Context, request nsm.NSMRe
 			srv.model.DeleteClientConnection(clientConnection.ConnectionId)
 			return nil, err
 		}
+		clientConnection.Xcon = newXcon
 		logrus.Infof("NSM:(10.3-%v) Dataplane configuration sucessfull %v", requestId, clientConnection.Xcon)
 		break
 	}

--- a/controlplane/pkg/nsm/nsm.go
+++ b/controlplane/pkg/nsm/nsm.go
@@ -37,6 +37,12 @@ type networkServiceManager struct {
 	serviceRegistry   serviceregistry.ServiceRegistry
 	model             model.Model
 	excluded_prefixes []string
+	properties        *nsm.HealTimeouts
+	stateRestored     chan bool
+}
+
+func (srv *networkServiceManager) GetHealProperties() *nsm.HealTimeouts {
+	return srv.properties
 }
 
 func NewNetworkServiceManager(model model.Model, serviceRegistry serviceregistry.ServiceRegistry, excluded_prefixes []string) nsm.NetworkServiceManager {
@@ -44,6 +50,8 @@ func NewNetworkServiceManager(model model.Model, serviceRegistry serviceregistry
 		serviceRegistry:   serviceRegistry,
 		model:             model,
 		excluded_prefixes: excluded_prefixes,
+		properties:        nsm.NewHealProperties(),
+		stateRestored:     make(chan bool, 1),
 	}
 }
 
@@ -67,6 +75,9 @@ func create_logid() (uuid string) {
 func (srv *networkServiceManager) request(ctx context.Context, request nsm.NSMRequest, existingConnection *model.ClientConnection) (nsm.NSMConnection, error) {
 	requestId := create_logid()
 	logrus.Infof("NSM:(%v) request: %v", requestId, request)
+	if existingConnection != nil {
+		logrus.Infof("NSM:(%v) Called with existing connection passed: %v", requestId, existingConnection)
+	}
 
 	// 0. Make sure its a valid request
 	err := request.IsValid()
@@ -105,7 +116,7 @@ func (srv *networkServiceManager) request(ctx context.Context, request nsm.NSMRe
 			requestNSEOnUpdate = true
 			closeDataplaneOnNSEFailed = true
 			// Network service is closing, we need to close remote NSM and re-programm local one.
-			if err := srv.close(ctx, existingConnection, false); err != nil {
+			if err := srv.close(ctx, existingConnection, false, false); err != nil {
 				logrus.Errorf("NSM:(4.1-%v) Error during close of NSE during Request.Upgrade %v Existing connection: %v error %v", requestId, request, existingConnection, err)
 			}
 		} else {
@@ -193,16 +204,16 @@ func (srv *networkServiceManager) request(ctx context.Context, request nsm.NSMRe
 	logrus.Infof("NSM:(10.2-%v) Sending request to dataplane: %v", requestId, clientConnection.Xcon)
 	clientConnection.Xcon, err = dataplaneClient.Request(ctx, clientConnection.Xcon)
 	if err != nil {
-		logrus.Errorf("NSM:(10.2.1-%v) Dataplane request failed: %s", requestId, err)
+		logrus.Errorf("NSM:(10.2.1-%v) Dataplane request failed: %v", requestId, err)
 		// Let's try again with a short delay
 		<-time.Tick(500)
 		logrus.Errorf("NSM:(10.2.2-%v) Dataplane request retry: %v", requestId, clientConnection.Xcon)
 		clientConnection.Xcon, err = dataplaneClient.Request(ctx, clientConnection.Xcon)
 
 		if err != nil {
-			logrus.Errorf("NSM:(10.2.3-%v) Dataplane request retry failed: %s", requestId, err)
+			logrus.Errorf("NSM:(10.2.3-%v) Dataplane request retry failed: %v", requestId, err)
 			// 10.3 If datplane configuration are failed, we need to close remore NSE actually.
-			if dp_err := srv.close(context.Background(), clientConnection, true); dp_err != nil {
+			if dp_err := srv.close(context.Background(), clientConnection, false, false); dp_err != nil {
 				logrus.Errorf("NSM:(10.2.4-%v) Failed to NSE.Close() caused by local dataplane configuration failure: %v", requestId, dp_err)
 			}
 			// 10.4 We need to remove local connection we just added already.
@@ -241,39 +252,39 @@ func (srv *networkServiceManager) findConnectNSE(requestId string, ctx context.C
 		nseConnection := srv.cloneConnection(request, nsmConnection)
 
 		if existingConnection != nil {
-			// 7.2.1 Check previous endpoint, and it we will be able to contact it, it should be fine.
-			if ignore_endpoints[existingConnection.Endpoint.NetworkserviceEndpoint.EndpointName] == nil {
+			// 7.1.2 Check previous endpoint, and it we will be able to contact it, it should be fine.
+			if existingConnection.Endpoint != nil && ignore_endpoints[existingConnection.Endpoint.NetworkserviceEndpoint.EndpointName] == nil {
 				endpoint = existingConnection.Endpoint
 			}
 		}
-		// 7.2.2 Check if endpoint is not ignored yet
+		// 7.1.3 Check if endpoint is not ignored yet
 
 		if endpoint == nil {
-			// 7.2.3 Choose a new endpoint
+			// 7.1.4 Choose a new endpoint
 			endpoint, err = srv.getEndpoint(ctx, nseConnection, ignore_endpoints)
 		}
 		if err != nil {
-			// 7.2.4 No endpoints found, we need to return error, including last error for previous NSE
+			// 7.1.5 No endpoints found, we need to return error, including last error for previous NSE
 			if last_error != nil {
-				return nil, fmt.Errorf("NSM:(7.2.4-%v) %v. Last NSE Error: %v", requestId, err, last_error)
+				return nil, fmt.Errorf("NSM:(7.1.5-%v) %v. Last NSE Error: %v", requestId, err, last_error)
 			} else {
 				return nil, err
 			}
 		}
-		// 7.2.5 Update Request with exclude_prefixes, etc
+		// 7.1.6 Update Request with exclude_prefixes, etc
 		srv.updateExcludePrefixes(nseConnection)
 
-		// 7.2.6 perform request to NSE/remote NSMD/NSE
+		// 7.1.7 perform request to NSE/remote NSMD/NSE
 		clientConnection, err = srv.performNSERequest(requestId, ctx, endpoint, nseConnection, request, dp, existingConnection)
 
-		// 7.2.7 in case of error we put NSE into ignored list to check another one.
+		// 7.1.8 in case of error we put NSE into ignored list to check another one.
 		if err != nil {
-			logrus.Errorf("NSM:(7.2.7-%v) NSE respond with error: %v ", requestId, err)
+			logrus.Errorf("NSM:(7.1.8-%v) NSE respond with error: %v ", requestId, err)
 			last_error = err
 			ignore_endpoints[endpoint.NetworkserviceEndpoint.EndpointName] = endpoint
 			continue
 		}
-		// 7.2.8 We are fine with NSE connection and could continue.
+		// 7.1.9 We are fine with NSE connection and could continue.
 		return clientConnection, nil
 	}
 }
@@ -298,11 +309,11 @@ func (srv *networkServiceManager) newConnection(request nsm.NSMRequest) nsm.NSMC
 }
 
 func (srv *networkServiceManager) Close(ctx context.Context, connection nsm.NSMClientConnection) error {
-	return srv.close(ctx, connection.(*model.ClientConnection), true)
+	return srv.close(ctx, connection.(*model.ClientConnection), true, true)
 }
 
-func (srv *networkServiceManager) close(ctx context.Context, clientConnection *model.ClientConnection, closeDataplane bool) error {
-	logrus.Infof("Closing connection %v", clientConnection)
+func (srv *networkServiceManager) close(ctx context.Context, clientConnection *model.ClientConnection, closeDataplane bool, modelRemove bool) error {
+	logrus.Infof("NSM: Closing connection %v", clientConnection)
 	if clientConnection.ConnectionState == model.ClientConnection_Closing {
 		return nil
 	}
@@ -316,7 +327,7 @@ func (srv *networkServiceManager) close(ctx context.Context, clientConnection *m
 		defer func() {
 			err := client.Cleanup()
 			if err != nil {
-				logrus.Errorf("Error during Cleanup: %v", err)
+				logrus.Errorf("NSM: Error during Cleanup: %v", err)
 			}
 		}()
 		ld := clientConnection.Xcon.GetLocalDestination()
@@ -328,19 +339,22 @@ func (srv *networkServiceManager) close(ctx context.Context, clientConnection *m
 			nseCloseError = client.Close(ctx, rd)
 		}
 	} else {
-		logrus.Errorf("Failed to create NSE Client %v", nseClientError)
+		logrus.Errorf("NSM: Failed to create NSE Client %v", nseClientError)
 	}
 	var dpCloseError error = nil
 	if closeDataplane {
 		dpCloseError = srv.closeDataplane(clientConnection)
 		// TODO: We need to be sure Dataplane is respond well so we could delete connection.
-		srv.model.DeleteClientConnection(clientConnection.ConnectionId)
+		if modelRemove {
+			srv.model.DeleteClientConnection(clientConnection.ConnectionId)
+			clientConnection.ConnectionState = model.ClientConnection_Closed
+		}
 	}
-	clientConnection.ConnectionState = model.ClientConnection_Closed
 
 	if nseClientError != nil || nseCloseError != nil || dpCloseError != nil {
-		return fmt.Errorf("Close error: %v", []error{nseClientError, nseCloseError, dpCloseError})
+		return fmt.Errorf("NSM: Close error: %v", []error{nseClientError, nseCloseError, dpCloseError})
 	}
+	logrus.Infof("NSM: Close for %s complete...", clientConnection.GetId())
 	return nil
 }
 
@@ -356,6 +370,8 @@ func (srv *networkServiceManager) createNSEClient(ctx context.Context, endpoint 
 		}
 		client, conn, err := srv.serviceRegistry.EndpointConnection(ctx, modelEp)
 		if err != nil {
+			// We failed to connect to local NSE.
+			srv.cleanupNSE(modelEp)
 			return nil, err
 		}
 		return &endpointClient{connection: conn, client: client}, nil
@@ -620,4 +636,110 @@ func (srv *networkServiceManager) checkNeedNSERequest(requestId string, nsmConne
 	}
 
 	return false
+}
+
+func (srv *networkServiceManager) cleanupNSE(endpoint *model.Endpoint) {
+	// Remove endpoint from model and put workspace into BAD state.
+	_ = srv.model.DeleteEndpoint(endpoint.EndpointName())
+	logrus.Infof("NSM: Remove Endpoint since it is not available... %v", endpoint)
+}
+
+func (srv *networkServiceManager) WaitForDataplane(timeout time.Duration) error {
+	// Wait for at least one dataplane to be available
+	if err := srv.serviceRegistry.WaitForDataplaneAvailable(srv.model, timeout); err != nil {
+		return err
+	}
+	logrus.Infof("Dataplane is available, waiting for initial state recieved and processed...")
+	select {
+	case <-srv.stateRestored:
+		return nil
+	case <-time.Tick(timeout):
+		return fmt.Errorf("Failed to wait for NSMD stare restore... timeout %v happened", timeout)
+	}
+}
+
+func (srv *networkServiceManager) RestoreConnections(xcons []*crossconnect.CrossConnect, dataplane string) {
+	for _, xcon := range xcons {
+		existing := srv.model.GetClientConnection(xcon.GetId())
+		if existing == nil {
+			logrus.Infof("Restoring state of active connection %v", xcon)
+
+			endpoint := &registry.NSERegistration{
+				NetworkService: &registry.NetworkService{
+				},
+				NetworkserviceEndpoint: &registry.NetworkServiceEndpoint{
+
+				},
+			}
+
+			connectionState := model.ClientConnection_Ready
+
+			dp := srv.model.GetDataplane(dataplane)
+			if src := xcon.GetRemoteSource(); src != nil {
+				// Since source is remote, connection need to be healed.
+				connectionState = model.ClientConnection_Healing
+
+				endpoint.NetworkService.Name = src.GetNetworkService()
+				endpoint.NetworkserviceEndpoint.EndpointName = src.GetNetworkServiceEndpointName()
+			}
+			if dst := xcon.GetLocalDestination(); dst != nil {
+				// Local NSE, connection is Ready
+				connectionState = model.ClientConnection_Ready
+
+				endpoint.NetworkService.Name = dst.GetNetworkService()
+				//TODO: Endpoint name is not defined for local case, seems we need to add it to local connection.
+				//endpoint.NetworkserviceEndpoint.EndpointName = xcon.GetLocalDestination().GetNetworkServiceEndpointName()
+			}
+			if dst := xcon.GetRemoteDestination(); dst != nil {
+				// NSE is remote one, and source is local one, we are ready.
+				connectionState = model.ClientConnection_Ready
+				endpoint.NetworkService.Name = xcon.GetRemoteDestination().GetNetworkService()
+				endpoint.NetworkserviceEndpoint.EndpointName = xcon.GetRemoteDestination().GetNetworkServiceEndpointName()
+			}
+
+			clientConnection := &model.ClientConnection{
+				ConnectionId:    xcon.GetId(),
+				Xcon:            xcon,
+				Endpoint:        endpoint, // We do not have endpoint here.
+				Dataplane:       dp,
+				ConnectionState: connectionState,
+				DataplaneState: model.DataplaneState_Ready, // It is configured already.
+			}
+			srv.model.AddClientConnection(clientConnection)
+
+			// Add healing timer, for connection to be headled from source side.
+			if src := xcon.GetRemoteSource(); src != nil {
+				go func() {
+					<-time.Tick(srv.properties.HealTimeout)
+					if clientConnection.ConnectionState == model.ClientConnection_Healing {
+						logrus.Errorf("NSM: Timeout happened for checking connection status from Healing.. %v. Closing connection...", clientConnection)
+						// Nobody was healed connection from Remote side.
+						if err := srv.Close(context.Background(), clientConnection); err != nil {
+							logrus.Errorf("NSM: Error cloding conneciton %v", err)
+						}
+					}
+				}()
+			}
+			if dst := xcon.GetRemoteDestination(); dst != nil {
+				if dst.State == remote_connection.State_DOWN {
+					srv.Heal(clientConnection, nsm.HealState_DstDown)
+				}
+			}
+			if dst := xcon.GetLocalDestination(); dst != nil {
+				if dst.State == connection.State_DOWN {
+					srv.Heal(clientConnection, nsm.HealState_DstDown)
+				}
+			}
+			if src := xcon.GetLocalSource(); src != nil {
+				if src.State == connection.State_DOWN {
+					// if source is down, we need to close connection properly.
+					_ = srv.Close(context.Background(), clientConnection)
+				}
+			}
+			logrus.Infof("Active connection state %v is Restored", xcon)
+		}
+	}
+	logrus.Infof("All connections are recovered...")
+	// Notify state is restored
+	srv.stateRestored <- true
 }

--- a/controlplane/pkg/nsm/nsm_heal.go
+++ b/controlplane/pkg/nsm/nsm_heal.go
@@ -160,7 +160,6 @@ func (srv *networkServiceManager) waitAnyNSE(clientConnection *model.ClientConne
 	for {
 		logrus.Infof("Waiting for NSE with network service %s. Since elapsed: %v", clientConnection.Endpoint.NetworkService.Name, time.Since(st))
 		ignored := map[string]*registry.NSERegistration{}
-		ignored[clientConnection.Endpoint.NetworkserviceEndpoint.EndpointName] = clientConnection.Endpoint
 		nsmConnection := srv.newConnection(clientConnection.Request)
 		ep, err := srv.getEndpoint(context.Background(), nsmConnection, ignored)
 		if err == nil && ep != nil {

--- a/controlplane/pkg/nsmd/nsmd.go
+++ b/controlplane/pkg/nsmd/nsmd.go
@@ -245,6 +245,12 @@ func (nsm *nsmServer) restoreClients(registeredEndpoints *registry.NetworkServic
 					}
 				} else {
 					nse.NseReg.NetworkServiceManager = nsm.model.GetNsm()
+					nse.NseReg.NetworkserviceEndpoint.NetworkServiceManagerName = nse.NseReg.NetworkServiceManager.Name
+					nsm.model.AddEndpoint(&model.Endpoint{
+						Endpoint: nse.NseReg,
+						Workspace: nse.Workspace,
+						SocketLocation: ws.NsmClientSocket(),
+					})
 					updatedNSEs[endpointId] = nse
 				}
 			}

--- a/controlplane/pkg/nsmd/nsmd.go
+++ b/controlplane/pkg/nsmd/nsmd.go
@@ -32,6 +32,7 @@ import (
 const (
 	NsmdDeleteLocalRegistry = "NSMD_LOCAL_REGISTRY_DELETE"
 	DataplaneTimeout = 1 * time.Hour
+	NSEAliveTimeout	= 1 * time.Second
 )
 
 type NSMServer interface {
@@ -212,7 +213,7 @@ func (nsm *nsmServer) restoreClients(registeredEndpoints *registry.NetworkServic
 		for endpointId, nse := range nses {
 			if ws, ok := nsm.workspaces[nse.Workspace]; ok {
 				logrus.Infof("Checking NSE %s is alive at %v...", endpointId, ws.NsmClientSocket())
-				ctx, cancelCtx := context.WithTimeout(context.Background(), 1 * time.Second)
+				ctx, cancelCtx := context.WithTimeout(context.Background(), NSEAliveTimeout)
 				defer cancelCtx()
 				nseConn, err := tools.SocketOperationCheckContext(ctx, ws.NsmClientSocket())
 				if err != nil {

--- a/controlplane/pkg/nsmd/nsmd.go
+++ b/controlplane/pkg/nsmd/nsmd.go
@@ -215,7 +215,7 @@ func (nsm *nsmServer) restoreClients(registeredEndpoints *registry.NetworkServic
 				logrus.Infof("Checking NSE %s is alive at %v...", endpointId, ws.NsmClientSocket())
 				ctx, cancelCtx := context.WithTimeout(context.Background(), NSEAliveTimeout)
 				defer cancelCtx()
-				nseConn, err := tools.SocketOperationCheckContext(ctx, ws.NsmClientSocket())
+				nseConn, err := tools.SocketOperationCheckContext(ctx, tools.SocketPath(ws.NsmClientSocket()))
 				if err != nil {
 					logrus.Errorf("Unable to connect to local nse %v. Skipping", nse.NseReg)
 

--- a/controlplane/pkg/nsmd/nsmd_crossconnect_client.go
+++ b/controlplane/pkg/nsmd/nsmd_crossconnect_client.go
@@ -79,6 +79,7 @@ func dial(ctx context.Context, network string, address string) (*grpc.ClientConn
 func (client *NsmMonitorCrossConnectClient) DataplaneAdded(dataplane *model.Dataplane) {
 	ctx, cancel := context.WithCancel(context.Background())
 	client.dataplanes[dataplane.RegisteredName] = cancel
+	logrus.Infof("Starting Dataplane crossconnect monitoring client...")
 	go client.dataplaneCrossConnectMonitor(dataplane, ctx)
 }
 
@@ -189,25 +190,32 @@ func (client *NsmMonitorCrossConnectClient) dataplaneCrossConnectMonitor(datapla
 					client.crossConnectMonitor.Update(xcon)
 				}
 			}
+			if event.GetType() == crossconnect.CrossConnectEventType_INITIAL_STATE_TRANSFER {
+				connects := []*crossconnect.CrossConnect{}
+				for _, xcon := range event.GetCrossConnects() {
+					connects = append(connects, xcon)
+				}
+				client.xconManager.UpdateFromInitialState(connects, dataplane)
+			}
 		}
 	}
 }
 
 func (client *NsmMonitorCrossConnectClient) remotePeerConnectionMonitor(remotePeer *registry.NetworkServiceManager, ctx context.Context) {
-	logrus.Infof("Connecting to Remote NSM: %s", remotePeer.Name)
+	logrus.Infof("NSM-PeerMonitor(%v): Connecting...", remotePeer.Name)
 	conn, err := grpc.Dial(remotePeer.Url, grpc.WithInsecure())
 	if err != nil {
-		logrus.Errorf("Failed to dial Network Service Registry %s at %s: %s", remotePeer.GetName(), remotePeer.Url, err)
+		logrus.Errorf("NSM-PeerMonitor(%v): Failed to dial Network Service Registry at %s: %s", remotePeer.GetName(), remotePeer.Url, err)
 		return
 	}
 	defer conn.Close()
 
 	defer func() {
-		logrus.Infof("Remote monitor closed... %v", remotePeer)
+		logrus.Infof("NSM-PeerMonitor(%v): Remote monitor closed...", remotePeer.Name)
 	}()
 
 	monitorClient := remote_connection.NewMonitorConnectionClient(conn)
-	selector := &remote_connection.MonitorScopeSelector{NetworkServiceManagerName: remotePeer.Name}
+	selector := &remote_connection.MonitorScopeSelector{NetworkServiceManagerName: client.xconManager.GetNsmName()}
 	stream, err := monitorClient.MonitorConnections(context.Background(), selector)
 	if err != nil {
 		logrus.Error(err)
@@ -217,17 +225,21 @@ func (client *NsmMonitorCrossConnectClient) remotePeerConnectionMonitor(remotePe
 	for {
 		select {
 		case <-ctx.Done():
-			logrus.Info("Context timeout exceeded...")
+			logrus.Infof("NSM-PeerMonitor(%v): Context timeout exceeded...", remotePeer.Name)
 			return
 		default:
-			logrus.Info("Recv Connection event...")
+			logrus.Infof("NSM-PeerMonitor(%v): Waiting for events...", remotePeer.Name)
 			event, err := stream.Recv()
 			if err != nil {
-				logrus.Error(err)
-				//TODO (lobkovilya): handle remote NSM dies
+				logrus.Errorf("NSM-PeerMonitor(%v) Uexpected error: %v", remotePeer.Name, err)
+				connections := client.xconManager.GetClientConnectionByRemote(remotePeer)
+				for _, c := range(connections) {
+					// Same as DST down case, we need to find another NSE to connect to.
+					client.xconManager.UpdateClientConnectionDstStateDown(c)
+				}
 				return
 			}
-			logrus.Infof("Receive event from remote NSM %s: %s %s", remotePeer.GetName(), event.Type, event.Connections)
+			logrus.Infof("NSM-PeerMonitor(%v) Receive event %s %s", remotePeer.GetName(), event.Type, event.Connections)
 
 			for _, remoteConnection := range event.GetConnections() {
 				clientConnection := client.xconManager.GetClientConnectionByDst(remoteConnection.GetId())

--- a/controlplane/pkg/nsmd/registry.go
+++ b/controlplane/pkg/nsmd/registry.go
@@ -56,6 +56,14 @@ func (es *registryServer) RegisterNSE(ctx context.Context, request *registry.NSE
 	if err != nil {
 		return reg,err
 	}
+
+	// Append to workspace...
+	err = es.workspace.localRegistry.AppendNSERegRequest(es.workspace.name, reg)
+	if err != nil {
+		logrus.Errorf("Failed to store NSE into local registry service: %v", err)
+		_, _ = client.RemoveNSE(context.Background(), &registry.RemoveNSERequest{ EndpointName: reg.NetworkserviceEndpoint.EndpointName})
+		return nil, err
+	}
 	return reg, nil
 }
 func (es *registryServer) RegisterNSEWithClient(ctx context.Context, request *registry.NSERegistration, client registry.NetworkServiceRegistryClient) (*registry.NSERegistration, error) {

--- a/controlplane/pkg/nsmd/serviceregistry.go
+++ b/controlplane/pkg/nsmd/serviceregistry.go
@@ -83,7 +83,7 @@ func (impl *nsmdServiceRegistry) RemoteNetworkServiceClient(ctx context.Context,
 		grpc.WithStreamInterceptor(
 			otgrpc.OpenTracingStreamClientInterceptor(tracer)))
 	if err != nil {
-		logrus.Errorf("Failed to dial Network Service Registry %s at %s: %s", nsm.GetName(), nsm.Url, err)
+		logrus.Errorf("Failed to dial Remote Network Service Manager %s at %s: %s", nsm.GetName(), nsm.Url, err)
 		return nil, nil, err
 	}
 	client := remote_networkservice.NewNetworkServiceClient(conn)

--- a/controlplane/pkg/nsmd/serviceregistry.go
+++ b/controlplane/pkg/nsmd/serviceregistry.go
@@ -248,6 +248,7 @@ type defaultWorkspaceProvider struct {
 	clientBaseDir   string
 	nsmServerSocket string
 	nsmClientSocket string
+	nseRegistryFile string
 }
 
 func NewDefaultWorkspaceProvider() serviceregistry.WorkspaceLocationProvider {
@@ -264,6 +265,7 @@ func NewWorkspaceProvider(rootDir string) serviceregistry.WorkspaceLocationProvi
 		clientBaseDir:   rootDir,
 		nsmServerSocket: "nsm.server.io.sock",
 		nsmClientSocket: "nsm.client.io.sock",
+		nseRegistryFile: "nse.registry",
 	}
 }
 
@@ -273,6 +275,10 @@ func (w *defaultWorkspaceProvider) HostBaseDir() string {
 
 func (w *defaultWorkspaceProvider) NsmBaseDir() string {
 	return w.nsmBaseDir
+}
+
+func (w *defaultWorkspaceProvider) NsmNSERegistryFile() string {
+	return w.nsmBaseDir + w.nseRegistryFile
 }
 
 func (w *defaultWorkspaceProvider) ClientBaseDir() string {

--- a/controlplane/pkg/nsmd/workspace.go
+++ b/controlplane/pkg/nsmd/workspace.go
@@ -15,6 +15,7 @@
 package nsmd
 
 import (
+	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/nseregistry"
 	"net"
 	"os"
 	"sync"
@@ -50,6 +51,7 @@ type Workspace struct {
 	sync.Mutex
 	state            WorkspaceState
 	locationProvider serviceregistry.WorkspaceLocationProvider
+	localRegistry    *nseregistry.NSERegistry
 }
 
 func NewWorkSpace(nsm *nsmServer, name string) (*Workspace, error) {
@@ -58,6 +60,7 @@ func NewWorkSpace(nsm *nsmServer, name string) (*Workspace, error) {
 		locationProvider: nsm.locationProvider,
 		name: name,
 		state: NEW,
+		localRegistry: nsm.localRegistry,
 	}
 
 	defer w.cleanup() // Cleans up if and only iff we are not in state RUNNING
@@ -170,3 +173,4 @@ func (w *Workspace) cleanup() {
 		}
 	}
 }
+

--- a/controlplane/pkg/serviceregistry/serviceregistry.go
+++ b/controlplane/pkg/serviceregistry/serviceregistry.go
@@ -50,4 +50,7 @@ type WorkspaceLocationProvider interface {
 	ClientBaseDir() string
 	NsmServerSocket() string
 	NsmClientSocket() string
+
+	// A persistent file based NSE <-> Workspace registry.
+	NsmNSERegistryFile() string
 }

--- a/controlplane/pkg/services/client_connection_manager.go
+++ b/controlplane/pkg/services/client_connection_manager.go
@@ -164,13 +164,9 @@ func (m *ClientConnectionManager) GetClientConnectionBySource(networkServiceName
 
 func (m *ClientConnectionManager) UpdateRemoteMonitorDone(networkServiceManagerName string) {
 	// We need to be sure there is no active connections from selected Remote NSM.
-	//TODO: Need to not immideatly close but to wait for possible source NSM resolver and Healing of connection happened.
 	for _, conn := range m.GetClientConnectionBySource(networkServiceManagerName) {
 		// Since remote monitor is done, and if connection is not closed we need to close them.
-		logrus.Infof("Remote NSM monitor is done but connections is still alive, Closing: %v", conn)
-		if err := m.manager.Close(context.Background(), conn); err != nil {
-			logrus.Infof("Error during close of connection: %v", err)
-		}
+		m.manager.RemoteConnectionLost(conn)
 	}
 }
 

--- a/controlplane/pkg/tests/heal_nse_test.go
+++ b/controlplane/pkg/tests/heal_nse_test.go
@@ -92,6 +92,7 @@ func TestHealRemoteNSE(t *testing.T) {
 	}
 	// Simlate delete
 	clientConnection2.Xcon.GetLocalDestination().State = connection.State_DOWN
+	srv.manager.GetHealProperties().HealDSTNSEWaitTimeout = time.Second * 1
 	srv2.manager.Heal(clientConnection2, nsm.HealState_DstDown)
 
 	// First update, is delete

--- a/controlplane/pkg/tests/nse_registry_test.go
+++ b/controlplane/pkg/tests/nse_registry_test.go
@@ -1,0 +1,102 @@
+package tests
+
+import (
+	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/registry"
+	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/nseregistry"
+	. "github.com/onsi/gomega"
+	"io/ioutil"
+	"os"
+	"testing"
+)
+
+func TestNSEFileRegistry(t *testing.T) {
+	RegisterTestingT(t)
+	fileName := tmpFile()
+	defer os.Remove(fileName)
+	reg := nseregistry.NewNSERegistry(fileName)
+
+	addValues(reg)
+
+	clients, nses, err := reg.LoadRegistry()
+	Expect(err).To(BeNil())
+	Expect(clients).To(Equal([]string{"nsm-1", "nsm-2", "nsm-3"}))
+	Expect(nses).To(Equal(map[string]nseregistry.NSEEntry{"endpoint1": createEntry("nsm-1", "endpoint1"), "endpoint2": createEntry("nsm-2", "endpoint2")}))
+}
+func createEntry(workspace string, endpoint string) nseregistry.NSEEntry {
+	return nseregistry.NSEEntry {
+		Workspace: workspace,
+		NseReg: createNSEReg(endpoint),
+	}
+}
+func TestNSEDeleteTest(t *testing.T) {
+	RegisterTestingT(t)
+	fileName := tmpFile()
+	defer os.Remove(fileName)
+	reg := nseregistry.NewNSERegistry(fileName)
+
+	addValues(reg)
+
+	Expect(reg.DeleteNSE("endpoint1")).To(BeNil())
+
+	clients, nses, err := reg.LoadRegistry()
+	Expect(err).To(BeNil())
+	Expect(clients).To(Equal([]string{"nsm-1", "nsm-2", "nsm-3"}))
+	Expect(nses).To(Equal(map[string]nseregistry.NSEEntry {"endpoint2": createEntry("nsm-2", "endpoint2")}))
+}
+
+func TestNSEDeleteClientTest(t *testing.T) {
+	RegisterTestingT(t)
+	fileName := tmpFile()
+	defer os.Remove(fileName)
+	reg := nseregistry.NewNSERegistry(fileName)
+
+
+	addValues(reg)
+
+	Expect(reg.DeleteClient("nsm-1")).To(BeNil())
+
+	clients, nses, err := reg.LoadRegistry()
+	Expect(err).To(BeNil())
+	Expect(clients).To(Equal([]string{"nsm-2", "nsm-3"}))
+	Expect(nses).To(Equal(map[string]nseregistry.NSEEntry{"endpoint2": nseregistry.NSEEntry {
+		Workspace: "nsm-2",
+		NseReg: createNSEReg("endpoint2"),
+	}}))
+}
+
+
+
+func addValues(reg *nseregistry.NSERegistry) {
+	err := reg.AppendClientRequest("nsm-1")
+	Expect(err).To(BeNil())
+	err = reg.AppendClientRequest("nsm-2")
+	Expect(err).To(BeNil())
+	err = reg.AppendClientRequest("nsm-3")
+	Expect(err).To(BeNil())
+	err = reg.AppendNSERegRequest("nsm-1", createNSEReg("endpoint1"))
+	Expect(err).To(BeNil())
+	err = reg.AppendNSERegRequest("nsm-2", createNSEReg("endpoint2"))
+	Expect(err).To(BeNil())
+}
+
+func createNSEReg(name string) *registry.NSERegistration {
+	return &registry.NSERegistration{
+		NetworkserviceEndpoint: &registry.NetworkServiceEndpoint{
+			EndpointName:              name,
+			NetworkServiceManagerName: "nsm1",
+		},
+		NetworkService: &registry.NetworkService{
+			Name:    "my_nsm",
+			Payload: "A\nB",
+		},
+	}
+}
+
+func tmpFile() (string) {
+	regFile, err := ioutil.TempFile(os.TempDir(), "nsm_reg.data")
+	fileName := regFile.Name()
+	Expect(err).To(BeNil())
+	_ = regFile.Close()
+	_ = os.Remove(fileName)
+	return fileName
+}

--- a/controlplane/pkg/tests/nsmd_crossconnect_client_test.go
+++ b/controlplane/pkg/tests/nsmd_crossconnect_client_test.go
@@ -30,10 +30,11 @@ func startAPIServer(model model.Model, nsmdApiAddress string) (error, *grpc.Serv
 	monitor := crossconnect_monitor.NewCrossConnectMonitor()
 	crossconnect.RegisterMonitorCrossConnectServer(grpcServer, monitor)
 
-	connectionMonitor := remote_connection_monitor.NewRemoteConnectionMonitor()
+	manager := services.NewClientConnectionManager(model, nil, serviceRegistry)
+	connectionMonitor := remote_connection_monitor.NewRemoteConnectionMonitor(manager)
 	connection.RegisterMonitorConnectionServer(grpcServer, connectionMonitor)
 
-	monitorClient := nsmd.NewMonitorCrossConnectClient(monitor, connectionMonitor, services.NewClientConnectionManager(model, nil, serviceRegistry))
+	monitorClient := nsmd.NewMonitorCrossConnectClient(monitor, connectionMonitor, manager)
 	model.AddListener(monitorClient)
 	// TODO: Add more public API services here.
 

--- a/controlplane/pkg/tests/nsmd_registry_test.go
+++ b/controlplane/pkg/tests/nsmd_registry_test.go
@@ -1,0 +1,65 @@
+package tests
+
+import (
+	"github.com/networkservicemesh/networkservicemesh/sdk/common"
+	"github.com/networkservicemesh/networkservicemesh/sdk/endpoint"
+	"github.com/networkservicemesh/networkservicemesh/sdk/endpoint/composite"
+	. "github.com/onsi/gomega"
+	"github.com/sirupsen/logrus"
+	"testing"
+	"time"
+)
+
+
+func TestNSMDRestart1(t *testing.T) {
+	RegisterTestingT(t)
+
+	storage := newSharedStorage()
+
+	srv := newNSMDFullServer("nsm1", storage)
+	srv.addFakeDataplane("test_data_plane", "tcp:some_addr")
+
+	reply, conn := srv.requestNSM("nsm-1")
+	defer conn.Close()
+
+	configuration := &common.NSConfiguration{
+		Workspace: reply.Workspace,
+		NsmServerSocket: reply.ClientBaseDir + reply.Workspace + "/" + reply.NsmServerSocket,
+		NsmClientSocket: reply.ClientBaseDir + reply.Workspace + "/" + reply.NsmClientSocket,
+		AdvertiseNseName: "test_nse",
+
+	}
+
+	composite := composite.NewMonitorCompositeEndpoint(configuration).SetNext(
+		composite.NewIpamCompositeEndpoint(configuration).SetNext(
+			composite.NewConnectionCompositeEndpoint(configuration)))
+
+	nsmEndpoint, err := endpoint.NewNSMEndpoint(nil, configuration, composite)
+	if err != nil {
+		logrus.Fatalf("%v", err)
+	}
+
+	l1 := newTestConnectionModelListener()
+	srv.testModel.AddListener(l1)
+	_ = nsmEndpoint.Start()
+	defer nsmEndpoint.Delete()
+
+	// Wait for at least one NSE is available.
+	l1.WaitEndpoints(1, time.Second*30, t)
+
+	endpoints1 := srv.testModel.GetNetworkServiceEndpoints("test_nse")
+	Expect(len(endpoints1)).To(Equal(1))
+	srv.StopNoClean()
+
+	// We need to restart server
+	storage2 := newSharedStorage()
+	srv = newNSMDFullServerAt("nsm2", storage2, srv.rootDir)
+	srv.addFakeDataplane("test_data_plane", "tcp:some_addr")
+	endpoints2 := srv.testModel.GetNetworkServiceEndpoints("test_nse")
+
+	Expect(len(endpoints2)).To(Equal(1))
+	Expect(endpoints1[0].SocketLocation).To(Equal(endpoints2[0].SocketLocation))
+	Expect(endpoints1[0].Workspace).To(Equal(endpoints2[0].Workspace))
+	Expect(endpoints1[0].Endpoint.NetworkServiceManager.Name).ToNot(Equal(endpoints2[0].Endpoint.NetworkServiceManager.Name))
+}
+

--- a/k8s/pkg/registryserver/nsm.go
+++ b/k8s/pkg/registryserver/nsm.go
@@ -6,6 +6,12 @@ import (
 	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/registry"
 	"github.com/sirupsen/logrus"
+	"time"
+)
+
+const (
+	attempts = 10
+	attemptDelay = 100 * time.Millisecond
 )
 
 type nsmRegistryService struct {
@@ -23,7 +29,9 @@ func newNsmRegistryService(nsmName string, cache RegistryCache) *nsmRegistryServ
 func (n *nsmRegistryService) RegisterNSM(ctx context.Context, nsm *registry.NetworkServiceManager) (*registry.NetworkServiceManager, error) {
 	logrus.Infof("Received RegisterNSM(%v)", nsm)
 
-	if nsm.GetName() == "" || n.cache.GetNetworkServiceManager(nsm.GetName()) == nil {
+	cachedValue := n.cache.GetNetworkServiceManager(nsm.GetName())
+	logrus.Infof("Cached value %v", cachedValue)
+	if nsm.GetName() == "" || cachedValue == nil {
 		return n.create(nsm)
 	}
 
@@ -73,12 +81,25 @@ func (n *nsmRegistryService) update(nsm *registry.NetworkServiceManager) (*regis
 	}
 
 	nsmCr := mapNsmToCustomResource(nsm)
-	nsmCr.ObjectMeta = oldNsm.ObjectMeta
 
-	nsmCr, err := n.cache.UpdateNetworkServiceManager(nsmCr)
-	if err != nil {
-		logrus.Errorf("Failed to update nsm: %s", err)
-		return nil, err
+	nsmCr.ObjectMeta = oldNsm.ObjectMeta
+	logrus.Infof("Performing update: %v", nsmCr)
+	var err error
+
+	//TODO: Workaround for issue: https://github.com/kubernetes/kubernetes/issues/71139
+	for i := 0; i < attempts; i++ {
+		nsmCr, err = n.cache.UpdateNetworkServiceManager(nsmCr)
+		if err != nil {
+			logrus.Errorf("Failed to update nsm: %s retrying...", err)
+			if i == attempts-1 {
+				return nil, err
+			} else {
+				logrus.Errorf("Waiting for Kubernetes to be consistent..")
+				<- time.Tick(attemptDelay)
+				continue
+			}
+		}
+		break
 	}
 
 	return mapNsmFromCustomResource(nsmCr), nil

--- a/k8s/pkg/registryserver/resource_cache/nsm_cache.go
+++ b/k8s/pkg/registryserver/resource_cache/nsm_cache.go
@@ -40,6 +40,7 @@ func (c *NetworkServiceManagerCache) Update(nsm *v1.NetworkServiceManager) {
 }
 
 func (c *NetworkServiceManagerCache) Delete(key string) {
+	logrus.Infof("NetworkServiceManagerCache.Delete(%v)", key)
 	c.cache.delete(key)
 }
 
@@ -49,6 +50,7 @@ func (c *NetworkServiceManagerCache) Start(informerFactory externalversions.Shar
 
 func (c *NetworkServiceManagerCache) resourceAdded(obj interface{}) {
 	nsm := obj.(*v1.NetworkServiceManager)
+	logrus.Infof("NetworkServiceManagerCache.Added(%v)", nsm)
 	c.networkServiceManagers[getNsmKey(nsm)] = nsm
 }
 
@@ -59,6 +61,7 @@ func (c *NetworkServiceManagerCache) resourceUpdated(obj interface{}) {
 }
 
 func (c *NetworkServiceManagerCache) resourceDeleted(key string) {
+	logrus.Infof("NetworkServiceManagerCache.Deleted(%v=%v)", key, c.networkServiceManagers[key])
 	delete(c.networkServiceManagers, key)
 }
 

--- a/pkg/tools/tools.go
+++ b/pkg/tools/tools.go
@@ -87,7 +87,10 @@ func (socket SocketPath) String() string {
 func SocketOperationCheck(endpoint net.Addr) (*grpc.ClientConn, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	conn, err := dial(ctx, endpoint)
+	return SocketOperationCheckContext(ctx, endpoint )
+}
+func SocketOperationCheckContext(ctx context.Context, listenEndpoint net.Addr) (*grpc.ClientConn, error) {
+	conn, err := dial(ctx, listenEndpoint)
 	if err != nil {
 		return nil, err
 	}
@@ -109,6 +112,7 @@ func dial(ctx context.Context, endpoint net.Addr) (*grpc.ClientConn, error) {
 	return c, err
 }
 
+//TODO: We need to change this method, having ctx and interval have not give good understanding of how it works.
 func WaitForPortAvailable(ctx context.Context, protoType string, registryAddress string, interval time.Duration) error {
 	if interval < 0 {
 		return errors.New("interval must be positive")

--- a/test/integration/basic_nsmd_deploy_test.go
+++ b/test/integration/basic_nsmd_deploy_test.go
@@ -47,7 +47,7 @@ func testNSMDDdataplaneDeploy(t *testing.T, nsmdPodFactory func(string, *v1.Node
 		return
 	}
 
-	var pods []*v1.Pod
+	var podsVal []*v1.Pod
 
 	for i, node := range nodes {
 		nsmdPodName := fmt.Sprintf("nsmd-%d", i+1)
@@ -57,10 +57,10 @@ func testNSMDDdataplaneDeploy(t *testing.T, nsmdPodFactory func(string, *v1.Node
 		k8s.WaitLogsContains(podsNode[0], "nsmd", "NSM gRPC API Server: [::]:5001 is operational", defaultTimeout)
 		k8s.WaitLogsContains(podsNode[0], "nsmdp", "ListAndWatch was called with", defaultTimeout)
 		k8s.WaitLogsContains(podsNode[1], "", "Sending MonitorMechanisms update", defaultTimeout)
-		pods = append(pods, podsNode...)
+		podsVal = append(podsVal, podsNode...)
 	}
 
-	k8s.DeletePods(pods...)
+	k8s.DeletePods(podsVal...)
 	var count int = 0
 	for _, lpod := range k8s.ListPods() {
 		logrus.Printf("Found pod %s %+v", lpod.Name, lpod.Status)

--- a/test/integration/basic_nsmd_k8s_test.go
+++ b/test/integration/basic_nsmd_k8s_test.go
@@ -151,6 +151,8 @@ func TestUpdateNSM(t *testing.T) {
 
 	// We need to wait until it is started
 	k8s.WaitLogsContains(nsmd, "nsmd-k8s", "nsmd-k8s initialized and waiting for connection", fastTimeout)
+	// To be sure NSMD is already called for register.
+	k8s.WaitLogsContains(nsmd, "nsmd", "Waiting for dataplane available...", defaultTimeout)
 
 	e := fwd.Start()
 	if e != nil {

--- a/test/integration/basic_nsmdp_test.go
+++ b/test/integration/basic_nsmdp_test.go
@@ -1,0 +1,65 @@
+// +build basic
+
+package nsmd_integration_tests
+
+import (
+	"github.com/networkservicemesh/networkservicemesh/test/integration/nsmd_test_utils"
+	"github.com/networkservicemesh/networkservicemesh/test/kube_testing"
+	"github.com/networkservicemesh/networkservicemesh/test/kube_testing/pods"
+	. "github.com/onsi/gomega"
+	"testing"
+)
+
+func TestNSMDDP(t *testing.T) {
+	RegisterTestingT(t)
+
+	if testing.Short() {
+		t.Skip("Skip, please run without -short")
+		return
+	}
+
+	k8s, err := kube_testing.NewK8s()
+	defer k8s.Cleanup()
+
+	Expect(err).To(BeNil())
+
+	k8s.Prepare("nsmd", "icmp")
+
+	nodes := nsmd_test_utils.SetupNodesConfig(k8s, 1, defaultTimeout, []*pods.NSMDPodConfig{})
+	icmpPod := nsmd_test_utils.DeployICMP(k8s, nodes[0].Node, "icmp-responder-nse-1", defaultTimeout)
+
+	nsmdName := nodes[0].Nsmd.Name
+	k8s.DeletePods(nodes[0].Nsmd)
+	k8s.DeletePods(icmpPod)
+
+	nodes[0].Nsmd = k8s.CreatePod(pods.NSMDPodWithConfig(nsmdName, nodes[0].Node, &pods.NSMDPodConfig{})) // Recovery NSEs
+	icmpPod = nsmd_test_utils.DeployICMP(k8s, nodes[0].Node, "icmp-responder-nse-2", defaultTimeout)
+	Expect(icmpPod).ToNot(BeNil())
+}
+
+func TestNSMDRecoverNSE(t *testing.T) {
+	RegisterTestingT(t)
+
+	if testing.Short() {
+		t.Skip("Skip, please run without -short")
+		return
+	}
+
+	k8s, err := kube_testing.NewK8s()
+	defer k8s.Cleanup()
+
+	Expect(err).To(BeNil())
+
+	k8s.Prepare("nsmd", "icmp")
+
+	nodes := nsmd_test_utils.SetupNodesConfig(k8s, 1, defaultTimeout, []*pods.NSMDPodConfig{})
+	icmpPod := nsmd_test_utils.DeployICMP(k8s, nodes[0].Node, "icmp-responder-nse-1", defaultTimeout)
+
+	nsmdName := nodes[0].Nsmd.Name
+	k8s.DeletePods(nodes[0].Nsmd)
+	k8s.DeletePods(icmpPod)
+
+	nodes[0].Nsmd = k8s.CreatePod(pods.NSMDPodWithConfig(nsmdName, nodes[0].Node, &pods.NSMDPodConfig{})) // Recovery NSEs
+	icmpPod = nsmd_test_utils.DeployICMP(k8s, nodes[0].Node, "icmp-responder-nse-2", defaultTimeout)
+	Expect(icmpPod).ToNot(BeNil())
+}

--- a/test/integration/nsmd_test_utils/test_utils.go
+++ b/test/integration/nsmd_test_utils/test_utils.go
@@ -156,7 +156,7 @@ func printNSMDLogs(k8s *kube_testing.K8s, nsmdPod *v1.Pod, k int) {
 	nsmdk8sLogs, _ := k8s.GetLogs(nsmdPod, "nsmd-k8s")
 	logrus.Errorf("===================== NSMD K8S %d output since test is failing %v\n=====================", k, nsmdk8sLogs)
 	nsmdpLogs, _ := k8s.GetLogs(nsmdPod, "nsmdp")
-	logrus.Errorf("===================== NSMD K8S %d output since test is failing %v\n=====================", k, nsmdpLogs)
+	logrus.Errorf("===================== NSMD K8P %d output since test is failing %v\n=====================", k, nsmdpLogs)
 }
 
 type NSCCheckInfo struct {

--- a/test/integration/nsmd_test_utils/test_utils.go
+++ b/test/integration/nsmd_test_utils/test_utils.go
@@ -82,9 +82,15 @@ func deployNsmdAndDataplane(k8s *kube_testing.K8s, node *v1.Node, corePods []*v1
 	Expect(nsmd.Name).To(Equal(corePods[0].Name))
 	Expect(dataplane.Name).To(Equal(corePods[1].Name))
 
-	k8s.WaitLogsContains(dataplane, "", "Sending MonitorMechanisms update", timeout)
-	k8s.WaitLogsContains(nsmd, "nsmd", "NSM gRPC API Server: [::]:5001 is operational", timeout)
-	k8s.WaitLogsContains(nsmd, "nsmdp", "ListAndWatch was called with", timeout)
+	failures := InterceptGomegaFailures(func() {
+		k8s.WaitLogsContains(dataplane, "", "Sending MonitorMechanisms update", timeout)
+		k8s.WaitLogsContains(nsmd, "nsmd", "NSM gRPC API Server: [::]:5001 is operational", timeout)
+		k8s.WaitLogsContains(nsmd, "nsmdp", "ListAndWatch was called with", timeout)
+	})
+	if len(failures) > 0 {
+		printNSMDLogs(k8s, nsmd, 0 )
+		printDataplaneLogs(k8s, dataplane, 0)
+	}
 	err = nil
 	return
 }
@@ -133,18 +139,24 @@ func DeployNSC(k8s *kube_testing.K8s, node *v1.Node, name string, timeout time.D
 func PrintLogs(k8s *kube_testing.K8s, nodesSetup []*NodeConf) {
 	for k := 0; k < len(nodesSetup); k++ {
 		nsmdPod := nodesSetup[k].Nsmd
-		nsmdLogs, _ := k8s.GetLogs(nsmdPod, "nsmd")
-		logrus.Errorf("===================== NSMD %d output since test is failing %v\n=====================", k, nsmdLogs)
+		printNSMDLogs(k8s, nsmdPod, k)
 
-		nsmdk8sLogs, _ := k8s.GetLogs(nsmdPod, "nsmd-k8s")
-		logrus.Errorf("===================== NSMD K8S %d output since test is failing %v\n=====================", k, nsmdk8sLogs)
-
-		nsmdpLogs, _ := k8s.GetLogs(nsmdPod, "nsmdp")
-		logrus.Errorf("===================== NSMD K8S %d output since test is failing %v\n=====================", k, nsmdpLogs)
-
-		dataplaneLogs, _ := k8s.GetLogs(nodesSetup[k].Dataplane, "")
-		logrus.Errorf("===================== Dataplane %d output since test is failing %v\n=====================", k, dataplaneLogs)
+		printDataplaneLogs(k8s, nodesSetup[k].Dataplane, k)
 	}
+}
+
+func printDataplaneLogs(k8s *kube_testing.K8s, dataplane *v1.Pod, k int) {
+	dataplaneLogs, _ := k8s.GetLogs(dataplane, "")
+	logrus.Errorf("===================== Dataplane %d output since test is failing %v\n=====================", k, dataplaneLogs)
+}
+
+func printNSMDLogs(k8s *kube_testing.K8s, nsmdPod *v1.Pod, k int) {
+	nsmdLogs, _ := k8s.GetLogs(nsmdPod, "nsmd")
+	logrus.Errorf("===================== NSMD %d output since test is failing %v\n=====================", k, nsmdLogs)
+	nsmdk8sLogs, _ := k8s.GetLogs(nsmdPod, "nsmd-k8s")
+	logrus.Errorf("===================== NSMD K8S %d output since test is failing %v\n=====================", k, nsmdk8sLogs)
+	nsmdpLogs, _ := k8s.GetLogs(nsmdPod, "nsmdp")
+	logrus.Errorf("===================== NSMD K8S %d output since test is failing %v\n=====================", k, nsmdpLogs)
 }
 
 type NSCCheckInfo struct {

--- a/test/integration/recover_nse_nsm_heal_test.go
+++ b/test/integration/recover_nse_nsm_heal_test.go
@@ -1,0 +1,129 @@
+// +build recover
+
+package nsmd_integration_tests
+
+import (
+	"fmt"
+	"github.com/networkservicemesh/networkservicemesh/test/integration/nsmd_test_utils"
+	"github.com/networkservicemesh/networkservicemesh/test/kube_testing/pods"
+	"testing"
+	"time"
+
+	"github.com/networkservicemesh/networkservicemesh/test/kube_testing"
+	. "github.com/onsi/gomega"
+	"github.com/sirupsen/logrus"
+)
+
+func TestNSMHealRemoteDieNSMD_NSE(t *testing.T) {
+	RegisterTestingT(t)
+
+	if testing.Short() {
+		t.Skip("Skip, please run without -short")
+		return
+	}
+
+	k8s, err := kube_testing.NewK8s()
+	defer k8s.Cleanup()
+
+	Expect(err).To(BeNil())
+
+	s1 := time.Now()
+	k8s.Prepare("nsmd", "nsc", "nsmd-dataplane", "icmp-responder-nse", "jaeger")
+	logrus.Printf("Cleanup done: %v", time.Since(s1))
+
+	// Deploy open tracing to see what happening.
+	nodes_setup := nsmd_test_utils.SetupNodes(k8s, 2, defaultTimeout )
+
+	// Run ICMP on latest node
+	icmpPod := nsmd_test_utils.DeployICMP(k8s, nodes_setup[1].Node, "icmp-responder-nse-1", defaultTimeout)
+
+	nscPodNode := nsmd_test_utils.DeployNSC(k8s, nodes_setup[0].Node, "nsc-1", defaultTimeout, false)
+	var nscInfo *nsmd_test_utils.NSCCheckInfo
+	failures := InterceptGomegaFailures(func() {
+		nscInfo = nsmd_test_utils.CheckNSC(k8s, t, nscPodNode)
+	})
+	// Do dumping of container state to dig into what is happened.
+	printErrors(failures, k8s, nodes_setup, nscInfo, t)
+
+	logrus.Infof("Delete Remote NSMD")
+	k8s.DeletePods(nodes_setup[1].Nsmd)
+
+	k8s.DeletePods(icmpPod)
+
+	logrus.Infof("Waiting for NSE with network service")
+	k8s.WaitLogsContains(nodes_setup[0].Nsmd, "nsmd", "Waiting for NSE with network service icmp-responder. Since elapsed:", 60*time.Second)
+	// Now are are in dataplane dead state, and in Heal procedure waiting for dataplane.
+	nsmdName := fmt.Sprintf("nsmd-worker-recovered-%d", 1)
+
+	logrus.Infof("Starting recovered NSMD...")
+	startTime := time.Now()
+	nodes_setup[1].Nsmd = k8s.CreatePod(pods.NSMDPod(nsmdName, nodes_setup[1].Node)) // Recovery NSEs
+	logrus.Printf("Started new NSMD: %v on node %s", time.Since(startTime), nodes_setup[1].Node.Name)
+
+	failures = InterceptGomegaFailures(func() {
+		// Restore ICMP responder pod.
+		icmpPod = nsmd_test_utils.DeployICMP(k8s, nodes_setup[1].Node, "icmp-responder-nse-2", defaultTimeout)
+
+		logrus.Infof("Waiting for connection recovery...")
+		k8s.WaitLogsContains(nodes_setup[0].Nsmd, "nsmd", "Heal: Connection recovered:", 60*time.Second)
+		logrus.Infof("Waiting for connection recovery Done...")
+
+		nscInfo = nsmd_test_utils.CheckNSC(k8s, t, nscPodNode)
+	})
+	printErrors(failures, k8s, nodes_setup, nscInfo, t)
+}
+
+func TestNSMHealRemoteDieNSMD(t *testing.T) {
+	RegisterTestingT(t)
+
+	if testing.Short() {
+		t.Skip("Skip, please run without -short")
+		return
+	}
+
+	k8s, err := kube_testing.NewK8s()
+	defer k8s.Cleanup()
+
+	Expect(err).To(BeNil())
+
+	s1 := time.Now()
+	k8s.Prepare("nsmd", "nsc", "nsmd-dataplane", "icmp-responder-nse", "jaeger")
+	logrus.Printf("Cleanup done: %v", time.Since(s1))
+
+	// Deploy open tracing to see what happening.
+	nodes_setup := nsmd_test_utils.SetupNodes(k8s, 2, defaultTimeout)
+
+	// Run ICMP on latest node
+	icmpPod := nsmd_test_utils.DeployICMP(k8s, nodes_setup[1].Node, "icmp-responder-nse-1", defaultTimeout)
+	Expect(icmpPod).ToNot(BeNil())
+
+	nscPodNode := nsmd_test_utils.DeployNSC(k8s, nodes_setup[0].Node, "nsc-1", defaultTimeout, false)
+	var nscInfo *nsmd_test_utils.NSCCheckInfo
+	failures := InterceptGomegaFailures(func() {
+		nscInfo = nsmd_test_utils.CheckNSC(k8s, t, nscPodNode)
+	})
+	// Do dumping of container state to dig into what is happened.
+	printErrors(failures, k8s, nodes_setup, nscInfo, t)
+
+	logrus.Infof("Delete Remote NSMD")
+	k8s.DeletePods(nodes_setup[1].Nsmd)
+
+	logrus.Infof("Waiting for NSE with network service")
+	k8s.WaitLogsContains(nodes_setup[0].Nsmd, "nsmd", "Waiting for NSE with network service icmp-responder. Since elapsed:", defaultTimeout)
+	// Now are are in dataplane dead state, and in Heal procedure waiting for dataplane.
+	nsmdName := fmt.Sprintf("nsmd-worker-recovered-%d", 1)
+
+	logrus.Infof("Starting recovered NSMD...")
+	startTime := time.Now()
+	nodes_setup[1].Nsmd = k8s.CreatePod(pods.NSMDPod(nsmdName, nodes_setup[1].Node)) // Recovery NSEs
+	logrus.Printf("Started new NSMD: %v on node %s", time.Since(startTime), nodes_setup[1].Node.Name)
+
+	failures = InterceptGomegaFailures(func() {
+		logrus.Infof("Waiting for connection recovery...")
+		k8s.WaitLogsContains(nodes_setup[0].Nsmd, "nsmd", "Heal: Connection recovered:", defaultTimeout)
+		logrus.Infof("Waiting for connection recovery Done...")
+
+		nscInfo = nsmd_test_utils.CheckNSC(k8s, t, nscPodNode)
+	})
+	printErrors(failures, k8s, nodes_setup, nscInfo, t)
+}

--- a/test/integration/recover_nse_nsm_heal_test.go
+++ b/test/integration/recover_nse_nsm_heal_test.go
@@ -57,7 +57,7 @@ func TestNSMHealRemoteDieNSMD_NSE(t *testing.T) {
 
 	logrus.Infof("Starting recovered NSMD...")
 	startTime := time.Now()
-	nodes_setup[1].Nsmd = k8s.CreatePod(pods.NSMDPod(nsmdName, nodes_setup[1].Node)) // Recovery NSEs
+	nodes_setup[1].Nsmd = k8s.CreatePod(pods.NSMDPodWithConfig(nsmdName, nodes_setup[1].Node, &pods.NSMDPodConfig{})) // Recovery NSEs
 	logrus.Printf("Started new NSMD: %v on node %s", time.Since(startTime), nodes_setup[1].Node.Name)
 
 	failures = InterceptGomegaFailures(func() {
@@ -115,7 +115,7 @@ func TestNSMHealRemoteDieNSMD(t *testing.T) {
 
 	logrus.Infof("Starting recovered NSMD...")
 	startTime := time.Now()
-	nodes_setup[1].Nsmd = k8s.CreatePod(pods.NSMDPod(nsmdName, nodes_setup[1].Node)) // Recovery NSEs
+	nodes_setup[1].Nsmd = k8s.CreatePod(pods.NSMDPodWithConfig(nsmdName, nodes_setup[1].Node, &pods.NSMDPodConfig{})) // Recovery NSEs
 	logrus.Printf("Started new NSMD: %v on node %s", time.Since(startTime), nodes_setup[1].Node.Name)
 
 	failures = InterceptGomegaFailures(func() {
@@ -170,7 +170,7 @@ func TestNSMHealLocalDieNSMD(t *testing.T) {
 
 	logrus.Infof("Starting recovered NSMD...")
 	startTime := time.Now()
-	nodes_setup[0].Nsmd = k8s.CreatePod(pods.NSMDPod(nsmdName, nodes_setup[0].Node)) // Recovery NSEs
+	nodes_setup[0].Nsmd = k8s.CreatePod(pods.NSMDPodWithConfig(nsmdName, nodes_setup[0].Node, &pods.NSMDPodConfig{})) // Recovery NSEs
 	logrus.Printf("Started new NSMD: %v on node %s", time.Since(startTime), nodes_setup[0].Node.Name)
 
 	failures = InterceptGomegaFailures(func() {

--- a/test/integration/recover_nse_nsm_heal_test.go
+++ b/test/integration/recover_nse_nsm_heal_test.go
@@ -4,6 +4,7 @@ package nsmd_integration_tests
 
 import (
 	"fmt"
+	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/nsm"
 	"github.com/networkservicemesh/networkservicemesh/test/integration/nsmd_test_utils"
 	"github.com/networkservicemesh/networkservicemesh/test/kube_testing/pods"
 	"testing"
@@ -32,7 +33,13 @@ func TestNSMHealRemoteDieNSMD_NSE(t *testing.T) {
 	logrus.Printf("Cleanup done: %v", time.Since(s1))
 
 	// Deploy open tracing to see what happening.
-	nodes_setup := nsmd_test_utils.SetupNodes(k8s, 2, defaultTimeout )
+	nodes_setup := nsmd_test_utils.SetupNodesConfig(k8s, 2, defaultTimeout, []*pods.NSMDPodConfig{
+		&pods.NSMDPodConfig{
+			Variables: map[string]string {
+				nsm.NsmdHealDSTWaitTimeout: "10", // 10 second delay, since we know NSE is new one.
+			},
+		}, &pods.NSMDPodConfig{},
+	} )
 
 	// Run ICMP on latest node
 	icmpPod := nsmd_test_utils.DeployICMP(k8s, nodes_setup[1].Node, "icmp-responder-nse-1", defaultTimeout)
@@ -171,6 +178,60 @@ func TestNSMHealLocalDieNSMD(t *testing.T) {
 	logrus.Infof("Starting recovered NSMD...")
 	startTime := time.Now()
 	nodes_setup[0].Nsmd = k8s.CreatePod(pods.NSMDPodWithConfig(nsmdName, nodes_setup[0].Node, &pods.NSMDPodConfig{})) // Recovery NSEs
+	logrus.Printf("Started new NSMD: %v on node %s", time.Since(startTime), nodes_setup[0].Node.Name)
+
+	failures = InterceptGomegaFailures(func() {
+		logrus.Infof("Waiting for connection recovery...")
+		k8s.WaitLogsContains(nodes_setup[0].Nsmd, "nsmd", "Heal: Connection recovered:", defaultTimeout)
+		logrus.Infof("Waiting for connection recovery Done...")
+
+		nscInfo = nsmd_test_utils.CheckNSC(k8s, t, nscPodNode)
+	})
+	printErrors(failures, k8s, nodes_setup, nscInfo, t)
+}
+
+func TestNSMHealLocalDieNSMDOneNode(t *testing.T) {
+	RegisterTestingT(t)
+
+	if testing.Short() {
+		t.Skip("Skip, please run without -short")
+		return
+	}
+
+	k8s, err := kube_testing.NewK8s()
+	defer k8s.Cleanup()
+
+	Expect(err).To(BeNil())
+
+	s1 := time.Now()
+	k8s.Prepare("nsmd", "nsc", "nsmd-dataplane", "icmp-responder-nse", "jaeger")
+	logrus.Printf("Cleanup done: %v", time.Since(s1))
+
+	// Deploy open tracing to see what happening.
+	nodes_setup := nsmd_test_utils.SetupNodes(k8s, 1, defaultTimeout)
+
+	// Run ICMP on latest node
+	icmpPod := nsmd_test_utils.DeployICMP(k8s, nodes_setup[0].Node, "icmp-responder-nse-1", defaultTimeout)
+	Expect(icmpPod).ToNot(BeNil())
+
+	nscPodNode := nsmd_test_utils.DeployNSC(k8s, nodes_setup[0].Node, "nsc-1", defaultTimeout, false)
+	var nscInfo *nsmd_test_utils.NSCCheckInfo
+	failures := InterceptGomegaFailures(func() {
+		nscInfo = nsmd_test_utils.CheckNSC(k8s, t, nscPodNode)
+	})
+	// Do dumping of container state to dig into what is happened.
+	printErrors(failures, k8s, nodes_setup, nscInfo, t)
+
+	logrus.Infof("Delete Local NSMD")
+	k8s.DeletePods(nodes_setup[0].Nsmd)
+
+	// Now are are in dataplane dead state, and in Heal procedure waiting for dataplane.
+	nsmdName := fmt.Sprintf("%s-recovered", nodes_setup[0].Nsmd.Name)
+
+	logrus.Infof("Starting recovered NSMD...")
+	startTime := time.Now()
+	nodes_setup[0].Nsmd = k8s.CreatePod(pods.NSMDPodWithConfig(nsmdName, nodes_setup[0].Node, &pods.NSMDPodConfig{
+	})) // Recovery NSEs
 	logrus.Printf("Started new NSMD: %v on node %s", time.Since(startTime), nodes_setup[0].Node.Name)
 
 	failures = InterceptGomegaFailures(func() {

--- a/test/integration/recover_nse_nsm_heal_test.go
+++ b/test/integration/recover_nse_nsm_heal_test.go
@@ -127,3 +127,58 @@ func TestNSMHealRemoteDieNSMD(t *testing.T) {
 	})
 	printErrors(failures, k8s, nodes_setup, nscInfo, t)
 }
+
+func TestNSMHealLocalDieNSMD(t *testing.T) {
+	RegisterTestingT(t)
+
+	if testing.Short() {
+		t.Skip("Skip, please run without -short")
+		return
+	}
+
+	k8s, err := kube_testing.NewK8s()
+	defer k8s.Cleanup()
+
+	Expect(err).To(BeNil())
+
+	s1 := time.Now()
+	k8s.Prepare("nsmd", "nsc", "nsmd-dataplane", "icmp-responder-nse", "jaeger")
+	logrus.Printf("Cleanup done: %v", time.Since(s1))
+
+	// Deploy open tracing to see what happening.
+	nodes_setup := nsmd_test_utils.SetupNodes(k8s, 2, defaultTimeout)
+
+	// Run ICMP on latest node
+	icmpPod := nsmd_test_utils.DeployICMP(k8s, nodes_setup[1].Node, "icmp-responder-nse-1", defaultTimeout)
+	Expect(icmpPod).ToNot(BeNil())
+
+	nscPodNode := nsmd_test_utils.DeployNSC(k8s, nodes_setup[0].Node, "nsc-1", defaultTimeout, false)
+	var nscInfo *nsmd_test_utils.NSCCheckInfo
+	failures := InterceptGomegaFailures(func() {
+		nscInfo = nsmd_test_utils.CheckNSC(k8s, t, nscPodNode)
+	})
+	// Do dumping of container state to dig into what is happened.
+	printErrors(failures, k8s, nodes_setup, nscInfo, t)
+
+	logrus.Infof("Delete Local NSMD")
+	k8s.DeletePods(nodes_setup[0].Nsmd)
+
+	logrus.Infof("Waiting for NSE with network service")
+	k8s.WaitLogsContains(nodes_setup[1].Nsmd, "nsmd", "NSM: Remote opened connection is not monitored and put into Healing state", defaultTimeout)
+	// Now are are in dataplane dead state, and in Heal procedure waiting for dataplane.
+	nsmdName := fmt.Sprintf("%s-recovered", nodes_setup[0].Nsmd.Name)
+
+	logrus.Infof("Starting recovered NSMD...")
+	startTime := time.Now()
+	nodes_setup[0].Nsmd = k8s.CreatePod(pods.NSMDPod(nsmdName, nodes_setup[0].Node)) // Recovery NSEs
+	logrus.Printf("Started new NSMD: %v on node %s", time.Since(startTime), nodes_setup[0].Node.Name)
+
+	failures = InterceptGomegaFailures(func() {
+		logrus.Infof("Waiting for connection recovery...")
+		k8s.WaitLogsContains(nodes_setup[0].Nsmd, "nsmd", "Heal: Connection recovered:", defaultTimeout)
+		logrus.Infof("Waiting for connection recovery Done...")
+
+		nscInfo = nsmd_test_utils.CheckNSC(k8s, t, nscPodNode)
+	})
+	printErrors(failures, k8s, nodes_setup, nscInfo, t)
+}

--- a/test/kube_testing/k8s.go
+++ b/test/kube_testing/k8s.go
@@ -334,6 +334,7 @@ func (l *K8s) Cleanup() {
 		Expect(err).To(BeNil())
 	}
 	l.CleanupCRDs()
+	l.pods = nil
 }
 
 func (l *K8s) Prepare(noPods ...string) {

--- a/test/kube_testing/pods/nsmd.go
+++ b/test/kube_testing/pods/nsmd.go
@@ -1,6 +1,7 @@
 package pods
 
 import (
+	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/nsmd"
 	"k8s.io/api/core/v1"
 	v12 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"os"
@@ -12,6 +13,7 @@ const (
 )
 
 var DefaultNSMD = map[string]string{
+	nsmd.NsmdDeleteLocalRegistry: "true", // Do not use local registry restore for clients/NSEs
 }
 
 func newNSMMount() v1.VolumeMount {


### PR DESCRIPTION
Implement NSMD die Healing for Remote/Local cases.

## Description

* Remote NSMD die handling.
* Source NSMD die handling.
* Local NSE/Client registry for NSMD recovery.
* Recover active connections from Dataplane.

## Motivation and Context
Heal is essential part of NSM, we need to be able to recover from most of die situations.

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [x] Covered by existing integration testing
- [x] Added integration testing to cover
- [x] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
