### PR TITLE
Wait for dataplane mechanisms before using it

### DIFF
--- a/controlplane/pkg/model/model.go
+++ b/controlplane/pkg/model/model.go
@@ -21,6 +21,7 @@ type Dataplane struct {
 	SocketLocation   string
 	LocalMechanisms  []*local.Mechanism
 	RemoteMechanisms []*remote.Mechanism
+	RemoteConfigured bool
 }
 
 type Endpoint struct {

--- a/controlplane/pkg/model/model.go
+++ b/controlplane/pkg/model/model.go
@@ -17,11 +17,11 @@ import (
 )
 
 type Dataplane struct {
-	RegisteredName   string
-	SocketLocation   string
-	LocalMechanisms  []*local.Mechanism
-	RemoteMechanisms []*remote.Mechanism
-	RemoteConfigured bool
+	RegisteredName       string
+	SocketLocation       string
+	LocalMechanisms      []*local.Mechanism
+	RemoteMechanisms     []*remote.Mechanism
+	MechanismsConfigured bool
 }
 
 type Endpoint struct {

--- a/controlplane/pkg/nsm/nsm.go
+++ b/controlplane/pkg/nsm/nsm.go
@@ -106,6 +106,7 @@ func (srv *networkServiceManager) request(ctx context.Context, request nsm.NSMRe
 	}
 
 	// 3. get dataplane
+	srv.serviceRegistry.WaitForDataplaneAvailable(srv.model, DataplaneTimeout);
 	dp, err := srv.model.SelectDataplane()
 	if err != nil {
 		return nil, err

--- a/controlplane/pkg/nsmd/dataplanes.go
+++ b/controlplane/pkg/nsmd/dataplanes.go
@@ -89,6 +89,7 @@ func dataplaneMonitor(model model.Model, dataplaneName string) {
 		// TODO: this is not good -- direct model changes
 		dataplane.RemoteMechanisms = updates.RemoteMechanisms
 		dataplane.LocalMechanisms = updates.LocalMechanisms
+		dataplane.RemoteConfigured = true
 	}
 }
 

--- a/controlplane/pkg/nsmd/dataplanes.go
+++ b/controlplane/pkg/nsmd/dataplanes.go
@@ -89,7 +89,7 @@ func dataplaneMonitor(model model.Model, dataplaneName string) {
 		// TODO: this is not good -- direct model changes
 		dataplane.RemoteMechanisms = updates.RemoteMechanisms
 		dataplane.LocalMechanisms = updates.LocalMechanisms
-		dataplane.RemoteConfigured = true
+		dataplane.MechanismsConfigured = true
 	}
 }
 

--- a/controlplane/pkg/nsmd/serviceregistry.go
+++ b/controlplane/pkg/nsmd/serviceregistry.go
@@ -243,9 +243,9 @@ func (impl *nsmdServiceRegistry) WaitForDataplaneAvailable(model model.Model, ti
 		if dp, _ := model.SelectDataplane(); dp != nil {
 
 			// Wait for mechanisms configuration
-			if !dp.RemoteConfigured {
+			if !dp.MechanismsConfigured {
 				logrus.Info("Waiting for dataplane mechanisms configured...")
-				for ; !dp.RemoteConfigured; <-time.After(100 * time.Millisecond) {
+				for ; !dp.MechanismsConfigured; <-time.After(100 * time.Millisecond) {
 					if time.Since(st) > timeout {
 						break
 					}

--- a/controlplane/pkg/nsmd/serviceregistry.go
+++ b/controlplane/pkg/nsmd/serviceregistry.go
@@ -241,6 +241,17 @@ func (impl *nsmdServiceRegistry) WaitForDataplaneAvailable(model model.Model, ti
 	st := time.Now()
 	for ; true; <-time.After(100 * time.Millisecond) {
 		if dp, _ := model.SelectDataplane(); dp != nil {
+
+			// Wait for mechanisms configuration
+			if !dp.RemoteConfigured {
+				logrus.Info("Waiting for dataplane mechanisms configured...")
+				for ; !dp.RemoteConfigured; <-time.After(100 * time.Millisecond) {
+					if time.Since(st) > timeout {
+						break
+					}
+				}
+			}
+
 			break
 		}
 		if time.Since(st) > timeout {

--- a/controlplane/pkg/tests/nsmd_remote_test.go
+++ b/controlplane/pkg/tests/nsmd_remote_test.go
@@ -3,6 +3,7 @@ package tests
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/connectioncontext"
 	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/local/connection"
@@ -92,6 +93,7 @@ func TestNSMDCloseCrossConnection(t *testing.T) {
 				},
 			},
 		},
+		RemoteConfigured: true,
 	})
 
 	srv2.testModel.AddDataplane(&model.Dataplane{
@@ -106,6 +108,7 @@ func TestNSMDCloseCrossConnection(t *testing.T) {
 				},
 			},
 		},
+		RemoteConfigured: true,
 	})
 
 	// Register in both
@@ -161,4 +164,78 @@ func TestNSMDCloseCrossConnection(t *testing.T) {
 	cross_connection2 = srv2.testModel.GetClientConnection(destConnectionId)
 	Expect(cross_connection2).To(BeNil())
 
+}
+
+func TestNSMDDelayRemoteMechanisms(t *testing.T) {
+	RegisterTestingT(t)
+
+	storage := newSharedStorage()
+	srv := newNSMDFullServer(Master, storage)
+	srv2 := newNSMDFullServer(Worker, storage)
+	defer srv.Stop()
+	defer srv2.Stop()
+
+	srv.testModel.AddDataplane(testDataplane1)
+
+	testDataplane2_2 := &model.Dataplane{
+		RegisteredName: "test_data_plane2",
+		SocketLocation: "tcp:some_addr",
+	}
+
+	srv2.testModel.AddDataplane(testDataplane2_2)
+
+	// Register in both
+	nseReg := srv2.registerFakeEndpoint("golden_network", "test", Worker)
+	// Add to local endpoints for Server2
+	srv2.testModel.AddEndpoint(nseReg)
+
+	// Now we could try to connect via Client API
+	nsmClient, conn := srv.requestNSMConnection("nsm-1")
+	defer conn.Close()
+
+	request := &networkservice.NetworkServiceRequest{
+		Connection: &connection.Connection{
+			NetworkService: "golden_network",
+			Context: &connectioncontext.ConnectionContext{
+				DstIpRequired: true,
+				SrcIpRequired: true,
+			},
+			Labels: make(map[string]string),
+		},
+		MechanismPreferences: []*connection.Mechanism{
+			{
+				Type: connection.MechanismType_KERNEL_INTERFACE,
+				Parameters: map[string]string{
+					connection.NetNsInodeKey:    "10",
+					connection.InterfaceNameKey: "icmp-responder1",
+				},
+			},
+		},
+	}
+
+	type Response struct {
+		nsmResponse *connection.Connection
+		err error
+	}
+	resultChan := make(chan *Response, 1)
+
+	go func(ctx context.Context, req *networkservice.NetworkServiceRequest) {
+		nsmResponse, err := nsmClient.Request(ctx, req)
+		resultChan <- &Response{nsmResponse: nsmResponse, err:err}
+	}(context.Background(), request)
+
+	<- time.Tick(1 * time.Second)
+
+	testDataplane2_2.LocalMechanisms = testDataplane2.LocalMechanisms
+	testDataplane2_2.RemoteMechanisms = testDataplane2.RemoteMechanisms
+	testDataplane2_2.RemoteConfigured = true
+
+	res := <- resultChan
+	Expect(res.err).To(BeNil())
+	Expect(res.nsmResponse.GetNetworkService()).To(Equal("golden_network"))
+
+	// We need to check for crМфвук31oss connections.
+	cross_connections := srv2.serviceRegistry.testDataplaneConnection.connections
+	Expect(len(cross_connections)).To(Equal(1))
+	logrus.Print("End of test")
 }

--- a/controlplane/pkg/tests/nsmd_remote_test.go
+++ b/controlplane/pkg/tests/nsmd_remote_test.go
@@ -93,7 +93,7 @@ func TestNSMDCloseCrossConnection(t *testing.T) {
 				},
 			},
 		},
-		RemoteConfigured: true,
+		MechanismsConfigured: true,
 	})
 
 	srv2.testModel.AddDataplane(&model.Dataplane{
@@ -108,7 +108,7 @@ func TestNSMDCloseCrossConnection(t *testing.T) {
 				},
 			},
 		},
-		RemoteConfigured: true,
+		MechanismsConfigured: true,
 	})
 
 	// Register in both
@@ -228,7 +228,7 @@ func TestNSMDDelayRemoteMechanisms(t *testing.T) {
 
 	testDataplane2_2.LocalMechanisms = testDataplane2.LocalMechanisms
 	testDataplane2_2.RemoteMechanisms = testDataplane2.RemoteMechanisms
-	testDataplane2_2.RemoteConfigured = true
+	testDataplane2_2.MechanismsConfigured = true
 
 	res := <- resultChan
 	Expect(res.err).To(BeNil())

--- a/controlplane/pkg/tests/nsmd_test_utils.go
+++ b/controlplane/pkg/tests/nsmd_test_utils.go
@@ -154,8 +154,7 @@ func (impl *nsmdTestServiceRegistry) NewWorkspaceProvider() serviceregistry.Work
 }
 
 func (impl *nsmdTestServiceRegistry) WaitForDataplaneAvailable(model model.Model, timeout time.Duration) error {
-	// Do Nothing.
-	return nil
+	return nsmd.NewServiceRegistry().WaitForDataplaneAvailable(model, timeout)
 }
 
 func (impl *nsmdTestServiceRegistry) WorkspaceName(endpoint *registry.NSERegistration) string {

--- a/controlplane/pkg/tests/test_dataplanes.go
+++ b/controlplane/pkg/tests/test_dataplanes.go
@@ -22,6 +22,7 @@ var testDataplane1 = &model.Dataplane{
 			},
 		},
 	},
+	RemoteConfigured: true,
 }
 var testDataplane1_1 = &model.Dataplane{
 	RegisteredName: "test_data_plane_11",
@@ -39,6 +40,7 @@ var testDataplane1_1 = &model.Dataplane{
 			},
 		},
 	},
+	RemoteConfigured: true,
 }
 
 var testDataplane2 = &model.Dataplane{
@@ -57,4 +59,5 @@ var testDataplane2 = &model.Dataplane{
 			},
 		},
 	},
+	RemoteConfigured: true,
 }

--- a/controlplane/pkg/tests/test_dataplanes.go
+++ b/controlplane/pkg/tests/test_dataplanes.go
@@ -22,7 +22,7 @@ var testDataplane1 = &model.Dataplane{
 			},
 		},
 	},
-	RemoteConfigured: true,
+	MechanismsConfigured: true,
 }
 var testDataplane1_1 = &model.Dataplane{
 	RegisteredName: "test_data_plane_11",
@@ -40,7 +40,7 @@ var testDataplane1_1 = &model.Dataplane{
 			},
 		},
 	},
-	RemoteConfigured: true,
+	MechanismsConfigured: true,
 }
 
 var testDataplane2 = &model.Dataplane{
@@ -59,5 +59,5 @@ var testDataplane2 = &model.Dataplane{
 			},
 		},
 	},
-	RemoteConfigured: true,
+	MechanismsConfigured: true,
 }


### PR DESCRIPTION
Wait for dataplane mechanisms before using it
nsmd starts working with dataplane right after registration. I cause errors with missing mechanisms (issue #884)

Signed-off-by: Artem Belov <artem.belov@xored.com>

## Description
Waiting for mechanisms configuration added.
Component test added.

## Motivation and Context
Issue #884 

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [ ] Covered by existing integration testing
- [ ] Added integration testing to cover
- [x] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
