### PR TITLE
Adding initial support for kind.sigs.k8s.io

### DIFF
--- a/.mk/k8s.mk
+++ b/.mk/k8s.mk
@@ -40,6 +40,11 @@ endif
 include .mk/vagrant.mk
 include .mk/packet.mk
 
+# .kind.mk enables the kind.sigs.k8s.io docker based K8s install:
+# export CLUSTER_RULES_PREFIX=kind
+# before running make
+include .mk/kind.mk
+
 # .null.mk allows you to skip the vagrant machinery with:
 # export CLUSTER_RULES_PREFIX=null
 # before running make

--- a/.mk/kind.mk
+++ b/.mk/kind.mk
@@ -1,0 +1,47 @@
+# Copyright 2019 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+KIND_CLUSTER_NAME="nsm"
+KIND_IMAGE_PATH=./scripts/vagrant/images/
+
+.PHONY: kind-config
+kind-config:
+	@which kind >/dev/null 2>&1 || \
+		GO111MODULE=off go get -u sigs.k8s.io/kind
+
+.PHONY: kind-start
+kind-start: kind-config
+	@kind get clusters | grep nsm  >/dev/null 2>&1 || \
+		( kind create cluster --name="$(KIND_CLUSTER_NAME)" --config ./scripts/kind.yaml && \
+		KUBECONFIG="$$(kind get kubeconfig-path --name="$(KIND_CLUSTER_NAME)")" \
+		kubectl taint node $(KIND_CLUSTER_NAME)-control-plane node-role.kubernetes.io/master:NoSchedule- )
+
+.PHONY: kind-stop
+kind-stop:
+	@kind delete cluster --name="$(KIND_CLUSTER_NAME)"
+
+.PHONY: kind-restart
+kind-restart: kind-stop kind-start
+	@echo "kind cluster restarted"
+
+.PHONY: kind-%-load-images
+kind-%-load-images:
+	@if [ -e "$(KIND_IMAGE_PATH)/$*.tar" ]; then \
+		echo "Loading image $*.tar to kind"; \
+		kind load image-archive --name="$(KIND_CLUSTER_NAME)" $(KIND_IMAGE_PATH)$*.tar ; \
+	else \
+		echo "Cannot load $*.tar: scripts/vagrant/images/$*.tar does not exist.  Try running 'make k8s-$*-save'"; \
+		exit 1; \
+	fi

--- a/.mk/kind.mk
+++ b/.mk/kind.mk
@@ -25,8 +25,10 @@ kind-config:
 kind-start: kind-config
 	@kind get clusters | grep nsm  >/dev/null 2>&1 || \
 		( kind create cluster --name="$(KIND_CLUSTER_NAME)" --config ./scripts/kind.yaml && \
-		KUBECONFIG="$$(kind get kubeconfig-path --name="$(KIND_CLUSTER_NAME)")" \
-		kubectl taint node $(KIND_CLUSTER_NAME)-control-plane node-role.kubernetes.io/master:NoSchedule- )
+		until \
+			KUBECONFIG="$$(kind get kubeconfig-path --name="$(KIND_CLUSTER_NAME)")" \
+			kubectl taint node $(KIND_CLUSTER_NAME)-control-plane node-role.kubernetes.io/master:NoSchedule- ; \
+		do echo "Waiting for the cluster to come up" && sleep 3; done )
 
 .PHONY: kind-stop
 kind-stop:

--- a/docs/guide-kind.md
+++ b/docs/guide-kind.md
@@ -1,0 +1,49 @@
+# Using `kind` as a cluster provider
+
+[`kind`](kind.sigs.k8s.io) is a tool for running local Kubernetes clusters using Docker container “nodes”.
+Docker is the only prerequisite, it does not require any additional steps, hypervisors etc.
+
+It is worth noting that `kind` as any other Kubernetes deplyment tool would expect that the machine that hostst the Docker has at lease 4 CPU cores and 4 GB of RAM. That is specifically pointed for OSX users in the official [docs](https://kind.sigs.k8s.io/docs/user/quick-start/).
+
+
+## `kind` lifecycle management
+
+To start a `kind` cluster, just run:
+
+```shell
+$ make kind-start
+Creating cluster "nsm" ...
+ ✓ Ensuring node image (kindest/node:v1.13.3) 🖼
+ ✓ Preparing nodes 📦📦📦
+ ✓ Creating kubeadm config 📜
+ ✓ Starting control-plane 🕹️
+ ✓ Joining worker nodes 🚜
+Cluster creation complete. You can now use the cluster with:
+
+export KUBECONFIG="$(kind get kubeconfig-path --name="nsm")"
+kubectl cluster-info
+node/nsm-control-plane untainted
+```
+
+As seen on the last lines, to point your `kubectl` command to the new cluster one shoudl run:
+
+```shell
+export KUBECONFIG="$(kind get kubeconfig-path --name="nsm")"
+```
+
+Deleting the cluster is as easy as:
+
+```shell
+$ make kind-stop
+Deleting cluster "nsm" ...
+$KUBECONFIG is still set to use /Users/nnikolay/.kube/kind-config-nsm even though that file has been deleted, remember to unset it
+```
+
+## `kind` as a cluster provide in Network Service Mesh
+
+Enabling `kind` instead of the default `vagrant` is as easy as:
+```shell
+export CLUSTER_RULES_PREFIX=kind
+```
+
+All subsequent commands will assume `kind` as the cluster provider.

--- a/scripts/kind.yaml
+++ b/scripts/kind.yaml
@@ -1,0 +1,7 @@
+# three node (two workers) cluster config
+kind: Config
+apiVersion: kind.sigs.k8s.io/v1alpha2
+nodes:
+  - role: control-plane
+  - role: worker
+    replicas: 2


### PR DESCRIPTION
K8s in Docker is a standard way to run K8s tests. We use this tool
here as an alternative cluster provider. Kind is lighter than bringing
up full VMs.

The setup consists of master and 2 nodes. It successfuly runs
make k8s-integration test, so can be used in the CI.

Signed-off-by: Nikolay Nikolaev <nnikolay@vmware.com>


## Description
`kind` can help us have a simpler and lighter weight development environment. We coudl even consider it to become part of our CI.

## Motivation and Context
The `vagrant` environment is complex, slow and resources hungry. Kind provides lighter means to have Kubernetes, depending just on a simple Docker installation.

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [ ] Covered by existing integration testing
- [ ] Added integration testing to cover
- [X] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
