### PR TITLE
VPP Agent Dataplane VETH mode is not working

### DIFF
--- a/test/integration/nsmd_test_utils/test_utils.go
+++ b/test/integration/nsmd_test_utils/test_utils.go
@@ -35,16 +35,19 @@ func SetupNodesConfig(k8s *kube_testing.K8s, nodesCount int, timeout time.Durati
 		nsmdName := fmt.Sprintf("nsmgr-%s", node.Name)
 		dataplaneName := fmt.Sprintf("nsmd-dataplane-%s", node.Name)
 		var corePod *v1.Pod
+		var dataplanePod *v1.Pod
 		debug := false
 		if i >= len(conf) {
 			corePod = pods.NSMgrPod(nsmdName, node)
+			dataplanePod = pods.VPPDataplanePod(dataplaneName, node)
 		} else {
 			if conf[i].Nsmd == pods.NSMgrContainerDebug || conf[i].NsmdK8s == pods.NSMgrContainerDebug || conf[i].NsmdP == pods.NSMgrContainerDebug {
 				debug = true
 			}
 			corePod = pods.NSMgrPodWithConfig(nsmdName, node, conf[i])
+			dataplanePod = pods.VPPDataplanePodConfig(dataplaneName, node, conf[i].DataplaneVariables)
 		}
-		corePods := k8s.CreatePods(corePod, pods.VPPDataplanePod(dataplaneName, node))
+		corePods := k8s.CreatePods(corePod, dataplanePod)
 		if debug {
 			podContainer := "nsmd"
 			if conf[i].Nsmd == pods.NSMgrContainerDebug {

--- a/test/integration/usecase_nsc_icmp_configuration_test.go
+++ b/test/integration/usecase_nsc_icmp_configuration_test.go
@@ -92,9 +92,9 @@ func testNSCAndICMP(t *testing.T, nodesCount int, useWebhook bool, disableVHost 
 	k8s.Prepare("nsmd", "nsc", "nsmd-dataplane", "icmp-responder-nse")
 	logrus.Printf("Cleanup done: %v", time.Since(s1))
 
-	config := []*pods.NSMDPodConfig{}
+	config := []*pods.NSMgrPodConfig{}
 	for i := 0; i< nodesCount;i++ {
-		cfg := &pods.NSMDPodConfig{}
+		cfg := &pods.NSMgrPodConfig{}
 		if disableVHost {
 			cfg.DataplaneVariables = map[string]string{}
 			cfg.DataplaneVariables["DATAPLANE_ALLOW_VHOST"] = "false"

--- a/test/kube_testing/pods/nsmd.go
+++ b/test/kube_testing/pods/nsmd.go
@@ -51,6 +51,7 @@ type NSMgrPodConfig struct {
 	NsmdK8s             NSMgrContainerMode // nsmd-k8s launch options - debug - for debug.sh, run - for run.sh
 	NsmdP               NSMgrContainerMode // nsmdp launch options - debug - for debug.sh, run - for run.sh
 	Variables           map[string]string
+	DataplaneVariables  map[string]string
 	liveness, readiness *v1.Probe
 }
 


### PR DESCRIPTION
Signed-off-by: Andrey Sobolev <haiodo@gmail.com>

Fix VPPAgent Dataplane VETH mode.

## Description

The veth devices are virtual Ethernet devices.  They can act as tunnels between network namespaces to create a bridge to a physical network device in another namespace, but can also be used as standalone network devices.

## Motivation and Context

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [ ] Covered by existing integration testing
- [x] Added integration testing to cover
- [x] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.