### PR TITLE
Fix IPAM to properly handle IPv6 Loopbacks

### DIFF
--- a/controlplane/pkg/tests/nsmd_remote_test.go
+++ b/controlplane/pkg/tests/nsmd_remote_test.go
@@ -2,6 +2,8 @@ package tests
 
 import (
 	"context"
+	"testing"
+
 	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/connectioncontext"
 	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/local/connection"
 	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/local/networkservice"
@@ -9,7 +11,6 @@ import (
 	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/model"
 	. "github.com/onsi/gomega"
 	"github.com/sirupsen/logrus"
-	"testing"
 )
 
 // Below only tests
@@ -87,7 +88,7 @@ func TestNSMDCloseCrossConnection(t *testing.T) {
 				Type: connection2.MechanismType_VXLAN,
 				Parameters: map[string]string{
 					connection2.VXLANVNI:   "1",
-					connection2.VXLANSrcIP: "127.0.0.1",
+					connection2.VXLANSrcIP: "10.1.1.1",
 				},
 			},
 		},
@@ -101,7 +102,7 @@ func TestNSMDCloseCrossConnection(t *testing.T) {
 				Type: connection2.MechanismType_VXLAN,
 				Parameters: map[string]string{
 					connection2.VXLANVNI:   "3",
-					connection2.VXLANSrcIP: "127.0.0.2",
+					connection2.VXLANSrcIP: "10.1.1.2",
 				},
 			},
 		},

--- a/sdk/endpoint/composite/ipam.go
+++ b/sdk/endpoint/composite/ipam.go
@@ -79,7 +79,7 @@ func (ice *IpamCompositeEndpoint) Request(ctx context.Context, request *networks
 			}
 			for _, a := range adrs {
 				addr, _, _ := net.ParseCIDR(a.String())
-				if addr.String() != "127.0.0.1" {
+				if !addr.IsLoopback() {
 					newConnection.Context.IpNeighbors = append(newConnection.Context.IpNeighbors,
 						&connectioncontext.IpNeighbor{
 							Ip:              addr.String(),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

IpamCompositeEndpoint was not properly excluding IPv6 loopback addresses from the IP Neighbors.  Since those addresses are on loopbacks, and loopbacks have no HW addresses, IPNeighbors without HW addresses were being sent and broke the Dataplane.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [x] Covered by existing integration testing
- [ ] Added integration testing to cover
- [x] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.