### PR TITLE
Skip TestClusterInfo on clusters without kubeadm-config

### DIFF
--- a/test/integration/basic_nsmd_k8s_test.go
+++ b/test/integration/basic_nsmd_k8s_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/networkservicemesh/networkservicemesh/test/kube_testing/pods"
 	. "github.com/onsi/gomega"
 	"github.com/sirupsen/logrus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestNSMDDRegistryNSE(t *testing.T) {
@@ -312,6 +313,15 @@ func TestClusterInfo(t *testing.T) {
 	k8s, err := kube_testing.NewK8s()
 	defer k8s.Cleanup()
 	Expect(err).To(BeNil())
+
+	clientset, err := k8s.GetClientSet()
+	Expect(err).To(BeNil())
+	cm, err := clientset.CoreV1().ConfigMaps("kube-system").Get("kubeadm-config", metav1.GetOptions{})
+
+	if cm == nil {
+		t.Skip("Skip, no kubeadm-config")
+		return
+	}
 
 	k8s.Prepare("nsmgr")
 	nsmd := nsmd_test_utils.SetupNodes(k8s, 1, defaultTimeout)


### PR DESCRIPTION
Signed-off-by: Ilya Lobkov <lobkovilya@yandex.ru>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
There is no `kubeadm-config` on GKE, AWS or Azure. Add check to skip `TestClusterConfig` on these clusters.

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [ ] Covered by existing integration testing
- [ ] Added integration testing to cover
- [X] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
