### PR TITLE
Raise vpp-agent log level

### DIFF
--- a/test/kube_testing/pods/vppagent_dataplane.go
+++ b/test/kube_testing/pods/vppagent_dataplane.go
@@ -71,13 +71,17 @@ func createVPPDataplanePod(name string, node *v1.Node, liveness, readiness *v1.P
 						},
 					},
 					Env: []v1.EnvVar{
-						v1.EnvVar{
+						{
 							Name: "NSM_DATAPLANE_SRC_IP",
 							ValueFrom: &v1.EnvVarSource{
 								FieldRef: &v1.ObjectFieldSelector{
 									FieldPath: "status.podIP",
 								},
 							},
+						},
+						{
+							Name:  "INITIAL_LOGLVL",
+							Value: "debug",
 						},
 					},
 					SecurityContext: &v1.SecurityContext{


### PR DESCRIPTION
Signed-off-by: Stepan Anokhin <stepan.anokhin@gmail.com>

Raise vpp-agent log level in integration tests

## Description
Set vpp-agent log level to `debug`

## Motivation and Context
We need to get more details in vpp-agent logs to troubleshoot dataplane issues. 

## How Has This Been Tested?
- [x] Covered by existing integration testing
- [ ] Added integration testing to cover
- [x] Tested locally
- [ ] Have not tested

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
