### PR TITLE
Vagrant setup: Pin K8s to 1.13.4 instead of latest(1.14.0) until we support it

### DIFF
--- a/scripts/vagrant/scripts/configureK8smaster.sh
+++ b/scripts/vagrant/scripts/configureK8smaster.sh
@@ -9,7 +9,7 @@ echo This VM has IP address "$IPADDR"
 
 # Set up Kubernetes
 NODENAME=$(hostname -s)
-kubeadm init --apiserver-cert-extra-sans="$IPADDR" --apiserver-advertise-address="$IPADDR" --node-name "$NODENAME" --pod-network-cidr="10.32.0.0/12"
+kubeadm init --apiserver-cert-extra-sans="$IPADDR" --apiserver-advertise-address="$IPADDR" --node-name "$NODENAME" --pod-network-cidr="10.32.0.0/12" --kubernetes-version="v1.13.4"
 
 echo "KUBELET_EXTRA_ARGS= --node-ip=${IPADDR}" > /etc/default/kubelet
 service kubelet restart

--- a/scripts/vagrant/scripts/install_kubernetes.sh
+++ b/scripts/vagrant/scripts/install_kubernetes.sh
@@ -8,7 +8,8 @@ deb http://apt.kubernetes.io/ kubernetes-xenial main
 EOF
 
 apt-get update
-apt-get install -y kubelet kubeadm kubectl
+apt-get install -y kubernetes-cni=0.6.0-00 kubelet=1.13.4-00 kubeadm=1.13.4-00 kubectl=1.13.4-00
+
 # kubelet requires swap off
 swapoff -a
 # keep swap off after reboot


### PR DESCRIPTION
Signed-off-by: Radoslav Dimitrov <dimitrovr@vmware.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The Vagrant environment is failing due to a lack of v1.14.0 support from the NSM side.

Until we resolve that, the k8s version is pinned to 1.13.4.

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [ ] Covered by existing integration testing
- [ ] Added integration testing to cover
- [ ] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
