### PR TITLE
Fix bug with lost update of NSM in registry

### DIFF
--- a/k8s/pkg/registryserver/nsm.go
+++ b/k8s/pkg/registryserver/nsm.go
@@ -2,7 +2,6 @@ package registryserver
 
 import (
 	"context"
-	"fmt"
 	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/registry"
 	"github.com/sirupsen/logrus"
@@ -22,14 +21,18 @@ func newNsmRegistryService(nsmName string, cache RegistryCache) *nsmRegistryServ
 
 func (n *nsmRegistryService) RegisterNSM(ctx context.Context, nsm *registry.NetworkServiceManager) (*registry.NetworkServiceManager, error) {
 	logrus.Infof("Received RegisterNSM(%v)", nsm)
+	nsmCr := mapNsmToCustomResource(nsm)
+	nsmCr.SetName(n.nsmName)
 
-	cachedValue := n.cache.GetNetworkServiceManager(nsm.GetName())
-	logrus.Infof("Cached value %v", cachedValue)
-	if nsm.GetName() == "" || cachedValue == nil {
-		return n.create(nsm)
+	registeredNsm, err := n.cache.CreateOrUpdateNetworkServiceManager(nsmCr)
+	if err != nil {
+		logrus.Errorf("Failed to create or update nsm: %s", err)
+		return nil, err
 	}
 
-	return n.update(nsm)
+	nsm = mapNsmFromCustomResource(registeredNsm)
+	logrus.Infof("RegisterNSM return: %v", nsm)
+	return nsm, nil
 }
 
 func (n *nsmRegistryService) GetEndpoints(context.Context, *empty.Empty) (*registry.NetworkServiceEndpointList, error) {
@@ -49,39 +52,4 @@ func (n *nsmRegistryService) GetEndpoints(context.Context, *empty.Empty) (*regis
 	return &registry.NetworkServiceEndpointList{
 		NetworkServiceEndpoints: response,
 	}, nil
-}
-
-func (n *nsmRegistryService) create(nsm *registry.NetworkServiceManager) (*registry.NetworkServiceManager, error) {
-	nsmCr := mapNsmToCustomResource(nsm)
-	nsmCr.SetName(n.nsmName)
-
-	nsmCr, err := n.cache.AddNetworkServiceManager(nsmCr)
-	if err != nil {
-		logrus.Errorf("Failed to create nsm: %s", err)
-		return nil, err
-	}
-
-	return mapNsmFromCustomResource(nsmCr), nil
-}
-
-func (n *nsmRegistryService) update(nsm *registry.NetworkServiceManager) (*registry.NetworkServiceManager, error) {
-	if nsm.GetName() != n.nsmName {
-		return nil, fmt.Errorf("wrong nsm name %v, expected - %v", nsm.GetName(), n.nsmName)
-	}
-
-	oldNsm := n.cache.GetNetworkServiceManager(nsm.Name)
-	if oldNsm == nil {
-		return nil, fmt.Errorf("no nsm with name %v", nsm.Name)
-	}
-
-	nsmCr := mapNsmToCustomResource(nsm)
-	nsmCr.ObjectMeta = oldNsm.ObjectMeta
-
-	nsmCr, err := n.cache.UpdateNetworkServiceManager(nsmCr)
-	if err != nil {
-		logrus.Errorf("Failed to update nsm: %s", err)
-		return nil, err
-	}
-
-	return mapNsmFromCustomResource(nsmCr), nil
 }

--- a/test/integration/basic_nsmd_k8s_test.go
+++ b/test/integration/basic_nsmd_k8s_test.go
@@ -369,7 +369,6 @@ func TestLostUpdate(t *testing.T) {
 
 	fwd, err := k8s.NewPortForwarder(nsmd, 5000)
 	Expect(err).To(BeNil())
-	//defer fwd.Stop()
 
 	e := fwd.Start()
 	if e != nil {


### PR DESCRIPTION
Signed-off-by: Ilya Lobkov <lobkovilya@yandex.ru>

## Motivation and Context
If nsmd-k8s restarts, old info from registry will rewrite new actual info about NSM. 
Fix: even if there is NSM in cache, update will unconditionally happen.

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [ ] Covered by existing integration testing
- [X] Added integration testing to cover
- [X] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
