### PR TITLE
Run supervisord as process with PID 1

### DIFF
--- a/docker/Dockerfile.vppagent-firewall-nse
+++ b/docker/Dockerfile.vppagent-firewall-nse
@@ -18,3 +18,6 @@ COPY --from=build /go/bin/vppagent-firewall-nse /bin/vppagent-firewall-nse
 RUN rm /opt/vpp-agent/dev/etcd.conf /opt/vpp-agent/dev/kafka.conf; echo 'Endpoint: "0.0.0.0:9112"' > /opt/vpp-agent/dev/grpc.conf; echo "disabled: true" > /opt/vpp-agent/dev/linux-plugin.conf
 COPY dataplane/vppagent/conf/vpp/startup.conf /etc/vpp/vpp.conf
 COPY examples/conf/vppagent-firewall-nse/supervisord.conf /etc/supervisord/supervisord.conf
+
+RUN rm -f /dev/shm/db /dev/shm/global_vm /dev/shm/vpe-api
+ENTRYPOINT ["/usr/bin/supervisord","-c","/etc/supervisord/supervisord.conf"]

--- a/docker/Dockerfile.vppagent-icmp-responder-nse
+++ b/docker/Dockerfile.vppagent-icmp-responder-nse
@@ -18,3 +18,6 @@ COPY --from=build /go/bin/vppagent-icmp-responder-nse /bin/vppagent-icmp-respond
 RUN rm /opt/vpp-agent/dev/etcd.conf /opt/vpp-agent/dev/kafka.conf; echo 'Endpoint: "0.0.0.0:9112"' > /opt/vpp-agent/dev/grpc.conf; echo "disabled: true" > /opt/vpp-agent/dev/linux-plugin.conf
 COPY dataplane/vppagent/conf/vpp/startup.conf /etc/vpp/vpp.conf
 COPY examples/conf/vppagent-icmp-responder-nse/supervisord.conf /etc/supervisord/supervisord.conf
+
+RUN rm -f /dev/shm/db /dev/shm/global_vm /dev/shm/vpe-api
+ENTRYPOINT ["/usr/bin/supervisord","-c","/etc/supervisord/supervisord.conf"]

--- a/docker/Dockerfile.vppagent-nsc
+++ b/docker/Dockerfile.vppagent-nsc
@@ -18,3 +18,6 @@ COPY --from=build /go/bin/vppagent-nsc /bin/vppagent-nsc
 RUN rm /opt/vpp-agent/dev/etcd.conf /opt/vpp-agent/dev/kafka.conf; echo 'Endpoint: "0.0.0.0:9113"' > /opt/vpp-agent/dev/grpc.conf; echo "disabled: true" > /opt/vpp-agent/dev/linux-plugin.conf
 COPY dataplane/vppagent/conf/vpp/startup.conf /etc/vpp/vpp.conf
 COPY examples/conf/vppagent-nsc/supervisord.conf /etc/supervisord/supervisord.conf
+
+RUN rm -f /dev/shm/db /dev/shm/global_vm /dev/shm/vpe-api
+ENTRYPOINT ["/usr/bin/supervisord","-c","/etc/supervisord/supervisord.conf"]


### PR DESCRIPTION
Fixes #894

Signed-off-by: Mathieu Rohon <mathieu.rohon@orange.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description

Supervisord needs to be run as PID 1 to receive kill signals from kubelet and forward them to the processes it manages. Once SIGTERM received, NSM endpoint will properly unregister themselves.

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [ ] Covered by existing integration testing
- [ ] Added integration testing to cover
- [x] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
