### PR TITLE
parametrize docker image ligato/vpp-agent to satisfy also ARM64 platform

### DIFF
--- a/.mk/docker.mk
+++ b/.mk/docker.mk
@@ -20,13 +20,20 @@ RUN_CONTAINERS=$(BUILD_CONTAINERS)
 KILL_CONTAINERS=$(BUILD_CONTAINERS)
 LOG_CONTAINERS=$(KILL_CONTAINERS)
 ORG=networkservicemesh
+ARCH ?= $(shell uname -m)
+ifeq (${ARCH}, x86_64)
+  VPP_AGENT=ligato/vpp-agent:v1.8.1
+endif
+ifeq (${ARCH}, aarch64)
+  VPP_AGENT=ligato/vpp-agent-arm64:v1.8.1
+endif
 
 .PHONY: docker-build
 docker-build: $(addsuffix -build,$(addprefix docker-,$(BUILD_CONTAINERS)))
 
 .PHONY: docker-%-build
 docker-%-build:
-	@${DOCKERBUILD} -t ${ORG}/$* -f docker/Dockerfile.$* . && \
+	@${DOCKERBUILD} --build-arg VPP_AGENT=${VPP_AGENT} -t ${ORG}/$* -f docker/Dockerfile.$* . && \
 	if [ "x${COMMIT}" != "x" ] ; then \
 		docker tag ${ORG}/$* ${ORG}/$*:${COMMIT} ;\
 	fi

--- a/dataplane/vppagent/build/Dockerfile.vppagent-dataplane
+++ b/dataplane/vppagent/build/Dockerfile.vppagent-dataplane
@@ -1,3 +1,5 @@
+ARG VPP_AGENT
+
 FROM golang:alpine as build
 RUN apk --no-cache add git
 ENV PACKAGEPATH=github.com/networkservicemesh/networkservicemesh/
@@ -11,7 +13,7 @@ RUN until go mod download;do echo "Trying again";done
 ADD [".","/root/networkservicemesh"]
 RUN CGO_ENABLED=0 GOOS=linux go build -ldflags '-extldflags "-static"' -o /go/bin/vppagent-dataplane ./dataplane/vppagent/cmd/vppagent-dataplane.go
 
-FROM ligato/vpp-agent:v1.8.1 as runtime
+FROM ${VPP_AGENT} as runtime
 COPY --from=build /go/bin/vppagent-dataplane /bin/vppagent-dataplane
 RUN rm /opt/vpp-agent/dev/etcd.conf /opt/vpp-agent/dev/kafka.conf; echo 'Endpoint: "localhost:9111"' > /opt/vpp-agent/dev/grpc.conf
 COPY dataplane/vppagent/conf/vpp/startup.conf /etc/vpp/vpp.conf

--- a/docker/Dockerfile.vppagent-firewall-nse
+++ b/docker/Dockerfile.vppagent-firewall-nse
@@ -1,3 +1,5 @@
+ARG VPP_AGENT
+
 FROM golang:alpine as build
 RUN apk --no-cache add git
 ENV PACKAGEPATH=github.com/networkservicemesh/networkservicemesh/
@@ -11,7 +13,7 @@ RUN until go mod download;do echo "Trying again";done
 ADD [".","/root/networkservicemesh"]
 RUN CGO_ENABLED=0 GOOS=linux go build -ldflags '-extldflags "-static"' -o /go/bin/vppagent-firewall-nse ./examples/cmd/vppagent-firewall-nse
 
-FROM ligato/vpp-agent:v1.8.1 as runtime
+FROM ${VPP_AGENT} as runtime
 COPY --from=build /go/bin/vppagent-firewall-nse /bin/vppagent-firewall-nse
 RUN rm /opt/vpp-agent/dev/etcd.conf /opt/vpp-agent/dev/kafka.conf; echo 'Endpoint: "0.0.0.0:9112"' > /opt/vpp-agent/dev/grpc.conf; echo "disabled: true" > /opt/vpp-agent/dev/linux-plugin.conf
 COPY dataplane/vppagent/conf/vpp/startup.conf /etc/vpp/vpp.conf

--- a/docker/Dockerfile.vppagent-icmp-responder-nse
+++ b/docker/Dockerfile.vppagent-icmp-responder-nse
@@ -1,3 +1,5 @@
+ARG VPP_AGENT
+
 FROM golang:alpine as build
 RUN apk --no-cache add git
 ENV PACKAGEPATH=github.com/networkservicemesh/networkservicemesh/
@@ -11,7 +13,7 @@ RUN until go mod download;do echo "Trying again";done
 ADD [".","/root/networkservicemesh"]
 RUN CGO_ENABLED=0 GOOS=linux go build -ldflags '-extldflags "-static"' -o /go/bin/vppagent-icmp-responder-nse ./examples/cmd/vppagent-icmp-responder-nse
 
-FROM ligato/vpp-agent:v1.8.1 as runtime
+FROM ${VPP_AGENT} as runtime
 COPY --from=build /go/bin/vppagent-icmp-responder-nse /bin/vppagent-icmp-responder-nse
 RUN rm /opt/vpp-agent/dev/etcd.conf /opt/vpp-agent/dev/kafka.conf; echo 'Endpoint: "0.0.0.0:9112"' > /opt/vpp-agent/dev/grpc.conf; echo "disabled: true" > /opt/vpp-agent/dev/linux-plugin.conf
 COPY dataplane/vppagent/conf/vpp/startup.conf /etc/vpp/vpp.conf

--- a/docker/Dockerfile.vppagent-nsc
+++ b/docker/Dockerfile.vppagent-nsc
@@ -1,3 +1,5 @@
+ARG VPP_AGENT
+
 FROM golang:alpine as build
 RUN apk --no-cache add git
 ENV PACKAGEPATH=github.com/networkservicemesh/networkservicemesh/
@@ -11,7 +13,7 @@ RUN until go mod download;do echo "Trying again";done
 ADD [".","/root/networkservicemesh"]
 RUN CGO_ENABLED=0 GOOS=linux go build -ldflags '-extldflags "-static"' -o /go/bin/vppagent-nsc ./examples/cmd/vppagent-nsc
 
-FROM ligato/vpp-agent:v1.8.1 as runtime
+FROM ${VPP_AGENT} as runtime
 COPY --from=build /go/bin/vppagent-nsc /bin/vppagent-nsc
 RUN rm /opt/vpp-agent/dev/etcd.conf /opt/vpp-agent/dev/kafka.conf; echo 'Endpoint: "0.0.0.0:9113"' > /opt/vpp-agent/dev/grpc.conf; echo "disabled: true" > /opt/vpp-agent/dev/linux-plugin.conf
 COPY dataplane/vppagent/conf/vpp/startup.conf /etc/vpp/vpp.conf


### PR DESCRIPTION
https://github.com/networkservicemesh/networkservicemesh/pull/818
Closed by my mistake - apologize for inconvienence and thanks for your help.

Signed-off-by: Stanislav Chlebec <stanislav.chlebec@pantheon.tech>

Where the docker image is used ligato/vpp-agent in different Dockerfiles it was replaced by parameter.
The parameter is going to be set up in the file .mk/docker.mk 

## Description
Parameter VPP_AGENT is used to define proper docker image according to detected platform x86_64 or aarch64

## Motivation and Context
This change is required if we want to have docker building process on ARM64 platform executed by command: make k8s_save

## How Has This Been Tested?
- [ ] Covered by existing integration testing
- [ ] Added integration testing to cover
- [x] Tested locally
- [ ] Have not tested


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
It should be somewhere mentioned where is the point where it is possible to change version of ligato/vpp-agent docker image