### PR TITLE
Update apiVersion to latest API

### DIFF
--- a/controllers/sriov-controller/README.md
+++ b/controllers/sriov-controller/README.md
@@ -74,9 +74,12 @@ metadata:
 Here is example for a deployment requesting 4 SRIOV network services
 
 ```yaml
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 spec:
+  selector:
+    matchLabels:
+      app: nsm-sriov
   replicas: 1
   template:
     metadata:

--- a/controllers/sriov-controller/sriov-client.yaml
+++ b/controllers/sriov-controller/sriov-client.yaml
@@ -1,7 +1,10 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 spec:
+  selector:
+    matchLabels:
+      app: nsm-sriov-client
   replicas: 1
   template:
     metadata:

--- a/controllers/sriov-controller/sriov-controller.yaml
+++ b/controllers/sriov-controller/sriov-controller.yaml
@@ -26,9 +26,12 @@ roleRef:
   name: sriov-controller
   apiGroup: rbac.authorization.k8s.io
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 spec:
+  selector:
+    matchLabels:
+      app: sriov-controller
   template:
     metadata:
       labels:

--- a/deployments/helm/icmp-responder/templates/icmp-responder-nse.tpl
+++ b/deployments/helm/icmp-responder/templates/icmp-responder-nse.tpl
@@ -1,7 +1,11 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 spec:
+  selector:
+    matchLabels:
+      networkservicemesh.io/app: "icmp-responder"
+      networkservicemesh.io/impl: "icmp-responder"
   replicas: 2
   template:
     metadata:

--- a/deployments/helm/icmp-responder/templates/nsc.yaml
+++ b/deployments/helm/icmp-responder/templates/nsc.yaml
@@ -1,7 +1,10 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 spec:
+  selector:
+    matchLabels:
+      networkservicemesh.io/app: "icmp-responder-nsc"
   replicas: 4
   template:
     metadata:

--- a/deployments/helm/nsm-monitoring/templates/crossconnect-monitor.tpl
+++ b/deployments/helm/nsm-monitoring/templates/crossconnect-monitor.tpl
@@ -1,7 +1,10 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 spec:
+  selector:
+    matchLabels:
+      app: nsmgr-daemonset
   template:
     metadata:
       labels:

--- a/deployments/helm/nsm-monitoring/templates/skydive.tpl
+++ b/deployments/helm/nsm-monitoring/templates/skydive.tpl
@@ -61,11 +61,15 @@ data:
         default_filter: "nsm-filter"
         default_highlight: "nsm-edges"
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: skydive-analyzer
 spec:
+  selector:
+    matchLabels:
+      app: skydive
+      tier: analyzer
   replicas: 1
   template:
     metadata:
@@ -101,11 +105,15 @@ spec:
           configMap:
             name: skydive-analyzer-config-file
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: skydive-agent
 spec:
+  selector:
+    matchLabels:
+      app: skydive
+      tier: agent
   template:
     metadata:
       labels:

--- a/deployments/helm/nsm/templates/cluster-role-binding.yaml
+++ b/deployments/helm/nsm/templates/cluster-role-binding.yaml
@@ -1,6 +1,6 @@
 ---
 kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: nsm-role-binding
 roleRef:

--- a/deployments/helm/nsm/templates/nsmgr.tpl
+++ b/deployments/helm/nsm/templates/nsmgr.tpl
@@ -1,8 +1,11 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: nsmgr
 spec:
+  selector:
+    matchLabels:
+      app: nsmmgr-daemonset
   template:
     metadata:
       labels:

--- a/deployments/helm/nsm/templates/vppagent-dataplane.tpl
+++ b/deployments/helm/nsm/templates/vppagent-dataplane.tpl
@@ -1,7 +1,10 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 spec:
+  selector:
+    matchLabels:
+      app: nsm-vpp-dataplane
   template:
     metadata:
       labels:

--- a/deployments/helm/vpn/templates/vpn-gateway-nsc.tpl
+++ b/deployments/helm/vpn/templates/vpn-gateway-nsc.tpl
@@ -1,7 +1,11 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 spec:
+  selector:
+    matchLabels:
+      networkservicemesh.io/app: "vpn-gateway-nsc"
+      networkservicemesh.io/impl: "secure-intranet-connectivity"
   replicas: 1
   template:
     metadata:

--- a/deployments/helm/vpn/templates/vpn-gateway-nse.tpl
+++ b/deployments/helm/vpn/templates/vpn-gateway-nse.tpl
@@ -1,7 +1,11 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 spec:
+  selector:
+    matchLabels:
+      networkservicemesh.io/app: "vpn-gateway"
+      networkservicemesh.io/impl: "secure-intranet-connectivity"
   replicas: 1
   template:
     metadata:

--- a/deployments/helm/vpn/templates/vppagent-firewall-nse.tpl
+++ b/deployments/helm/vpn/templates/vppagent-firewall-nse.tpl
@@ -1,7 +1,11 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 spec:
+  selector:
+    matchLabels:
+      networkservicemesh.io/app: "firewall"
+      networkservicemesh.io/impl: "secure-intranet-connectivity"
   replicas: 1
   template:
     metadata:

--- a/deployments/helm/vpp-icmp-responder/templates/vppagent-icmp-responder-nse.tpl
+++ b/deployments/helm/vpp-icmp-responder/templates/vppagent-icmp-responder-nse.tpl
@@ -1,7 +1,11 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 spec:
+  selector:
+    matchLabels:
+      networkservicemesh.io/app: "icmp-responder"
+      networkservicemesh.io/impl: "vppagent-icmp-responder"
   replicas: 2
   template:
     metadata:

--- a/deployments/helm/vpp-icmp-responder/templates/vppagent-nsc.tpl
+++ b/deployments/helm/vpp-icmp-responder/templates/vppagent-nsc.tpl
@@ -1,7 +1,11 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 spec:
+  selector:
+    matchLabels:
+      networkservicemesh.io: "true"
+      networkservicemesh.io/app: "vppagent-nsc"
   replicas: 2
   template:
     metadata:

--- a/k8s/conf/cluster-role-binding.yaml
+++ b/k8s/conf/cluster-role-binding.yaml
@@ -1,6 +1,6 @@
 ---
 kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: nsm-role-binding
 roleRef:

--- a/k8s/conf/crossconnect-monitor.yaml
+++ b/k8s/conf/crossconnect-monitor.yaml
@@ -1,7 +1,10 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 spec:
+  selector:
+    matchLabels:
+      app: nsmgr-daemonset
   template:
     metadata:
       labels:

--- a/k8s/conf/debug/nsmgr-debug.yaml
+++ b/k8s/conf/debug/nsmgr-debug.yaml
@@ -1,9 +1,12 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: nsmgr
 spec:
+  selector:
+    matchLabels:
+      app: nsmgr-daemonset
   template:
     metadata:
       labels:

--- a/k8s/conf/icmp-responder-nse.yaml
+++ b/k8s/conf/icmp-responder-nse.yaml
@@ -1,7 +1,11 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 spec:
+  selector:
+    matchLabels:
+      networkservicemesh.io/app: "icmp-responder"
+      networkservicemesh.io/impl: "icmp-responder"
   replicas: 2
   template:
     metadata:

--- a/k8s/conf/nsc.yaml
+++ b/k8s/conf/nsc.yaml
@@ -1,7 +1,10 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 spec:
+  selector:
+    matchLabels:
+      networkservicemesh.io/app: "icmp-responder-nsc"
   replicas: 4
   template:
     metadata:

--- a/k8s/conf/nsmgr.yaml
+++ b/k8s/conf/nsmgr.yaml
@@ -1,9 +1,12 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: nsmgr
 spec:
+  selector:
+    matchLabels:
+      app: nsmgr-daemonset
   template:
     metadata:
       labels:

--- a/k8s/conf/skydive.yaml
+++ b/k8s/conf/skydive.yaml
@@ -61,11 +61,15 @@ data:
         default_filter: "nsm-filter"
         default_highlight: "nsm-edges"
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: skydive-analyzer
 spec:
+  selector:
+    matchLabels:
+      app: skydive
+      tier: analyzer
   replicas: 1
   template:
     metadata:
@@ -101,11 +105,15 @@ spec:
           configMap:
             name: skydive-analyzer-config-file
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: skydive-agent
 spec:
+  selector:
+    matchLabels:
+      app: skydive
+      tier: agent
   template:
     metadata:
       labels:

--- a/k8s/conf/vpn-gateway-nsc.yaml
+++ b/k8s/conf/vpn-gateway-nsc.yaml
@@ -1,7 +1,11 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 spec:
+  selector:
+    matchLabels:
+      networkservicemesh.io/app: "vpn-gateway-nsc"
+      networkservicemesh.io/impl: "secure-intranet-connectivity"
   replicas: 1
   template:
     metadata:

--- a/k8s/conf/vpn-gateway-nse.yaml
+++ b/k8s/conf/vpn-gateway-nse.yaml
@@ -1,7 +1,11 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 spec:
+  selector:
+    matchLabels:
+      networkservicemesh.io/app: "vpn-gateway"
+      networkservicemesh.io/impl: "secure-intranet-connectivity"
   replicas: 1
   template:
     metadata:

--- a/k8s/conf/vppagent-dataplane.yaml
+++ b/k8s/conf/vppagent-dataplane.yaml
@@ -1,7 +1,10 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 spec:
+  selector:
+    matchLabels:
+      app: nsm-vpp-dataplane
   template:
     metadata:
       labels:

--- a/k8s/conf/vppagent-firewall-nse.yaml
+++ b/k8s/conf/vppagent-firewall-nse.yaml
@@ -1,7 +1,11 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 spec:
+  selector:
+    matchLabels:
+      networkservicemesh.io/app: "firewall"
+      networkservicemesh.io/impl: "secure-intranet-connectivity"
   replicas: 1
   template:
     metadata:

--- a/k8s/conf/vppagent-icmp-responder-nse.yaml
+++ b/k8s/conf/vppagent-icmp-responder-nse.yaml
@@ -1,7 +1,11 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 spec:
+  selector:
+    matchLabels:
+      networkservicemesh.io/app: "icmp-responder"
+      networkservicemesh.io/impl: "vppagent-icmp-responder"
   replicas: 2
   template:
     metadata:

--- a/k8s/conf/vppagent-nsc.yaml
+++ b/k8s/conf/vppagent-nsc.yaml
@@ -1,7 +1,11 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 spec:
+  selector:
+    matchLabels:
+      networkservicemesh.io: "true"
+      networkservicemesh.io/app: "vppagent-nsc"
   replicas: 2
   template:
     metadata:

--- a/scripts/vagrant/skydive.yaml
+++ b/scripts/vagrant/skydive.yaml
@@ -39,11 +39,15 @@ metadata:
     app: skydive-agent
   name: skydive-agent-config
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: skydive-analyzer
 spec:
+  selector:
+    matchLabels:
+      app: skydive
+      tier: analyzer
   replicas: 1
   template:
     metadata:
@@ -74,11 +78,15 @@ spec:
             periodSeconds: 10
             failureThreshold: 3
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: skydive-agent
 spec:
+  selector:
+    matchLabels:
+      app: skydive
+      tier: agent
   template:
     metadata:
       labels:


### PR DESCRIPTION
This moves `apiVersion` from `v1beta1` to `v1` for all resources for which `v1beta1` is old and updates changed configs to match the latest API requirements

Signed-off-by: Ivana Yovcheva <iyovcheva@vmware.com>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #830

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [ ] Covered by existing integration testing
- [ ] Added integration testing to cover
- [x] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->
Tested locally with infra, imp and vpn deploy

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.