### PR TITLE
Fix delay with dataolane startup connect to NSMD

### DIFF
--- a/dataplane/impl/dataplaneregistrarclient/dataplaneregistrarclient.go
+++ b/dataplane/impl/dataplaneregistrarclient/dataplaneregistrarclient.go
@@ -53,7 +53,7 @@ func (dr *dataplaneRegistration) register(ctx context.Context) {
 	logrus.Infof("Retry interval: %s", dr.registrar.registrationRetryInterval)
 
 	// Wait fo NSMD to be ready to register dataplane.
-	_ = tools.WaitForPortAvailable(context.Background(), "unix", dr.registrar.registrarSocket, dr.registrar.registrationRetryInterval)
+	_ = tools.WaitForPortAvailable(context.Background(), "unix", dr.registrar.registrarSocket, 100* time.Millisecond)
 	ticker := time.NewTicker(dr.registrar.registrationRetryInterval)
 	for ; true; <-ticker.C {
 		select {


### PR DESCRIPTION
Fix initial dataplane connection delay if NSMD is not start enough.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [x] Covered by existing integration testing
- [ ] Added integration testing to cover
- [x] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
