### PR TITLE
CI: replace curl API invocation with a command

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,11 +53,11 @@ jobs:
       - run: wget https://releases.hashicorp.com/terraform/0.11.13/terraform_0.11.13_linux_amd64.zip
       - run: unzip terraform_0.11.13_linux_amd64.zip
       - run: mv terraform /go/bin/
-      - run: mkdir data
-      - run: ssh-keygen -t rsa -f data/sshkey -q -N ""
-      - run: ssh-add data/sshkey
+      - run: mkdir terraform
+      - run: ssh-keygen -t rsa -f terraform/sshkey -q -N ""
+      - run: ssh-add terraform/sshkey
       - run: .circleci/provision.sh
-      - run: cp -a scripts/terraform/ data/
+      - run: cp -a scripts/terraform/ terraform/
       - run:
           when: on_fail
           command: .circleci/destroy-cluster.sh
@@ -65,7 +65,7 @@ jobs:
           key: terraform-{{.Environment.CIRCLE_WORKFLOW_ID}}
           paths:
             - /go/bin/terraform
-            - data
+            - terraform
 
   packet-deploy-k8s:
     parameters:
@@ -75,17 +75,18 @@ jobs:
       - image: circleci/golang
     steps:
       - checkout
-      - run: mkdir data
+      - run: mkdir terraform
       - restore_cache:
           key: terraform-{{.Environment.CIRCLE_WORKFLOW_ID}}
-      - run: ssh-add data/sshkey
-      - run: cp -a data/terraform/* ./scripts/terraform/
+      - run: ssh-add terraform/sshkey
+      - run: cp -a terraform/terraform/* ./scripts/terraform/
       - run: cd ./scripts/terraform && terraform init && cd ../..
       - run: cd scripts/terraform && ./create-kubernetes-cluster.sh && cd ../..
       - run: make packet-get-kubeconfig
       - run:
           name: "Prepare cache data<< parameters.cluster_id >>"
           command: |
+            mkdir -p data
             cp kubeconfig data/
       - run:
           when: on_fail
@@ -120,12 +121,16 @@ jobs:
       - run:
           name: Cache Prep
           command: |
+            mkdir terraform
             sudo mkdir -p /cncf/data
             sudo chown -R circleci:circleci /cncf/
       - restore_cache:
           key: terraform-{{.Environment.CIRCLE_WORKFLOW_ID}}
+      - run: cp -a /home/circleci/project/terraform/terraform/* ./scripts/terraform/
+      - run: ssh-add /home/circleci/project/terraform/sshkey
       - restore_cache:
           key: cncf-data<< parameters.cluster_id >>-{{.Environment.CIRCLE_WORKFLOW_ID}}
+      - run: cp /home/circleci/project/terraform/sshkey* /cncf/data
       - run:
           name: Downloading go deps
           command: |
@@ -169,6 +174,7 @@ jobs:
           command: .circleci/destroy-cluster.sh
 
     environment:
+      PACKET_CLUSTER_ID: "<< parameters.cluster_id >>"
       KUBECONFIG: /home/circleci/project/data/kubeconfig
       GO111MODULE: "on"
 
@@ -177,16 +183,9 @@ jobs:
       - image: circleci/golang
     steps:
       - checkout
-      - run:
-          command: |
-            sudo mkdir -p /cncf/data
-            sudo chown -R circleci:circleci /cncf/
-          name: Cache Prep
-      - restore_cache:
-          key: cncf-data-{{.Environment.CIRCLE_WORKFLOW_ID}}
       - restore_cache:
           key: terraform-{{.Environment.CIRCLE_WORKFLOW_ID}}
-      - run: cp -a data/terraform/* ./scripts/terraform/
+      - run: cp -a /home/circleci/project/terraform/terraform/* ./scripts/terraform/
       - run: cd ./scripts/terraform && terraform init && cd ../..
       - run: .circleci/destroy-cluster.sh
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,15 @@
 ---
 version: 2.1
 
+commands:
+  packet-destroy:
+    steps:
+      - restore_cache:
+          key: terraform-{{.Environment.CIRCLE_WORKFLOW_ID}}
+      - run: cp -a data/terraform/* ./scripts/terraform/ || true
+      - run: cd ./scripts/terraform && terraform init && cd ../..
+      - run: .circleci/destroy-cluster.sh
+
 jobs:
   sanity-check:
     resource_class: medium+
@@ -87,8 +96,8 @@ jobs:
           name: "Prepare cache data<< parameters.cluster_id >>"
           command: |
             cp kubeconfig data/
-      - run:
-          when: on_fail
+      - when:
+          condition: on_fail
           command: .circleci/destroy-cluster.sh
       - save_cache:
           key: cncf-data<< parameters.cluster_id >>-{{.Environment.CIRCLE_WORKFLOW_ID}}
@@ -159,15 +168,11 @@ jobs:
             kubectl get nodes
             kubectl get pods -o wide
             kubectl describe pods
-      - run:
-          when: on_fail
-          name: Trigger packet-destroy
-          command: |
-            curl --user ${CIRCLE_API_PROJECT_TOKEN}: \
-                --data build_parameters[CIRCLE_JOB]=packet-destroy \
-                --data build_parameters[CIRCLE_WORKFLOW_ID]=${CIRCLE_WORKFLOW_ID} \
-                --data revision=$CIRCLE_SHA1 \
-                https://circleci.com/api/v1.1/project/github/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME/tree/$CIRCLE_BRANCH
+      - when:
+          condition: on_fail
+          steps:
+            - packet-destroy
+
     environment:
       KUBECONFIG: /home/circleci/project/data/kubeconfig
       GO111MODULE: "on"
@@ -184,11 +189,7 @@ jobs:
           name: Cache Prep
       - restore_cache:
           key: cncf-data-{{.Environment.CIRCLE_WORKFLOW_ID}}
-      - restore_cache:
-          key: terraform-{{.Environment.CIRCLE_WORKFLOW_ID}}
-      - run: cp -a data/terraform/* ./scripts/terraform/
-      - run: cd ./scripts/terraform && terraform init && cd ../..
-      - run: .circleci/destroy-cluster.sh
+      - packet-destroy
 
   build-container:
     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,15 +1,6 @@
 ---
 version: 2.1
 
-commands:
-  packet-destroy:
-    steps:
-      - restore_cache:
-          key: terraform-{{.Environment.CIRCLE_WORKFLOW_ID}}
-      - run: cp -a data/terraform/* ./scripts/terraform/ || true
-      - run: cd ./scripts/terraform && terraform init && cd ../..
-      - run: .circleci/destroy-cluster.sh
-
 jobs:
   sanity-check:
     resource_class: medium+
@@ -96,8 +87,8 @@ jobs:
           name: "Prepare cache data<< parameters.cluster_id >>"
           command: |
             cp kubeconfig data/
-      - when:
-          condition: on_fail
+      - run:
+          when: on_fail
           command: .circleci/destroy-cluster.sh
       - save_cache:
           key: cncf-data<< parameters.cluster_id >>-{{.Environment.CIRCLE_WORKFLOW_ID}}
@@ -131,6 +122,8 @@ jobs:
           command: |
             sudo mkdir -p /cncf/data
             sudo chown -R circleci:circleci /cncf/
+      - restore_cache:
+          key: terraform-{{.Environment.CIRCLE_WORKFLOW_ID}}
       - restore_cache:
           key: cncf-data<< parameters.cluster_id >>-{{.Environment.CIRCLE_WORKFLOW_ID}}
       - run:
@@ -168,10 +161,12 @@ jobs:
             kubectl get nodes
             kubectl get pods -o wide
             kubectl describe pods
-      - when:
-          condition: on_fail
-          steps:
-            - packet-destroy
+      - run:
+          when: on_fail
+          command: cd ./scripts/terraform && terraform init && cd ../..
+      - run:
+          when: on_fail
+          command: .circleci/destroy-cluster.sh
 
     environment:
       KUBECONFIG: /home/circleci/project/data/kubeconfig
@@ -189,7 +184,11 @@ jobs:
           name: Cache Prep
       - restore_cache:
           key: cncf-data-{{.Environment.CIRCLE_WORKFLOW_ID}}
-      - packet-destroy
+      - restore_cache:
+          key: terraform-{{.Environment.CIRCLE_WORKFLOW_ID}}
+      - run: cp -a data/terraform/* ./scripts/terraform/
+      - run: cd ./scripts/terraform && terraform init && cd ../..
+      - run: .circleci/destroy-cluster.sh
 
   build-container:
     parameters:

--- a/.circleci/destroy-cluster.sh
+++ b/.circleci/destroy-cluster.sh
@@ -21,7 +21,7 @@ export TF_VAR_worker1_1_hostname="ci-${CIRCLE_BUILD_NUM}-worker1-1"
 export TF_VAR_master2_hostname="ci-${CIRCLE_BUILD_NUM}-master2"
 export TF_VAR_worker2_1_hostname="ci-${CIRCLE_BUILD_NUM}-worker2-1"
 export TF_VAR_project_id="${PACKET_PROJECT_ID}"
-export TF_VAR_public_key="${PWD}/data/sshkey.pub"
+export TF_VAR_public_key="${PWD}/terraform/sshkey.pub"
 export TF_VAR_public_key_name="key-${CIRCLE_BUILD_NUM}"
 
 make packet-stop

--- a/.circleci/provision.sh
+++ b/.circleci/provision.sh
@@ -20,7 +20,7 @@ export TF_VAR_worker1_1_hostname="ci-${CIRCLE_BUILD_NUM}-worker1-1"
 export TF_VAR_master2_hostname="ci-${CIRCLE_BUILD_NUM}-master2"
 export TF_VAR_worker2_1_hostname="ci-${CIRCLE_BUILD_NUM}-worker2-1"
 export TF_VAR_project_id="${PACKET_PROJECT_ID}"
-export TF_VAR_public_key="${PWD}/data/sshkey.pub"
+export TF_VAR_public_key="${PWD}/terraform/sshkey.pub"
 export TF_VAR_public_key_name="key-${CIRCLE_BUILD_NUM}"
 
 echo "workdir: ${PWD}"


### PR DESCRIPTION
Signed-off-by: Nikolay Nikolaev <nnikolay@vmware.com>


## Description
Lates changes to CircleCI 2.1 yaml schema fail when invoking the API:
https://discuss.circleci.com/t/api-job-trigger-fails-on-2-1-circle-project/27010/11

Replace the `curl` invocation with the 2.1 commands.

## Motivation and Context
We get dangling servers in Packet when the tests fail.

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [x] Covered by existing integration testing
- [ ] Added integration testing to cover
- [ ] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.