### PR TITLE
Fix nsmd pod deletion in tests (#860)

### DIFF
--- a/test/integration/basic_nsmdp_test.go
+++ b/test/integration/basic_nsmdp_test.go
@@ -30,7 +30,7 @@ func TestNSMDDP(t *testing.T) {
 	icmpPod := nsmd_test_utils.DeployICMP(k8s, nodes[0].Node, "icmp-responder-nse-1", defaultTimeout)
 
 	nsmdName := nodes[0].Nsmd.Name
-	k8s.DeletePods(nodes[0].Nsmd)
+	k8s.DeletePodsSafe(60, nodes[0].Nsmd)
 	k8s.DeletePods(icmpPod)
 	time.Sleep(10 * time.Second)
 	nodes[0].Nsmd = k8s.CreatePod(pods.NSMgrPodWithConfig(nsmdName, nodes[0].Node, &pods.NSMgrPodConfig{})) // Recovery NSEs
@@ -57,7 +57,7 @@ func TestNSMDRecoverNSE(t *testing.T) {
 	icmpPod := nsmd_test_utils.DeployICMP(k8s, nodes[0].Node, "icmp-responder-nse-1", defaultTimeout)
 
 	nsmdName := nodes[0].Nsmd.Name
-	k8s.DeletePods(nodes[0].Nsmd)
+	k8s.DeletePodsSafe(60, nodes[0].Nsmd)
 	k8s.DeletePods(icmpPod)
 	time.Sleep(10 * time.Second)
 

--- a/test/integration/basic_nsmdp_test.go
+++ b/test/integration/basic_nsmdp_test.go
@@ -30,7 +30,7 @@ func TestNSMDDP(t *testing.T) {
 	icmpPod := nsmd_test_utils.DeployICMP(k8s, nodes[0].Node, "icmp-responder-nse-1", defaultTimeout)
 
 	nsmdName := nodes[0].Nsmd.Name
-	k8s.DeletePodsSafe(60, nodes[0].Nsmd)
+	k8s.DeletePods(nodes[0].Nsmd)
 	k8s.DeletePods(icmpPod)
 	time.Sleep(10 * time.Second)
 	nodes[0].Nsmd = k8s.CreatePod(pods.NSMgrPodWithConfig(nsmdName, nodes[0].Node, &pods.NSMgrPodConfig{})) // Recovery NSEs
@@ -57,7 +57,7 @@ func TestNSMDRecoverNSE(t *testing.T) {
 	icmpPod := nsmd_test_utils.DeployICMP(k8s, nodes[0].Node, "icmp-responder-nse-1", defaultTimeout)
 
 	nsmdName := nodes[0].Nsmd.Name
-	k8s.DeletePodsSafe(60, nodes[0].Nsmd)
+	k8s.DeletePods(nodes[0].Nsmd)
 	k8s.DeletePods(icmpPod)
 	time.Sleep(10 * time.Second)
 

--- a/test/integration/recover_nse_nsm_heal_test.go
+++ b/test/integration/recover_nse_nsm_heal_test.go
@@ -53,7 +53,7 @@ func TestNSMHealRemoteDieNSMD_NSE(t *testing.T) {
 	printErrors(failures, k8s, nodes_setup, nscInfo, t)
 
 	logrus.Infof("Delete Remote NSMD")
-	k8s.DeletePodsSafe(10, nodes_setup[1].Nsmd)
+	k8s.DeletePods(nodes_setup[1].Nsmd)
 	k8s.DeletePods(icmpPod)
 	logrus.Infof("Waiting for NSE with network service")
 	k8s.WaitLogsContains(nodes_setup[0].Nsmd, "nsmd", "Waiting for NSE with network service icmp-responder. Since elapsed:", 60*time.Second)

--- a/test/integration/recover_nse_nsm_heal_test.go
+++ b/test/integration/recover_nse_nsm_heal_test.go
@@ -53,8 +53,7 @@ func TestNSMHealRemoteDieNSMD_NSE(t *testing.T) {
 	printErrors(failures, k8s, nodes_setup, nscInfo, t)
 
 	logrus.Infof("Delete Remote NSMD")
-	k8s.DeletePods(nodes_setup[1].Nsmd)
-
+	k8s.DeletePodsSafe(10, nodes_setup[1].Nsmd)
 	k8s.DeletePods(icmpPod)
 	logrus.Infof("Waiting for NSE with network service")
 	k8s.WaitLogsContains(nodes_setup[0].Nsmd, "nsmd", "Waiting for NSE with network service icmp-responder. Since elapsed:", 60*time.Second)

--- a/test/kube_testing/k8s.go
+++ b/test/kube_testing/k8s.go
@@ -24,7 +24,7 @@ import (
 
 const (
 	podStartTimeout  = 1 * time.Minute
-	podDeleteTimeout = 1 * time.Minute
+	podDeleteTimeout = 15 * time.Second
 	podExecTimeout   = 1 * time.Minute
 	podGetLogTimeout = 1 * time.Minute
 )
@@ -271,9 +271,29 @@ func NewK8s() (*K8s, error) {
 	return &client, nil
 }
 
+// Immediate deletion does not wait for confirmation that the running resource has been terminated.
+// The resource may continue to run on the cluster indefinitely
+func (o *K8s) deletePodForce(pod *v1.Pod) error {
+	graceTimeout := int64(0)
+	delOpt := &metaV1.DeleteOptions{
+		GracePeriodSeconds: &graceTimeout,
+	}
+	err := o.clientset.CoreV1().Pods(pod.Namespace).Delete(pod.Name, delOpt)
+	if err != nil {
+		return err
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), podDeleteTimeout)
+	defer cancel()
+	err = blockUntilPodWorking(o.clientset, ctx, pod)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
 // Delete POD with completion check
 // Make force delete on timeout
-func (o *K8s) deletePodsSafe(timeout int, pods ...*v1.Pod) error {
+func (o *K8s) deletePods(pods ...*v1.Pod) error {
 	for _, pod := range pods {
 		delOpt := &metaV1.DeleteOptions{}
 		err := o.clientset.CoreV1().Pods(pod.Namespace).Delete(pod.Name, delOpt)
@@ -281,38 +301,15 @@ func (o *K8s) deletePodsSafe(timeout int, pods ...*v1.Pod) error {
 			return err
 		}
 
-		ctx, cancel := context.WithTimeout(context.Background(), time.Duration(timeout) * time.Second)
-		defer cancel()
-		err = blockUntilPodWorking(o.clientset, ctx, pod)
-		if err != nil {
-			err = o.deletePods(pod)
-			logrus.Warnf(`The POD "%s" may continue to run on the cluster`, pod.Name)
-			if err != nil {
-				logrus.Error(err)
-			}
-		}
-	}
-
-	return nil
-}
-
-// Immediate deletion does not wait for confirmation that the running resource has been terminated.
-// The resource may continue to run on the cluster indefinitely
-func (o *K8s) deletePods(pods ...*v1.Pod) error {
-	for _, pod := range pods {
-		graceTimeout := int64(0)
-		delOpt := &metaV1.DeleteOptions{
-			GracePeriodSeconds: &graceTimeout,
-		}
-		err := o.clientset.CoreV1().Pods(pod.Namespace).Delete(pod.Name, delOpt)
-		if err != nil {
-			return err
-		}
 		ctx, cancel := context.WithTimeout(context.Background(), podDeleteTimeout)
 		defer cancel()
 		err = blockUntilPodWorking(o.clientset, ctx, pod)
 		if err != nil {
-			return err
+			err = o.deletePodForce(pod)
+			logrus.Warnf(`The POD "%s" may continue to run on the cluster`, pod.Name)
+			if err != nil {
+				logrus.Error(err)
+			}
 		}
 	}
 
@@ -423,21 +420,6 @@ func (l *K8s) CreatePod(template *v1.Pod) *v1.Pod {
 	return results[0]
 }
 
-func (l *K8s) DeletePodsSafe(timeout int, pods ...*v1.Pod) {
-	err := l.deletePodsSafe(timeout, pods...)
-	Expect(err).To(BeNil())
-
-	for _, pod := range pods {
-		for idx, pod0 := range l.pods {
-			if pod.Name == pod0.Name {
-				l.pods = append(l.pods[:idx], l.pods[idx+1:]...)
-			}
-		}
-	}
-}
-
-// Immediate deletion does not wait for confirmation that the running resource has been terminated.
-// The resource may continue to run on the cluster indefinitely
 func (l *K8s) DeletePods(pods ...*v1.Pod) {
 	err := l.deletePods(pods...)
 	Expect(err).To(BeNil())


### PR DESCRIPTION
## Description
If you are deleting pod with Grace Period 0 - the Pod may not be terminated instantly.
It may return error next time, when nsmdp will try to allocate not freed resource.

## Motivation and Context
Following tests are not stable:

- TestNSMDDP
- TestNSMDRecoverNSE
- TestNSMHealRemoteDieNSMD_NSE

With the fix test will wait while previous nsmd pod will be terminated before creating new one. 

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [ ] Covered by existing integration testing
- [ ] Added integration testing to cover
- [x] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
