### PR TITLE
Fix race condition in nsmd/nsmdp startup.

### DIFF
--- a/controlplane/pkg/nsmd/nsmd.go
+++ b/controlplane/pkg/nsmd/nsmd.go
@@ -130,16 +130,16 @@ func StartNSMServer(model model.Model, manager nsm.NetworkServiceManager, servic
 		logrus.Errorf("failed to start device plugin grpc server %+v", err)
 		return err
 	}
-	err = setLocalNSM(model, serviceRegistry)
-	if err != nil {
-		logrus.Errorf("failed to set local NSM %+v", err)
-		return err
-	}
 	go func() {
 		if err := grpcServer.Serve(sock); err != nil {
 			logrus.Error("failed to start device plugin grpc server")
 		}
 	}()
+	err = setLocalNSM(model, serviceRegistry)
+	if err != nil {
+		logrus.Errorf("failed to set local NSM %+v", err)
+		return err
+	}
 
 	// Check if the socket of NSM server is operation
 	_, conn, err := serviceRegistry.NSMDApiClient()


### PR DESCRIPTION
nsmd was listening on the socket for nsmdp requests...
but then went and did a bunch of other stuff before having
the grpc ClientAPI Serve on that socket.  This led to a race
condition.



<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [x] Covered by existing integration testing
- [ ] Added integration testing to cover
- [ ] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.