### PR TITLE
Create Helm charts deployment

### DIFF
--- a/docs/guide-helm.md
+++ b/docs/guide-helm.md
@@ -1,0 +1,49 @@
+# Using Helm to install NSM on kubernetes cluster
+
+This document will show you how to use `Helm` for `NSM` installation. 
+
+##Helm installation
+[Helm Installation Guide](https://helm.sh/docs/using_helm/#quickstart-guide)
+
+##Useful Helm commands
+* `$ helm install PATH_TO_CHART` - install specified chart on cluster
+* `$ helm ls` - list of deployed releases and their states
+* `$ helm delete RELEASE_NAME` - delete release
+
+##Using Helm for NSM installation
+```bash
+$ helm install helm/nsm
+```
+
+*Note: in case of `Error: no available release name found` do (according to [issue](https://github.com/helm/helm/issues/4412)):*
+```bash
+$ kubectl create serviceaccount --namespace kube-system tiller
+$ kubectl create clusterrolebinding tiller-cluster-rule --clusterrole=cluster-admin --serviceaccount=kube-system:tiller
+$ kubectl patch deploy --namespace kube-system tiller-deploy -p '{"spec":{"template":{"spec":{"serviceAccount":"tiller"}}}}'
+```
+
+##Using Helm to install examples
+After installation of NSM on cluster you can install examples to check correctness of cluster configuration.
+
+Install simple NSC and icmp-responder:
+```
+helm install helm/icmp-responder
+```
+
+Install vppagent-nsc and vppagent-icmp-responder:
+```
+helm install helm/vpp-icmp-responder
+```
+
+Install vpn-gateway-nsc, vpp-gateway-nse and vppagent-firewall-nse:
+```
+helm install helm/vpn
+```
+
+##Values specification
+Every chart has file `values.yaml`. Now there is a possibility to specify docker registry and tag for images in this file:
+
+```yaml
+registry: docker.io
+tag: latest
+```

--- a/docs/guide-helm.md
+++ b/docs/guide-helm.md
@@ -2,15 +2,15 @@
 
 This document will show you how to use `Helm` for `NSM` installation. 
 
-##Helm installation
+## Helm installation
 [Helm Installation Guide](https://helm.sh/docs/using_helm/#quickstart-guide)
 
-##Useful Helm commands
+## Useful Helm commands
 * `$ helm install PATH_TO_CHART` - install specified chart on cluster
 * `$ helm ls` - list of deployed releases and their states
 * `$ helm delete RELEASE_NAME` - delete release
 
-##Using Helm for NSM installation
+## Using Helm for NSM installation
 ```bash
 $ helm install helm/nsm
 ```
@@ -22,7 +22,7 @@ $ kubectl create clusterrolebinding tiller-cluster-rule --clusterrole=cluster-ad
 $ kubectl patch deploy --namespace kube-system tiller-deploy -p '{"spec":{"template":{"spec":{"serviceAccount":"tiller"}}}}'
 ```
 
-##Using Helm to install examples
+## Using Helm to install examples
 After installation of NSM on cluster you can install examples to check correctness of cluster configuration.
 
 Install simple NSC and icmp-responder:
@@ -40,7 +40,7 @@ Install vpn-gateway-nsc, vpp-gateway-nse and vppagent-firewall-nse:
 helm install helm/vpn
 ```
 
-##Values specification
+## Values specification
 Every chart has file `values.yaml`. Now there is a possibility to specify docker registry and tag for images in this file:
 
 ```yaml

--- a/helm/icmp-responder/.helmignore
+++ b/helm/icmp-responder/.helmignore
@@ -1,0 +1,22 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/helm/icmp-responder/Chart.yaml
+++ b/helm/icmp-responder/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: "1.0"
+description: A Helm chart for Kubernetes
+name: icmp-responder
+version: 0.1.0

--- a/helm/icmp-responder/templates/icmp-responder-nse.tpl
+++ b/helm/icmp-responder/templates/icmp-responder-nse.tpl
@@ -1,0 +1,44 @@
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+spec:
+  replicas: 2
+  template:
+    metadata:
+      labels:
+        networkservicemesh.io/app: "icmp-responder"
+        networkservicemesh.io/impl: "icmp-responder"
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: networkservicemesh.io/app
+                    operator: In
+                    values:
+                      - icmp-responder
+                  - key: networkservicemesh.io/impl
+                    operator: In
+                    values:
+                      - icmp-responder
+              topologyKey: "kubernetes.io/hostname"
+      containers:
+        - name: icmp-responder-nse
+          image: {{ .Values.registry }}/networkservicemesh/icmp-responder-nse:{{ .Values.tag}}
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: ADVERTISE_NSE_NAME
+              value: "icmp-responder"
+            - name: ADVERTISE_NSE_LABELS
+              value: "app=icmp-responder"
+            - name: TRACER_ENABLED
+              value: "true"
+            - name: IP_ADDRESS
+              value: "10.20.1.0/24"
+          resources:
+            limits:
+              networkservicemesh.io/socket: 1
+metadata:
+  name: icmp-responder-nse
+  namespace: default

--- a/helm/icmp-responder/templates/nsc.yaml
+++ b/helm/icmp-responder/templates/nsc.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+spec:
+  replicas: 4
+  template:
+    metadata:
+      labels:
+        networkservicemesh.io/app: "icmp-responder-nsc"
+    spec:
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
+      containers:
+        - name: alpine-img
+          image: alpine:latest
+          command: ['tail', '-f', '/dev/null']
+metadata:
+  name: nsc-vpp
+  namespace: default
+  annotations:
+    ns.networkservicemesh.io: icmp-responder?app=icmp

--- a/helm/icmp-responder/values.yaml
+++ b/helm/icmp-responder/values.yaml
@@ -1,0 +1,6 @@
+# Default values for icmp-responder.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+registry: docker.io
+tag: latest

--- a/helm/nsm/.helmignore
+++ b/helm/nsm/.helmignore
@@ -1,0 +1,22 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/helm/nsm/Chart.yaml
+++ b/helm/nsm/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: "1.0"
+description: A Helm chart for Kubernetes
+name: nsm
+version: 0.1.0

--- a/helm/nsm/charts/admission-webhook/.helmignore
+++ b/helm/nsm/charts/admission-webhook/.helmignore
@@ -1,0 +1,22 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/helm/nsm/charts/admission-webhook/Chart.yaml
+++ b/helm/nsm/charts/admission-webhook/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: "1.0"
+description: A Helm chart for Kubernetes
+name: admission-webhook
+version: 0.1.0

--- a/helm/nsm/charts/admission-webhook/templates/admission-webhook-secret.tpl
+++ b/helm/nsm/charts/admission-webhook/templates/admission-webhook-secret.tpl
@@ -1,0 +1,76 @@
+{{- $ca := genCA "admission-controller-ca" 3650 -}}
+{{- $cn := printf "nsm-admission-webhook-svc" -}}
+{{- $altName1 := printf "%s.%s" $cn .Release.Namespace }}
+{{- $altName2 := printf "%s.%s.svc" $cn .Release.Namespace }}
+{{- $cert := genSignedCert $cn nil (list $altName1 $altName2) 3650 $ca -}}
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: nsm-admission-webhook-certs
+type: Opaque
+data:
+  key.pem: {{ $cert.Key | b64enc }}
+  cert.pem: {{ $cert.Cert | b64enc }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nsm-admission-webhook
+  labels:
+    app: nsm-admission-webhook
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nsm-admission-webhook
+  template:
+    metadata:
+      labels:
+        app: nsm-admission-webhook
+    spec:
+      containers:
+        - name: nsm-admission-webhook
+          image: networkservicemesh/admission-webhook
+          imagePullPolicy: IfNotPresent
+          volumeMounts:
+            - name: webhook-certs
+              mountPath: /etc/webhook/certs
+              readOnly: true
+      volumes:
+        - name: webhook-certs
+          secret:
+            secretName: nsm-admission-webhook-certs
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: nsm-admission-webhook-svc
+  labels:
+    app: nsm-admission-webhook
+spec:
+  ports:
+    - port: 443
+      targetPort: 443
+  selector:
+    app: nsm-admission-webhook
+---
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: nsm-admission-webhook-cfg
+  labels:
+    app: nsm-admission-webhook
+webhooks:
+  - name: admission-webhook.networkservicemesh.io
+    clientConfig:
+      service:
+        name: nsm-admission-webhook-svc
+        namespace: default
+        path: "/mutate"
+      caBundle: {{ $ca.Cert | b64enc }}
+    rules:
+      - operations: ["CREATE"]
+        apiGroups: ["apps", "extensions", ""]
+        apiVersions: ["v1", "v1beta1"]
+        resources: ["deployments", "services", "pods"]

--- a/helm/nsm/charts/admission-webhook/values.yaml
+++ b/helm/nsm/charts/admission-webhook/values.yaml
@@ -1,0 +1,3 @@
+# Default values for admission-webhook.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.

--- a/helm/nsm/charts/jaeger/.helmignore
+++ b/helm/nsm/charts/jaeger/.helmignore
@@ -1,0 +1,22 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/helm/nsm/charts/jaeger/Chart.yaml
+++ b/helm/nsm/charts/jaeger/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: "1.0"
+description: A Helm chart for Kubernetes
+name: jaeger
+version: 0.1.0

--- a/helm/nsm/charts/jaeger/templates/jaeger.yaml
+++ b/helm/nsm/charts/jaeger/templates/jaeger.yaml
@@ -1,0 +1,41 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: jaeger
+spec:
+  selector:
+    matchLabels:
+      run: jaeger
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        run: jaeger
+    spec:
+      containers:
+        - name: jaeger
+          image: jaegertracing/all-in-one:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 16686
+            - name: jaeger
+              containerPort: 6831
+              protocol: UDP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: jaeger
+  labels:
+    run: jaeger
+spec:
+  ports:
+    - name: http
+      port: 16686
+      protocol: TCP
+    - name: jaeger
+      port: 6831
+      protocol: UDP
+  selector:
+    run: jaeger

--- a/helm/nsm/charts/jaeger/values.yaml
+++ b/helm/nsm/charts/jaeger/values.yaml
@@ -1,0 +1,3 @@
+# Default values for jaeger.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.

--- a/helm/nsm/charts/skydive/.helmignore
+++ b/helm/nsm/charts/skydive/.helmignore
@@ -1,0 +1,22 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/helm/nsm/charts/skydive/Chart.yaml
+++ b/helm/nsm/charts/skydive/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: "1.0"
+description: A Helm chart for Kubernetes
+name: skydive
+version: 0.1.0

--- a/helm/nsm/charts/skydive/templates/crossconnect-monitor.tpl
+++ b/helm/nsm/charts/skydive/templates/crossconnect-monitor.tpl
@@ -1,0 +1,16 @@
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+spec:
+  template:
+    metadata:
+      labels:
+        app: nsmd-ds
+    spec:
+      containers:
+        - name: crossconnect-monitor
+          image: {{ .Values.registry }}/networkservicemesh/crossconnect-monitor:{{ .Values.tag }}
+          imagePullPolicy: IfNotPresent
+metadata:
+  name: crossconnect-monitor
+  namespace: default

--- a/helm/nsm/charts/skydive/templates/skydive.yaml
+++ b/helm/nsm/charts/skydive/templates/skydive.yaml
@@ -1,0 +1,141 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: skydive-analyzer
+  labels:
+    app: skydive-analyzer
+spec:
+  type: NodePort
+  ports:
+    - port: 8082
+      name: api
+    - port: 8082
+      name: protobuf
+      protocol: UDP
+    - port: 12379
+      name: etcd
+    - port: 12380
+      name: etcd-cluster
+  selector:
+    app: skydive
+    tier: analyzer
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: skydive-analyzer-config-file
+data:
+  skydive.yml: |
+    storage:
+      mymemory:
+        driver: memory
+
+    logging:
+      level: DEBUG
+
+    agent:
+      topology:
+        probes:
+          - docker
+
+    analyzer:
+      listen: 0.0.0.0:8082
+      topology:
+        probes:
+          - nsm
+        backend: mymemory
+      flow:
+        backend: mymemory
+
+    etcd:
+      data_dir: /tmp/skydive/etcd
+      listen: 0.0.0.0:12379
+
+    ui:
+      topology:
+        favorites:
+          nsm-filter: "G.V().Has('Type', 'container', 'Docker.Labels.io.kubernetes.pod.namespace', 'default').In('Type', 'netns').Descendants().As('namespaces').G.V().Has('Type', 'host').As('hosts').Select('namespaces', 'hosts')"
+          nsm-filter-secure-intranet-connectivity: "G.V().Has('Type', 'container', 'Docker.Labels.networkservicemesh.io/impl', 'secure-intranet-connectivity').In('Type', 'netns').Descendants().As('namespaces').G.V().Has('Type', 'host').As('hosts').Select('namespaces', 'hosts')"
+          nsm-edges: "G.E().HasKey('NSM')"
+
+        default_filter: "nsm-filter"
+        default_highlight: "nsm-edges"
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: skydive-analyzer
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: skydive
+        tier: analyzer
+    spec:
+      containers:
+        - name: skydive-analyzer
+          image: matrohon/skydive
+          imagePullPolicy: IfNotPresent
+          args:
+            - analyzer
+          ports:
+            - containerPort: 8082
+            - containerPort: 8082
+              protocol: UDP
+            - containerPort: 12379
+            - containerPort: 12380
+          livenessProbe:
+            httpGet:
+              port: 8082
+              path: /api/status
+            initialDelaySeconds: 60
+            periodSeconds: 10
+            failureThreshold: 3
+          volumeMounts:
+            - mountPath: /etc/skydive.yml
+              subPath: skydive.yml
+              name: skydive-analyzer-config-file
+      volumes:
+        - name: skydive-analyzer-config-file
+          configMap:
+            name: skydive-analyzer-config-file
+---
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: skydive-agent
+spec:
+  template:
+    metadata:
+      labels:
+        app: skydive
+        tier: agent
+    spec:
+      hostNetwork: true
+      hostPID: true
+      containers:
+        - name: skydive-agent
+          image: matrohon/skydive
+          imagePullPolicy: IfNotPresent
+          args:
+            - agent
+          ports:
+            - containerPort: 8081
+          env:
+            - name: SKYDIVE_ANALYZERS
+              value: "$(SKYDIVE_ANALYZER_SERVICE_HOST):$(SKYDIVE_ANALYZER_SERVICE_PORT_API)"
+          securityContext:
+            privileged: true
+          volumeMounts:
+            - name: docker
+              mountPath: /var/run/docker.sock
+            - name: run
+              mountPath: /host/run
+      volumes:
+        - name: docker
+          hostPath:
+            path: /var/run/docker.sock
+        - name: run
+          hostPath:
+            path: /var/run/netns

--- a/helm/nsm/charts/skydive/values.yaml
+++ b/helm/nsm/charts/skydive/values.yaml
@@ -2,5 +2,5 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-registry: registry-1.docker.io
+registry: docker.io
 tag: latest

--- a/helm/nsm/charts/skydive/values.yaml
+++ b/helm/nsm/charts/skydive/values.yaml
@@ -1,0 +1,6 @@
+# Default values for skydive.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+registry: registry-1.docker.io
+tag: latest

--- a/helm/nsm/templates/cluster-role-admin.yaml
+++ b/helm/nsm/templates/cluster-role-admin.yaml
@@ -1,0 +1,18 @@
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: nsm-role
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+rules:
+  - apiGroups: ["networkservicemesh.io"]
+    resources:
+      - "networkservices"
+      - "networkserviceendpoints"
+      - "networkservicemanagers"
+    verbs: ["*"]
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions"]
+    verbs: ["*"]

--- a/helm/nsm/templates/cluster-role-binding.yaml
+++ b/helm/nsm/templates/cluster-role-binding.yaml
@@ -1,0 +1,13 @@
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: nsm-role-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: nsm-role
+subjects:
+  - kind: ServiceAccount
+    name: default
+    namespace: default

--- a/helm/nsm/templates/cluster-role-view.yaml
+++ b/helm/nsm/templates/cluster-role-view.yaml
@@ -1,0 +1,12 @@
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: aggregate-network-services-view
+  labels:
+    # Add these permissions to the "view" default role.
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+rules:
+  - apiGroups: ["networkservicemesh.io"]
+    resources: ["networkservices"]
+    verbs: ["get", "list", "watch"]

--- a/helm/nsm/templates/crd-networkserviceendpoints.yaml
+++ b/helm/nsm/templates/crd-networkserviceendpoints.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: networkserviceendpoints.networkservicemesh.io
+spec:
+  conversion:
+    strategy: None
+  group: networkservicemesh.io
+  names:
+    kind: NetworkServiceEndpoint
+    listKind: NetworkServiceEndpointList
+    plural: networkserviceendpoints
+    shortNames:
+      - nse
+      - nses
+    singular: networkserviceendpoint
+  scope: Cluster
+  version: v1
+  versions:
+    - name: v1
+      served: true
+      storage: true

--- a/helm/nsm/templates/crd-networkservicemanagers.yaml
+++ b/helm/nsm/templates/crd-networkservicemanagers.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: networkservicemanagers.networkservicemesh.io
+spec:
+  conversion:
+    strategy: None
+  group: networkservicemesh.io
+  names:
+    kind: NetworkServiceManager
+    listKind: NetworkServiceManagerList
+    plural: networkservicemanagers
+    shortNames:
+      - nsm
+      - nsms
+    singular: networkservicemanager
+  scope: Cluster
+  version: v1
+  versions:
+    - name: v1
+      served: true
+      storage: true

--- a/helm/nsm/templates/crd-networkservices.yaml
+++ b/helm/nsm/templates/crd-networkservices.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: networkservices.networkservicemesh.io
+spec:
+  conversion:
+    strategy: None
+  group: networkservicemesh.io
+  names:
+    kind: NetworkService
+    listKind: NetworkServiceList
+    plural: networkservices
+    shortNames:
+      - netsvc
+      - netsvcs
+    singular: networkservice
+  scope: Cluster
+  version: v1
+  versions:
+    - name: v1
+      served: true
+      storage: true

--- a/helm/nsm/templates/nsmd.tpl
+++ b/helm/nsm/templates/nsmd.tpl
@@ -1,0 +1,56 @@
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: nsmd
+spec:
+  template:
+    metadata:
+      labels:
+        app: nsmd-ds
+    spec:
+      containers:
+        - name: nsmdp
+          image: {{ .Values.registry }}/networkservicemesh/nsmdp:{{ .Values.tag }}
+          imagePullPolicy: IfNotPresent
+          volumeMounts:
+            - name: kubelet-socket
+              mountPath: /var/lib/kubelet/device-plugins
+            - name: nsm-socket
+              mountPath: /var/lib/networkservicemesh
+        - name: nsmd
+          image: {{ .Values.registry }}/networkservicemesh/nsmd:{{ .Values.tag }}
+          imagePullPolicy: IfNotPresent
+          volumeMounts:
+            - name: nsm-socket
+              mountPath: /var/lib/networkservicemesh
+          livenessProbe:
+            httpGet:
+              path: /liveness
+              port: 5555
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 3
+          readinessProbe:
+            httpGet:
+              path: /readiness
+              port: 5555
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 3
+        - name: nsmd-k8s
+          image: {{ .Values.registry }}/networkservicemesh/nsmd-k8s:{{ .Values.tag }}
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+      volumes:
+        - hostPath:
+            path: /var/lib/kubelet/device-plugins
+            type: DirectoryOrCreate
+          name: kubelet-socket
+        - hostPath:
+            path: /var/lib/networkservicemesh
+            type: DirectoryOrCreate
+          name: nsm-socket

--- a/helm/nsm/templates/vppagent-dataplane.tpl
+++ b/helm/nsm/templates/vppagent-dataplane.tpl
@@ -1,0 +1,48 @@
+---
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+spec:
+  template:
+    metadata:
+      labels:
+        app: nsm-vpp-dataplane
+    spec:
+      hostPID: true
+      hostNetwork: true
+      containers:
+        - name: vppagent-dataplane
+          securityContext:
+            privileged: true
+          image: {{ .Values.registry }}/networkservicemesh/vppagent-dataplane:{{ .Values.tag }}
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: NSM_DATAPLANE_SRC_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+          volumeMounts:
+            - name: workspace
+              mountPath: /var/lib/networkservicemesh/
+              mountPropagation: Bidirectional
+          livenessProbe:
+            httpGet:
+              path: /liveness
+              port: 5555
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 3
+          readinessProbe:
+            httpGet:
+              path: /readiness
+              port: 5555
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 3
+      volumes:
+        - hostPath:
+            path: /var/lib/networkservicemesh
+            type: DirectoryOrCreate
+          name: workspace
+metadata:
+  name: nsm-vppagent-dataplane
+  namespace: default

--- a/helm/nsm/values.yaml
+++ b/helm/nsm/values.yaml
@@ -1,0 +1,6 @@
+# Default values for nsm.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+registry: docker.io
+tag: latest

--- a/helm/vpn/.helmignore
+++ b/helm/vpn/.helmignore
@@ -1,0 +1,22 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/helm/vpn/Chart.yaml
+++ b/helm/vpn/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: "1.0"
+description: A Helm chart for Kubernetes
+name: vpn
+version: 0.1.0

--- a/helm/vpn/templates/secure-intranet-connectivity.yaml
+++ b/helm/vpn/templates/secure-intranet-connectivity.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: networkservicemesh.io/v1
+kind: NetworkService
+metadata:
+  name: secure-intranet-connectivity
+spec:
+  payload: IP
+  matches:
+    - match:
+      sourceSelector:
+        app: firewall
+      route:
+        - destination:
+          destinationSelector:
+            app: vpn-gateway
+    - match:
+      route:
+        - destination:
+          destinationSelector:
+            app: firewall

--- a/helm/vpn/templates/vpn-gateway-nsc.yaml
+++ b/helm/vpn/templates/vpn-gateway-nsc.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        networkservicemesh.io/app: "vpn-gateway-nsc"
+        networkservicemesh.io/impl: "secure-intranet-connectivity"
+    spec:
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
+      containers:
+        - name: alpine-img
+          image: alpine:latest
+          imagePullPolicy: IfNotPresent
+          command: ['tail', '-f', '/dev/null']
+metadata:
+  name: vpn-gateway-nsc
+  namespace: default
+  annotations:
+    ns.networkservicemesh.io: secure-intranet-connectivity

--- a/helm/vpn/templates/vpn-gateway-nse.tpl
+++ b/helm/vpn/templates/vpn-gateway-nse.tpl
@@ -1,0 +1,42 @@
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        networkservicemesh.io/app: "vpn-gateway"
+        networkservicemesh.io/impl: "secure-intranet-connectivity"
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: networkservicemesh.io/app
+                    operator: In
+                    values:
+                      - vpn-gateway
+              topologyKey: "kubernetes.io/hostname"
+      containers:
+        - name: vpn-gateway
+          image: {{ .Values.registry }}/networkservicemesh/icmp-responder-nse:{{ .Values.tag }}/
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: ADVERTISE_NSE_NAME
+              value: "secure-intranet-connectivity"
+            - name: ADVERTISE_NSE_LABELS
+              value: "app=vpn-gateway"
+            - name: TRACER_ENABLED
+              value: "true"
+            - name: IP_ADDRESS
+              value: "10.60.1.0/24"
+          resources:
+            limits:
+              networkservicemesh.io/socket: 1
+        - name: nginx
+          image: {{ .Values.registry }}/networkservicemesh/nginx:{{ .Values.tag }}/
+metadata:
+  name: vpn-gateway-nse
+  namespace: default

--- a/helm/vpn/templates/vppagent-firewall-nse.tpl
+++ b/helm/vpn/templates/vppagent-firewall-nse.tpl
@@ -1,0 +1,32 @@
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        networkservicemesh.io/app: "firewall"
+        networkservicemesh.io/impl: "secure-intranet-connectivity"
+    spec:
+      containers:
+        - name: firewall-nse
+          image: {{ .Values.registry }}/networkservicemesh/vppagent-firewall-nse:{{ .Values.tag }}/
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: ADVERTISE_NSE_NAME
+              value: "secure-intranet-connectivity"
+            - name: ADVERTISE_NSE_LABELS
+              value: "app=firewall"
+            - name: OUTGOING_NSC_NAME
+              value: "secure-intranet-connectivity"
+            - name: OUTGOING_NSC_LABELS
+              value: "app=firewall"
+            - name: TRACER_ENABLED
+              value: "true"
+          resources:
+            limits:
+              networkservicemesh.io/socket: 1
+metadata:
+  name: vppagent-firewall-nse
+  namespace: default

--- a/helm/vpn/values.yaml
+++ b/helm/vpn/values.yaml
@@ -1,0 +1,49 @@
+# Default values for vpn.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository: nginx
+  tag: stable
+  pullPolicy: IfNotPresent
+
+nameOverride: ""
+fullnameOverride: ""
+
+service:
+  type: ClusterIP
+  port: 80
+
+ingress:
+  enabled: false
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  hosts:
+    - host: chart-example.local
+      paths: []
+
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}

--- a/helm/vpp-icmp-responder/Chart.yaml
+++ b/helm/vpp-icmp-responder/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: "1.0"
+description: A Helm chart for Kubernetes
+name: vpp-icmp-responder
+version: 0.1.0

--- a/helm/vpp-icmp-responder/templates/vppagent-icmp-responder-nse.tpl
+++ b/helm/vpp-icmp-responder/templates/vppagent-icmp-responder-nse.tpl
@@ -1,0 +1,44 @@
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+spec:
+  replicas: 2
+  template:
+    metadata:
+      labels:
+        networkservicemesh.io/app: "icmp-responder"
+        networkservicemesh.io/impl: "vppagent-icmp-responder"
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: networkservicemesh.io/app
+                    operator: In
+                    values:
+                      - icmp-responder
+                  - key: networkservicemesh.io/impl
+                    operator: In
+                    values:
+                      - vppagent-icmp-responder
+              topologyKey: "kubernetes.io/hostname"
+      containers:
+        - name: icmp-responder-nse
+          image: {{ .Values.registry }}/networkservicemesh/vppagent-icmp-responder-nse:{{ .Values.tag }}/
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: ADVERTISE_NSE_NAME
+              value: "icmp-responder"
+            - name: ADVERTISE_NSE_LABELS
+              value: "app=icmp-responder"
+            - name: TRACER_ENABLED
+              value: "true"
+            - name: IP_ADDRESS
+              value: "10.30.1.1"
+          resources:
+            limits:
+              networkservicemesh.io/socket: 1
+metadata:
+  name: vppagent-icmp-responder-nse
+  namespace: default

--- a/helm/vpp-icmp-responder/templates/vppagent-nsc.tpl
+++ b/helm/vpp-icmp-responder/templates/vppagent-nsc.tpl
@@ -1,0 +1,27 @@
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+spec:
+  replicas: 2
+  template:
+    metadata:
+      labels:
+        networkservicemesh.io: "true"
+        networkservicemesh.io/app: "vppagent-nsc"
+    spec:
+      hostPID: true
+      containers:
+        - name: vppagent-nsc
+          image: {{ .Values.registry }}/networkservicemesh/vppagent-nsc:{{ .Values.tag }}
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: OUTGOING_NSC_LABELS
+              value: "app=icmp"
+            - name: OUTGOING_NSC_NAME
+              value: "icmp-responder"
+          resources:
+            limits:
+              networkservicemesh.io/socket: 1
+metadata:
+  name: vppagent-nsc
+  namespace: default

--- a/helm/vpp-icmp-responder/values.yaml
+++ b/helm/vpp-icmp-responder/values.yaml
@@ -1,0 +1,3 @@
+# Default values for vpp-icmp-responder.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.


### PR DESCRIPTION
Signed-off-by: Ilya Lobkov <lobkovilya@yandex.ru>

<!--- Provide a general summary of your changes in the Title above -->

## Description
Add initial supporting of Helm

To install NSM and all depending charts (skydive, jaeger, admission-webhook):
```
helm install helm/nsm
```

Install simple NSC and icmp-responder:
```
helm install helm/icmp-responder
```

Install vppagent-nsc and vppagent-icmp-responder:
```
helm install helm/vpp-icmp-responder
```

Install vpn-gateway-nsc, vpp-gateway-nse and vppagent-firewall-nse:
```
helm install helm/vpn
```

Every chart has file `values.yaml`. Now there is a possibility to specify docker registry and tag for images in this file.

## Motivation and Context
According to issue https://github.com/networkservicemesh/networkservicemesh/issues/747

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

