### PR TITLE
WIP: Make SDK use Viper to handle the env config

### DIFF
--- a/controlplane/pkg/tests/nsmd_registry_test.go
+++ b/controlplane/pkg/tests/nsmd_registry_test.go
@@ -22,9 +22,9 @@ func TestNSMDRestart1(t *testing.T) {
 	reply := srv.requestNSM("nsm-1")
 
 	configuration := &common.NSConfiguration{
-		Workspace:        reply.Workspace,
-		NsmServerSocket:  reply.ClientBaseDir + reply.Workspace + "/" + reply.NsmServerSocket,
-		NsmClientSocket:  reply.ClientBaseDir + reply.Workspace + "/" + reply.NsmClientSocket,
+		Workspace:              reply.Workspace,
+		NsmServerSocket:        reply.ClientBaseDir + reply.Workspace + "/" + reply.NsmServerSocket,
+		NsmClientSocket:        reply.ClientBaseDir + reply.Workspace + "/" + reply.NsmClientSocket,
 		EndpointNetworkService: "test_nse",
 	}
 

--- a/controlplane/pkg/tests/nsmd_registry_test.go
+++ b/controlplane/pkg/tests/nsmd_registry_test.go
@@ -25,7 +25,7 @@ func TestNSMDRestart1(t *testing.T) {
 		Workspace:        reply.Workspace,
 		NsmServerSocket:  reply.ClientBaseDir + reply.Workspace + "/" + reply.NsmServerSocket,
 		NsmClientSocket:  reply.ClientBaseDir + reply.Workspace + "/" + reply.NsmClientSocket,
-		AdvertiseNseName: "test_nse",
+		EndpointNetworkService: "test_nse",
 	}
 
 	composite := endpoint.NewCompositeEndpoint(

--- a/controlplane/pkg/tests/nsmd_registry_test.go
+++ b/controlplane/pkg/tests/nsmd_registry_test.go
@@ -21,12 +21,12 @@ func TestNSMDRestart1(t *testing.T) {
 
 	reply := srv.requestNSM("nsm-1")
 
-	configuration := &common.NSConfiguration{
+	configuration := common.NewNSConfiguration(&common.NSConfiguration{
 		Workspace:              reply.Workspace,
 		NsmServerSocket:        reply.ClientBaseDir + reply.Workspace + "/" + reply.NsmServerSocket,
 		NsmClientSocket:        reply.ClientBaseDir + reply.Workspace + "/" + reply.NsmClientSocket,
 		EndpointNetworkService: "test_nse",
-	}
+	})
 
 	composite := endpoint.NewCompositeEndpoint(
 		endpoint.NewMonitorEndpoint(configuration),

--- a/deployments/helm/icmp-responder/templates/icmp-responder-nse.tpl
+++ b/deployments/helm/icmp-responder/templates/icmp-responder-nse.tpl
@@ -33,9 +33,9 @@ spec:
           command: ["/bin/icmp-responder-nse"]
           imagePullPolicy: {{ .Values.pullPolicy }}
           env:
-            - name: ADVERTISE_NSE_NAME
+            - name: ENDPOINT_NETWORK_SERVICE
               value: "icmp-responder"
-            - name: ADVERTISE_NSE_LABELS
+            - name: ENDPOINT_LABELS
               value: "app=icmp-responder"
             - name: TRACER_ENABLED
               value: "true"

--- a/deployments/helm/vpn/templates/vpn-gateway-nse.tpl
+++ b/deployments/helm/vpn/templates/vpn-gateway-nse.tpl
@@ -29,9 +29,9 @@ spec:
           command: ["/bin/icmp-responder-nse"]
           imagePullPolicy: {{ .Values.pullPolicy }}
           env:
-            - name: ADVERTISE_NSE_NAME
+            - name: ENDPOINT_NETWORK_SERVICE
               value: "secure-intranet-connectivity"
-            - name: ADVERTISE_NSE_LABELS
+            - name: ENDPOINT_LABELS
               value: "app=vpn-gateway"
             - name: TRACER_ENABLED
               value: "true"

--- a/deployments/helm/vpn/templates/vppagent-firewall-nse.tpl
+++ b/deployments/helm/vpn/templates/vppagent-firewall-nse.tpl
@@ -20,13 +20,13 @@ spec:
           env:
             - name: TEST_APPLICATION
               value: "vppagent-firewall-nse"
-            - name: ADVERTISE_NSE_NAME
+            - name: ENDPOINT_NETWORK_SERVICE
               value: "secure-intranet-connectivity"
-            - name: ADVERTISE_NSE_LABELS
+            - name: ENDPOINT_LABELS
               value: "app=firewall"
-            - name: OUTGOING_NSC_NAME
+            - name: CLIENT_NETWORK_SERVICE
               value: "secure-intranet-connectivity"
-            - name: OUTGOING_NSC_LABELS
+            - name: CLIENT_LABELS
               value: "app=firewall"
             - name: TRACER_ENABLED
               value: "true"

--- a/deployments/helm/vpn/templates/vppagent-passthrough-nse.tpl
+++ b/deployments/helm/vpn/templates/vppagent-passthrough-nse.tpl
@@ -20,13 +20,13 @@ spec:
           env:
             - name: TEST_APPLICATION
               value: "vppagent-firewall-nse"
-            - name: ADVERTISE_NSE_NAME
+            - name: ENDPOINT_NETWORK_SERVICE
               value: "secure-intranet-connectivity"
-            - name: ADVERTISE_NSE_LABELS
+            - name: ENDPOINT_LABELS
               value: "app=passthrough-1"
-            - name: OUTGOING_NSC_NAME
+            - name: CLIENT_NETWORK_SERVICE
               value: "secure-intranet-connectivity"
-            - name: OUTGOING_NSC_LABELS
+            - name: CLIENT_LABELS
               value: "app=passthrough-1"
             - name: TRACER_ENABLED
               value: "true"
@@ -58,13 +58,13 @@ spec:
           env:
             - name: TEST_APPLICATION
               value: "vppagent-firewall-nse"
-            - name: ADVERTISE_NSE_NAME
+            - name: ENDPOINT_NETWORK_SERVICE
               value: "secure-intranet-connectivity"
-            - name: ADVERTISE_NSE_LABELS
+            - name: ENDPOINT_LABELS
               value: "app=passthrough-2"
-            - name: OUTGOING_NSC_NAME
+            - name: CLIENT_NETWORK_SERVICE
               value: "secure-intranet-connectivity"
-            - name: OUTGOING_NSC_LABELS
+            - name: CLIENT_LABELS
               value: "app=passthrough-2"
             - name: TRACER_ENABLED
               value: "true"
@@ -96,13 +96,13 @@ spec:
           env:
             - name: TEST_APPLICATION
               value: "vppagent-firewall-nse"
-            - name: ADVERTISE_NSE_NAME
+            - name: ENDPOINT_NETWORK_SERVICE
               value: "secure-intranet-connectivity"
-            - name: ADVERTISE_NSE_LABELS
+            - name: ENDPOINT_LABELS
               value: "app=passthrough-3"
-            - name: OUTGOING_NSC_NAME
+            - name: CLIENT_NETWORK_SERVICE
               value: "secure-intranet-connectivity"
-            - name: OUTGOING_NSC_LABELS
+            - name: CLIENT_LABELS
               value: "app=passthrough-3"
             - name: TRACER_ENABLED
               value: "true"

--- a/deployments/helm/vpp-icmp-responder/templates/vppagent-icmp-responder-nse.tpl
+++ b/deployments/helm/vpp-icmp-responder/templates/vppagent-icmp-responder-nse.tpl
@@ -34,9 +34,9 @@ spec:
           env:
             - name: TEST_APPLICATION
               value: "vppagent-icmp-responder-nse"
-            - name: ADVERTISE_NSE_NAME
+            - name: ENDPOINT_NETWORK_SERVICE
               value: "icmp-responder"
-            - name: ADVERTISE_NSE_LABELS
+            - name: ENDPOINT_LABELS
               value: "app=icmp-responder"
             - name: TRACER_ENABLED
               value: "true"

--- a/deployments/helm/vpp-icmp-responder/templates/vppagent-nsc.tpl
+++ b/deployments/helm/vpp-icmp-responder/templates/vppagent-nsc.tpl
@@ -21,9 +21,9 @@ spec:
           env:
             - name: TEST_APPLICATION
               value: "vppagent-nsc"
-            - name: OUTGOING_NSC_LABELS
+            - name: CLIENT_LABELS
               value: "app=icmp"
-            - name: OUTGOING_NSC_NAME
+            - name: CLIENT_NETWORK_SERVICE
               value: "icmp-responder"
           resources:
             limits:

--- a/k8s/conf/icmp-responder-nse.yaml
+++ b/k8s/conf/icmp-responder-nse.yaml
@@ -33,9 +33,9 @@ spec:
           command: ["/bin/icmp-responder-nse"]
           imagePullPolicy: IfNotPresent
           env:
-            - name: ADVERTISE_NSE_NAME
+            - name: ENDPOINT_NETWORK_SERVICE
               value: "icmp-responder"
-            - name: ADVERTISE_NSE_LABELS
+            - name: ENDPOINT_LABELS
               value: "app=icmp-responder"
             - name: TRACER_ENABLED
               value: "true"

--- a/k8s/conf/vpn-gateway-nse.yaml
+++ b/k8s/conf/vpn-gateway-nse.yaml
@@ -29,9 +29,9 @@ spec:
           command: ["/bin/icmp-responder-nse"]
           imagePullPolicy: IfNotPresent
           env:
-            - name: ADVERTISE_NSE_NAME
+            - name: ENDPOINT_NETWORK_SERVICE
               value: "secure-intranet-connectivity"
-            - name: ADVERTISE_NSE_LABELS
+            - name: ENDPOINT_LABELS
               value: "app=vpn-gateway"
             - name: TRACER_ENABLED
               value: "true"

--- a/k8s/conf/vppagent-firewall-nse.yaml
+++ b/k8s/conf/vppagent-firewall-nse.yaml
@@ -20,13 +20,13 @@ spec:
           env:
             - name: TEST_APPLICATION
               value: "vppagent-firewall-nse"
-            - name: ADVERTISE_NSE_NAME
+            - name: ENDPOINT_NETWORK_SERVICE
               value: "secure-intranet-connectivity"
-            - name: ADVERTISE_NSE_LABELS
+            - name: ENDPOINT_LABELS
               value: "app=firewall"
-            - name: OUTGOING_NSC_NAME
+            - name: CLIENT_NETWORK_SERVICE
               value: "secure-intranet-connectivity"
-            - name: OUTGOING_NSC_LABELS
+            - name: CLIENT_LABELS
               value: "app=firewall"
             - name: TRACER_ENABLED
               value: "true"

--- a/k8s/conf/vppagent-icmp-responder-nse.yaml
+++ b/k8s/conf/vppagent-icmp-responder-nse.yaml
@@ -34,9 +34,9 @@ spec:
           env:
             - name: TEST_APPLICATION
               value: "vppagent-icmp-responder-nse"
-            - name: ADVERTISE_NSE_NAME
+            - name: ENDPOINT_NETWORK_SERVICE
               value: "icmp-responder"
-            - name: ADVERTISE_NSE_LABELS
+            - name: ENDPOINT_LABELS
               value: "app=icmp-responder"
             - name: TRACER_ENABLED
               value: "true"

--- a/k8s/conf/vppagent-nsc.yaml
+++ b/k8s/conf/vppagent-nsc.yaml
@@ -21,9 +21,9 @@ spec:
           env:
             - name: TEST_APPLICATION
               value: "vppagent-nsc"
-            - name: OUTGOING_NSC_LABELS
+            - name: CLIENT_LABELS
               value: "app=icmp"
-            - name: OUTGOING_NSC_NAME
+            - name: CLIENT_NETWORK_SERVICE
               value: "icmp-responder"
           resources:
             limits:

--- a/k8s/conf/vppagent-passthrough-nse.yaml
+++ b/k8s/conf/vppagent-passthrough-nse.yaml
@@ -20,13 +20,13 @@ spec:
           env:
             - name: TEST_APPLICATION
               value: "vppagent-firewall-nse"
-            - name: ADVERTISE_NSE_NAME
+            - name: ENDPOINT_NETWORK_SERVICE
               value: "secure-intranet-connectivity"
-            - name: ADVERTISE_NSE_LABELS
+            - name: ENDPOINT_LABELS
               value: "app=passthrough-1"
-            - name: OUTGOING_NSC_NAME
+            - name: CLIENT_NETWORK_SERVICE
               value: "secure-intranet-connectivity"
-            - name: OUTGOING_NSC_LABELS
+            - name: CLIENT_LABELS
               value: "app=passthrough-1"
             - name: TRACER_ENABLED
               value: "true"
@@ -58,13 +58,13 @@ spec:
           env:
             - name: TEST_APPLICATION
               value: "vppagent-firewall-nse"
-            - name: ADVERTISE_NSE_NAME
+            - name: ENDPOINT_NETWORK_SERVICE
               value: "secure-intranet-connectivity"
-            - name: ADVERTISE_NSE_LABELS
+            - name: ENDPOINT_LABELS
               value: "app=passthrough-2"
-            - name: OUTGOING_NSC_NAME
+            - name: CLIENT_NETWORK_SERVICE
               value: "secure-intranet-connectivity"
-            - name: OUTGOING_NSC_LABELS
+            - name: CLIENT_LABELS
               value: "app=passthrough-2"
             - name: TRACER_ENABLED
               value: "true"
@@ -96,13 +96,13 @@ spec:
           env:
             - name: TEST_APPLICATION
               value: "vppagent-firewall-nse"
-            - name: ADVERTISE_NSE_NAME
+            - name: ENDPOINT_NETWORK_SERVICE
               value: "secure-intranet-connectivity"
-            - name: ADVERTISE_NSE_LABELS
+            - name: ENDPOINT_LABELS
               value: "app=passthrough-3"
-            - name: OUTGOING_NSC_NAME
+            - name: CLIENT_NETWORK_SERVICE
               value: "secure-intranet-connectivity"
-            - name: OUTGOING_NSC_LABELS
+            - name: CLIENT_LABELS
               value: "app=passthrough-3"
             - name: TRACER_ENABLED
               value: "true"

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -29,10 +29,10 @@ type NSConfiguration struct {
 	NsmServerSocket    string
 	NsmClientSocket    string
 	Workspace          string
-	AdvertiseNseName   string // ENDPOINT_NETWORK_SERVICE
-	OutgoingNscName    string // CLIENT_NETWORK_SERVICE
-	AdvertiseNseLabels string // ENDPOINT_LABELS
-	OutgoingNscLabels  string // CLIENT_LABELS
+	EndpointNetworkService   string // ENDPOINT_NETWORK_SERVICE
+	ClientNetworkService    string // CLIENT_NETWORK_SERVICE
+	EndpointLabels string // ENDPOINT_LABELS
+	ClientLabels  string // CLIENT_LABELS
 	TracerEnabled      bool   // TRACER_ENABLED
 	MechanismType      string // MECHANISM_TYPE
 	IPAddress          string // IP_ADDRESS
@@ -45,10 +45,10 @@ Note that some of the members of this structure can be initialized through the e
  * `NsmServerSocket` - [ *system* ], NS manager communication socket
  * `NsmClientSocket` - [ *system* ], NS manager communication socket
  * `Workspace` - [ *system* ], Kubernetes Pod namespace
- * `AdvertiseNseName` - [ `ENDPOINT_NETWORK_SERVICE` ], the *endpoint* name, as advertised to the NS registry
- * `OutgoingNscName` - [ `CLIENT_NETWORK_SERVICE` ], the *endpoint* name, as the *client* looks up in the NS registry
- * `AdvertiseNseLabels` - [ `ENDPOINT_LABELS` ], the *endpoint* labels, as advertised to the NS registry. Used in NSM's selector to match the DestinationSelector. The format is `label1=value1,label2=value2`
- * `OutgoingNscLabels` - [ `CLIENT_LABELS` ], the *endpoint* labels, as send by the *client* . Used in NSM's slector to match the SourceSelector. The format is the same as `AdvertiseNseLabels`
+ * `EndpointNetworkService` - [ `ENDPOINT_NETWORK_SERVICE` ], the *endpoint* name, as advertised to the NS registry
+ * `ClientNetworkService` - [ `CLIENT_NETWORK_SERVICE` ], the *endpoint* name, as the *client* looks up in the NS registry
+ * `EndpointLabels` - [ `ENDPOINT_LABELS` ], the *endpoint* labels, as advertised to the NS registry. Used in NSM's selector to match the DestinationSelector. The format is `label1=value1,label2=value2`
+ * `ClientLabels` - [ `CLIENT_LABELS` ], the *endpoint* labels, as send by the *client* . Used in NSM's slector to match the SourceSelector. The format is the same as `EndpointLabels`
  * `TracerEnabled` - [ `TRACER_ENABLED` ], enable the Jager tracing for an *endpoint*
  * `MechanismType` - [ `MECHANISM_TYPE` ], enforce a particular Mechanism type. Currently `kernel` or `mem`. Defaults to `kernel`
  * `IPAddress` - [ `IP_ADDRESS` ], the IP network to initalize a prefix pool in the IPAM composite

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -26,33 +26,33 @@ NSM SDK configuration is common for both Client and Endpoint APIs. It is done by
 
 ```go
 type NSConfiguration struct {
-    NsmServerSocket    string
-    NsmClientSocket    string
-    Workspace          string
-    AdvertiseNseName   string // ADVERTISE_NSE_NAME
-    OutgoingNscName    string // OUTGOING_NSC_NAME
-    AdvertiseNseLabels string // ADVERTISE_NSE_LABELS
-    OutgoingNscLabels  string // OUTGOING_NSC_LABELS
-    TracerEnabled      bool   // TRACER_ENABLED
-    MechanismType      string // MECHANISM_TYPE
-    IPAddress          string // IP_ADDRESS
-    Routes             []string // ROUTES
+	NsmServerSocket    string
+	NsmClientSocket    string
+	Workspace          string
+	AdvertiseNseName   string // ENDPOINT_NETWORK_SERVICE
+	OutgoingNscName    string // CLIENT_NETWORK_SERVICE
+	AdvertiseNseLabels string // ENDPOINT_LABELS
+	OutgoingNscLabels  string // CLIENT_LABELS
+	TracerEnabled      bool   // TRACER_ENABLED
+	MechanismType      string // MECHANISM_TYPE
+	IPAddress          string // IP_ADDRESS
+        Routes             []string // ROUTES
 }
 ```
 
 Note that some of the members of this structure can be initialized through the environment variables shown as comments above. A detailed explanation of each configuration option follows:
 
-* `NsmServerSocket` - [ *system* ], NS manager communication socket
-* `NsmClientSocket` - [ *system* ], NS manager communication socket
-* `Workspace` - [ *system* ], Kubernetes Pod namespace
-* `AdvertiseNseName` - [ `ADVERTISE_NSE_NAME` ], the *endpoint* name, as advertised to the NS registry
-* `OutgoingNscName` - [ `OUTGOING_NSC_NAME` ], the *endpoint* name, as the *client* looks up in the NS registry
-* `AdvertiseNseLabels` - [ `ADVERTISE_NSE_LABELS` ], the *endpoint* labels, as advertised to the NS registry. Used in NSM's selector to match the DestinationSelector. The format is `label1=value1,label2=value2`
-* `OutgoingNscLabels` - [ `OUTGOING_NSC_LABELS` ], the *endpoint* labels, as send by the *client* . Used in NSM's selector to match the SourceSelector. The format is the same as `AdvertiseNseLabels`
-* `TracerEnabled` - [ `TRACER_ENABLED` ], enable the Jaeger tracing for an *endpoint*
-* `MechanismType` - [ `MECHANISM_TYPE` ], enforce a particular Mechanism type. Currently `kernel` or `mem`. Defaults to `kernel`
-* `IPAddress` - [ `IP_ADDRESS` ], the IP network to initialize a prefix pool in the IPAM composite
-* `Routes` - [ `ROUTES` ], list of routes that will be set into connection's context by *Client*
+ * `NsmServerSocket` - [ *system* ], NS manager communication socket
+ * `NsmClientSocket` - [ *system* ], NS manager communication socket
+ * `Workspace` - [ *system* ], Kubernetes Pod namespace
+ * `AdvertiseNseName` - [ `ENDPOINT_NETWORK_SERVICE` ], the *endpoint* name, as advertised to the NS registry
+ * `OutgoingNscName` - [ `CLIENT_NETWORK_SERVICE` ], the *endpoint* name, as the *client* looks up in the NS registry
+ * `AdvertiseNseLabels` - [ `ENDPOINT_LABELS` ], the *endpoint* labels, as advertised to the NS registry. Used in NSM's selector to match the DestinationSelector. The format is `label1=value1,label2=value2`
+ * `OutgoingNscLabels` - [ `CLIENT_LABELS` ], the *endpoint* labels, as send by the *client* . Used in NSM's slector to match the SourceSelector. The format is the same as `AdvertiseNseLabels`
+ * `TracerEnabled` - [ `TRACER_ENABLED` ], enable the Jager tracing for an *endpoint*
+ * `MechanismType` - [ `MECHANISM_TYPE` ], enforce a particular Mechanism type. Currently `kernel` or `mem`. Defaults to `kernel`
+ * `IPAddress` - [ `IP_ADDRESS` ], the IP network to initalize a prefix pool in the IPAM composite
+ * `Routes` - [ `ROUTES` ], list of routes that will be set into connection's context by *Client*
 
 ## Implementing a Client
 

--- a/sdk/client/client.go
+++ b/sdk/client/client.go
@@ -37,9 +37,9 @@ const (
 // NsmClient is the NSM client struct
 type NsmClient struct {
 	*common.NsmConnection
-	ClientNetworkService     string
-	ClientLabels   map[string]string
-	OutgoingConnections []*connection.Connection
+	ClientNetworkService string
+	ClientLabels         map[string]string
+	OutgoingConnections  []*connection.Connection
 }
 
 // Connect implements the business logic
@@ -143,9 +143,8 @@ func (nsmc *NsmClient) PerformRequest(outgoingRequest *networkservice.NetworkSer
 
 // NewNSMClient creates the NsmClient
 func NewNSMClient(ctx context.Context, configuration *common.NSConfiguration) (*NsmClient, error) {
-	if configuration == nil {
-		configuration = &common.NSConfiguration{}
-	}
+	// ensure the env variables are processed
+	configuration = common.NewNSConfiguration(configuration)
 	configuration.CompleteNSConfiguration()
 
 	nsmConnection, err := common.NewNSMConnection(ctx, configuration)
@@ -155,9 +154,9 @@ func NewNSMClient(ctx context.Context, configuration *common.NSConfiguration) (*
 	}
 
 	client := &NsmClient{
-		NsmConnection:     nsmConnection,
-		ClientNetworkService:   configuration.ClientNetworkService,
-		ClientLabels: tools.ParseKVStringToMap(configuration.ClientLabels, ",", "="),
+		NsmConnection:        nsmConnection,
+		ClientNetworkService: configuration.ClientNetworkService,
+		ClientLabels:         tools.ParseKVStringToMap(configuration.ClientLabels, ",", "="),
 	}
 
 	return client, nil

--- a/sdk/client/client.go
+++ b/sdk/client/client.go
@@ -37,8 +37,8 @@ const (
 // NsmClient is the NSM client struct
 type NsmClient struct {
 	*common.NsmConnection
-	OutgoingNscName     string
-	OutgoingNscLabels   map[string]string
+	ClientNetworkService     string
+	ClientLabels   map[string]string
 	OutgoingConnections []*connection.Connection
 }
 
@@ -63,7 +63,7 @@ func (nsmc *NsmClient) Connect(name, mechanism, description string) (*connection
 
 	outgoingRequest := &networkservice.NetworkServiceRequest{
 		Connection: &connection.Connection{
-			NetworkService: nsmc.Configuration.OutgoingNscName,
+			NetworkService: nsmc.Configuration.ClientNetworkService,
 			Context: &connectioncontext.ConnectionContext{
 				IpContext: &connectioncontext.IPContext{
 					SrcIpRequired: true,
@@ -71,7 +71,7 @@ func (nsmc *NsmClient) Connect(name, mechanism, description string) (*connection
 					SrcRoutes:     routes,
 				},
 			},
-			Labels: nsmc.OutgoingNscLabels,
+			Labels: nsmc.ClientLabels,
 		},
 		MechanismPreferences: []*connection.Mechanism{
 			outgoingMechanism,
@@ -156,8 +156,8 @@ func NewNSMClient(ctx context.Context, configuration *common.NSConfiguration) (*
 
 	client := &NsmClient{
 		NsmConnection:     nsmConnection,
-		OutgoingNscName:   configuration.OutgoingNscName,
-		OutgoingNscLabels: tools.ParseKVStringToMap(configuration.OutgoingNscLabels, ",", "="),
+		ClientNetworkService:   configuration.ClientNetworkService,
+		ClientLabels: tools.ParseKVStringToMap(configuration.ClientLabels, ",", "="),
 	}
 
 	return client, nil

--- a/sdk/client/client.go
+++ b/sdk/client/client.go
@@ -145,7 +145,6 @@ func (nsmc *NsmClient) PerformRequest(outgoingRequest *networkservice.NetworkSer
 func NewNSMClient(ctx context.Context, configuration *common.NSConfiguration) (*NsmClient, error) {
 	// ensure the env variables are processed
 	configuration = common.NewNSConfiguration(configuration)
-	configuration.CompleteNSConfiguration()
 
 	nsmConnection, err := common.NewNSMConnection(ctx, configuration)
 	if err != nil {

--- a/sdk/client/clientlist.go
+++ b/sdk/client/clientlist.go
@@ -20,8 +20,6 @@ import (
 	"os"
 	"strconv"
 
-	"github.com/sirupsen/logrus"
-
 	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/local/connection"
 	"github.com/networkservicemesh/networkservicemesh/pkg/tools"
 
@@ -101,7 +99,7 @@ func NewNSMClientList(ctx context.Context, configuration *common.NSConfiguration
 
 	var clients []nsmClientListEntry
 	for _, url := range urls {
-		configuration = common.NSConfigurationFromUrl(configuration, url)
+		configuration = common.NewNSConfigurationWithURL(configuration, url)
 		client, err := NewNSMClient(ctx, configuration)
 		if err != nil {
 			return nil, err

--- a/sdk/client/clientlist.go
+++ b/sdk/client/clientlist.go
@@ -23,8 +23,9 @@ import (
 	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/local/connection"
 	"github.com/networkservicemesh/networkservicemesh/pkg/tools"
 
-	"github.com/networkservicemesh/networkservicemesh/sdk/common"
 	"github.com/sirupsen/logrus"
+
+	"github.com/networkservicemesh/networkservicemesh/sdk/common"
 )
 
 type nsmClientListEntry struct {

--- a/sdk/client/clientlist.go
+++ b/sdk/client/clientlist.go
@@ -26,6 +26,7 @@ import (
 	"github.com/networkservicemesh/networkservicemesh/pkg/tools"
 
 	"github.com/networkservicemesh/networkservicemesh/sdk/common"
+	"github.com/sirupsen/logrus"
 )
 
 type nsmClientListEntry struct {

--- a/sdk/common/configuration.go
+++ b/sdk/common/configuration.go
@@ -24,10 +24,10 @@ import (
 )
 
 const (
-	advertiseNseNameEnv   = "ADVERTISE_NSE_NAME"
-	advertiseNseLabelsEnv = "ADVERTISE_NSE_LABELS"
-	outgoingNscNameEnv    = "OUTGOING_NSC_NAME"
-	outgoingNscLabelsEnv  = "OUTGOING_NSC_LABELS"
+	advertiseNseNameEnv   = "ENDPOINT_NETWORK_SERVICE"
+	advertiseNseLabelsEnv = "ENDPOINT_LABELS"
+	outgoingNscNameEnv    = "CLIENT_NETWORK_SERVICE"
+	outgoingNscLabelsEnv  = "CLIENT_LABELS"
 	tracerEnabled         = "TRACER_ENABLED"
 	mechanismTypeEnv      = "MECHANISM_TYPE"
 	ipAddressEnv          = "IP_ADDRESS"

--- a/sdk/common/configuration.go
+++ b/sdk/common/configuration.go
@@ -24,14 +24,14 @@ import (
 )
 
 const (
-	advertiseNseNameEnv   = "ENDPOINT_NETWORK_SERVICE"
-	advertiseNseLabelsEnv = "ENDPOINT_LABELS"
-	outgoingNscNameEnv    = "CLIENT_NETWORK_SERVICE"
-	outgoingNscLabelsEnv  = "CLIENT_LABELS"
-	tracerEnabled         = "TRACER_ENABLED"
-	mechanismTypeEnv      = "MECHANISM_TYPE"
-	ipAddressEnv          = "IP_ADDRESS"
-	routesEnv             = "ROUTES"
+	endpointNetworkServiceEnv = "ENDPOINT_NETWORK_SERVICE"
+	endpointLabelsEnv         = "ENDPOINT_LABELS"
+	clientNetworkServiceEnv   = "CLIENT_NETWORK_SERVICE"
+	clientLabelsEnv           = "CLIENT_LABELS"
+	tracerEnabledEnv          = "TRACER_ENABLED"
+	mechanismTypeEnv          = "MECHANISM_TYPE"
+	ipAddressEnv              = "IP_ADDRESS"
+	routesEnv                 = "ROUTES"
 )
 
 // NSConfiguration contains the full configuration used in the SDK
@@ -65,22 +65,22 @@ func (configuration *NSConfiguration) CompleteNSConfiguration() {
 	}
 
 	if configuration.AdvertiseNseName == "" {
-		configuration.AdvertiseNseName = getEnv(advertiseNseNameEnv, "Advertise Network Service Name", false)
+		configuration.AdvertiseNseName = getEnv(endpointNetworkServiceEnv, "Advertise Network Service Name", false)
 	}
 
 	if configuration.OutgoingNscName == "" {
-		configuration.OutgoingNscName = getEnv(outgoingNscNameEnv, "Outgoing Network Service Name", false)
+		configuration.OutgoingNscName = getEnv(clientNetworkServiceEnv, "Outgoing Network Service Name", false)
 	}
 
 	if configuration.AdvertiseNseLabels == "" {
-		configuration.AdvertiseNseLabels = getEnv(advertiseNseLabelsEnv, "Advertise labels", false)
+		configuration.AdvertiseNseLabels = getEnv(endpointLabelsEnv, "Advertise labels", false)
 	}
 
 	if configuration.OutgoingNscLabels == "" {
-		configuration.OutgoingNscLabels = getEnv(outgoingNscLabelsEnv, "Outgoing labels", false)
+		configuration.OutgoingNscLabels = getEnv(clientLabelsEnv, "Outgoing labels", false)
 	}
 
-	configuration.TracerEnabled, _ = strconv.ParseBool(getEnv(tracerEnabled, "Tracer enabled", false))
+	configuration.TracerEnabled, _ = strconv.ParseBool(getEnv(tracerEnabledEnv, "Tracer enabled", false))
 
 	if configuration.MechanismType == "" {
 		configuration.MechanismType = getEnv(mechanismTypeEnv, "Outgoing mechanism type", false)

--- a/sdk/common/configuration.go
+++ b/sdk/common/configuration.go
@@ -55,7 +55,7 @@ type NSConfiguration struct {
 func (nsc *NSConfiguration) getEnv(key, description string, mandatory bool) string {
 
 	value := nsc.viperConfig.GetString(key)
-	if len(value) == 0 {
+	if value == "" {
 		if mandatory {
 			logrus.Fatalf("Error getting %v", key)
 		} else {
@@ -100,11 +100,11 @@ func (nsc *NSConfiguration) completeNSConfiguration() {
 
 	nsc.TracerEnabled, _ = strconv.ParseBool(nsc.getEnv(tracerEnabledEnv, "Tracer enabled", false))
 
-	if configuration.MechanismType == "" {
-		configuration.MechanismType = nsc.getEnv(mechanismTypeEnv, "Outgoing mechanism type", false)
+	if nsc.MechanismType == "" {
+		nsc.MechanismType = nsc.getEnv(mechanismTypeEnv, "Outgoing mechanism type", false)
 	}
 
-	if len(nsc.IPAddress) == 0 {
+	if nsc.IPAddress == "" {
 		nsc.IPAddress = nsc.getEnv(ipAddressEnv, "IP Address", false)
 	}
 
@@ -116,42 +116,51 @@ func (nsc *NSConfiguration) completeNSConfiguration() {
 	}
 }
 
-func NSConfigurationFromUrl(configuration *NSConfiguration, url *tools.NSUrl) *NSConfiguration {
-	var conf NSConfiguration
-	if configuration != nil {
-		conf = *configuration
-	}
-	conf.ClientNetworkService = url.NsName
-	var labels strings.Builder
-	separator := false
-	for k, v := range url.Params {
-		if separator {
-			labels.WriteRune(',')
-		} else {
-			separator = true
-		}
-		labels.WriteString(k)
-		labels.WriteRune('=')
-		labels.WriteString(v[0])
-	}
-	conf.ClientLabels = labels.String()
-	return &conf
-}
-
 func (nsc *NSConfiguration) bindNSConfiguration() {
-	nsc.viperConfig.BindEnv(nsmd.NsmServerSocketEnv)
-	nsc.viperConfig.BindEnv(nsmd.NsmClientSocketEnv)
-	nsc.viperConfig.BindEnv(nsmd.WorkspaceEnv)
-	nsc.viperConfig.BindEnv(endpointNetworkServiceEnv)
-	nsc.viperConfig.BindEnv(clientNetworkServiceEnv)
-	nsc.viperConfig.BindEnv(endpointLabelsEnv)
-	nsc.viperConfig.BindEnv(clientLabelsEnv)
-	nsc.viperConfig.BindEnv(tracerEnabledEnv)
-	nsc.viperConfig.BindEnv(mechanismTypeEnv)
-	nsc.viperConfig.BindEnv(ipAddressEnv)
+	err := nsc.viperConfig.BindEnv(nsmd.NsmServerSocketEnv)
+	if err != nil {
+		logrus.Errorf("Unable to bind %s", nsmd.NsmServerSocketEnv)
+	}
+	err = nsc.viperConfig.BindEnv(nsmd.NsmClientSocketEnv)
+	if err != nil {
+		logrus.Errorf("Unable to bind %s", nsmd.NsmClientSocketEnv)
+	}
+	err = nsc.viperConfig.BindEnv(nsmd.WorkspaceEnv)
+	if err != nil {
+		logrus.Errorf("Unable to bind %s", nsmd.WorkspaceEnv)
+	}
+	err = nsc.viperConfig.BindEnv(endpointNetworkServiceEnv)
+	if err != nil {
+		logrus.Errorf("Unable to bind %s", endpointNetworkServiceEnv)
+	}
+	err = nsc.viperConfig.BindEnv(clientNetworkServiceEnv)
+	if err != nil {
+		logrus.Errorf("Unable to bind %s", clientNetworkServiceEnv)
+	}
+	err = nsc.viperConfig.BindEnv(endpointLabelsEnv)
+	if err != nil {
+		logrus.Errorf("Unable to bind %s", endpointLabelsEnv)
+	}
+	err = nsc.viperConfig.BindEnv(clientLabelsEnv)
+	if err != nil {
+		logrus.Errorf("Unable to bind %s", clientLabelsEnv)
+	}
+	err = nsc.viperConfig.BindEnv(tracerEnabledEnv)
+	if err != nil {
+		logrus.Errorf("Unable to bind %s", tracerEnabledEnv)
+	}
+	err = nsc.viperConfig.BindEnv(ipAddressEnv)
+	if err != nil {
+		logrus.Errorf("Unable to bind %s", ipAddressEnv)
+	}
+	err = nsc.viperConfig.BindEnv(ipAddressEnv)
+	if err != nil {
+		logrus.Errorf("Unable to bind %s", ipAddressEnv)
+	}
 }
 
-func NewNSConfigurationWithUrl(nsc *NSConfiguration, url *tools.NsUrl) *NSConfiguration {
+// NewNSConfigurationWithURL ensure the new NS configuration with a provided URL
+func NewNSConfigurationWithURL(nsc *NSConfiguration, url *tools.NSUrl) *NSConfiguration {
 
 	nsc = NewNSConfiguration(nsc)
 	nsc.ClientNetworkService = url.NsName
@@ -171,6 +180,7 @@ func NewNSConfigurationWithUrl(nsc *NSConfiguration, url *tools.NsUrl) *NSConfig
 	return nsc
 }
 
+// NewNSConfiguration ensure the new NS configuration
 func NewNSConfiguration(nsc *NSConfiguration) *NSConfiguration {
 	if nsc == nil {
 		nsc = &NSConfiguration{}

--- a/sdk/common/configuration.go
+++ b/sdk/common/configuration.go
@@ -19,10 +19,11 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/nsmd"
-	"github.com/networkservicemesh/networkservicemesh/pkg/tools"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
+
+	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/nsmd"
+	"github.com/networkservicemesh/networkservicemesh/pkg/tools"
 )
 
 const (
@@ -48,7 +49,7 @@ type NSConfiguration struct {
 	TracerEnabled          bool
 	MechanismType          string
 	IPAddress              string
-	Routes             []string
+	Routes                 []string
 	viperConfig            *viper.Viper
 }
 

--- a/sdk/common/configuration.go
+++ b/sdk/common/configuration.go
@@ -36,16 +36,16 @@ const (
 
 // NSConfiguration contains the full configuration used in the SDK
 type NSConfiguration struct {
-	NsmServerSocket    string
-	NsmClientSocket    string
-	Workspace          string
-	AdvertiseNseName   string
-	OutgoingNscName    string
-	AdvertiseNseLabels string
-	OutgoingNscLabels  string
-	TracerEnabled      bool
-	MechanismType      string
-	IPAddress          string
+	NsmServerSocket        string
+	NsmClientSocket        string
+	Workspace              string
+	EndpointNetworkService string
+	ClientNetworkService   string
+	EndpointLabels         string
+	ClientLabels           string
+	TracerEnabled          bool
+	MechanismType          string
+	IPAddress              string
 	Routes             []string
 }
 
@@ -64,20 +64,20 @@ func (configuration *NSConfiguration) CompleteNSConfiguration() {
 		configuration.Workspace = getEnv(nsmd.WorkspaceEnv, "workspace", true)
 	}
 
-	if configuration.AdvertiseNseName == "" {
-		configuration.AdvertiseNseName = getEnv(endpointNetworkServiceEnv, "Advertise Network Service Name", false)
+	if configuration.EndpointNetworkService == "" {
+		configuration.EndpointNetworkService = getEnv(endpointNetworkServiceEnv, "Advertise Network Service Name", false)
 	}
 
-	if configuration.OutgoingNscName == "" {
-		configuration.OutgoingNscName = getEnv(clientNetworkServiceEnv, "Outgoing Network Service Name", false)
+	if configuration.ClientNetworkService == "" {
+		configuration.ClientNetworkService = getEnv(clientNetworkServiceEnv, "Outgoing Network Service Name", false)
 	}
 
-	if configuration.AdvertiseNseLabels == "" {
-		configuration.AdvertiseNseLabels = getEnv(endpointLabelsEnv, "Advertise labels", false)
+	if configuration.EndpointLabels == "" {
+		configuration.EndpointLabels = getEnv(endpointLabelsEnv, "Advertise labels", false)
 	}
 
-	if configuration.OutgoingNscLabels == "" {
-		configuration.OutgoingNscLabels = getEnv(clientLabelsEnv, "Outgoing labels", false)
+	if configuration.ClientLabels == "" {
+		configuration.ClientLabels = getEnv(clientLabelsEnv, "Outgoing labels", false)
 	}
 
 	configuration.TracerEnabled, _ = strconv.ParseBool(getEnv(tracerEnabledEnv, "Tracer enabled", false))
@@ -103,7 +103,7 @@ func NSConfigurationFromUrl(configuration *NSConfiguration, url *tools.NSUrl) *N
 	if configuration != nil {
 		conf = *configuration
 	}
-	conf.OutgoingNscName = url.NsName
+	conf.ClientNetworkService = url.NsName
 	var labels strings.Builder
 	separator := false
 	for k, v := range url.Params {
@@ -116,6 +116,6 @@ func NSConfigurationFromUrl(configuration *NSConfiguration, url *tools.NSUrl) *N
 		labels.WriteRune('=')
 		labels.WriteString(v[0])
 	}
-	conf.OutgoingNscLabels = labels.String()
+	conf.ClientLabels = labels.String()
 	return &conf
 }

--- a/sdk/common/configuration.go
+++ b/sdk/common/configuration.go
@@ -50,44 +50,44 @@ type NSConfiguration struct {
 }
 
 // CompleteNSConfiguration fills all unset options from the env variables
-func (configuration *NSConfiguration) CompleteNSConfiguration() {
+func (nsc *NSConfiguration) CompleteNSConfiguration() {
 
-	if configuration.NsmServerSocket == "" {
-		configuration.NsmServerSocket = getEnv(nsmd.NsmServerSocketEnv, "nsmServerSocket", true)
+	if nsc.NsmServerSocket == "" {
+		nsc.NsmServerSocket = getEnv(nsmd.NsmServerSocketEnv, "nsmServerSocket", true)
 	}
 
-	if configuration.NsmClientSocket == "" {
-		configuration.NsmClientSocket = getEnv(nsmd.NsmClientSocketEnv, "nsmClientSocket", true)
+	if nsc.NsmClientSocket == "" {
+		nsc.NsmClientSocket = getEnv(nsmd.NsmClientSocketEnv, "nsmClientSocket", true)
 	}
 
-	if configuration.Workspace == "" {
-		configuration.Workspace = getEnv(nsmd.WorkspaceEnv, "workspace", true)
+	if nsc.Workspace == "" {
+		nsc.Workspace = getEnv(nsmd.WorkspaceEnv, "workspace", true)
 	}
 
-	if configuration.EndpointNetworkService == "" {
-		configuration.EndpointNetworkService = getEnv(endpointNetworkServiceEnv, "Advertise Network Service Name", false)
+	if nsc.EndpointNetworkService == "" {
+		nsc.EndpointNetworkService = getEnv(endpointNetworkServiceEnv, "Advertise Network Service Name", false)
 	}
 
-	if configuration.ClientNetworkService == "" {
-		configuration.ClientNetworkService = getEnv(clientNetworkServiceEnv, "Outgoing Network Service Name", false)
+	if nsc.ClientNetworkService == "" {
+		nsc.ClientNetworkService = getEnv(clientNetworkServiceEnv, "Outgoing Network Service Name", false)
 	}
 
-	if configuration.EndpointLabels == "" {
-		configuration.EndpointLabels = getEnv(endpointLabelsEnv, "Advertise labels", false)
+	if nsc.EndpointLabels == "" {
+		nsc.EndpointLabels = getEnv(endpointLabelsEnv, "Advertise labels", false)
 	}
 
-	if configuration.ClientLabels == "" {
-		configuration.ClientLabels = getEnv(clientLabelsEnv, "Outgoing labels", false)
+	if nsc.ClientLabels == "" {
+		nsc.ClientLabels = getEnv(clientLabelsEnv, "Outgoing labels", false)
 	}
 
-	configuration.TracerEnabled, _ = strconv.ParseBool(getEnv(tracerEnabledEnv, "Tracer enabled", false))
+	nsc.TracerEnabled, _ = strconv.ParseBool(getEnv(tracerEnabledEnv, "Tracer enabled", false))
 
 	if configuration.MechanismType == "" {
 		configuration.MechanismType = getEnv(mechanismTypeEnv, "Outgoing mechanism type", false)
 	}
 
-	if len(configuration.IPAddress) == 0 {
-		configuration.IPAddress = getEnv(ipAddressEnv, "IP Address", false)
+	if len(nsc.IPAddress) == 0 {
+		nsc.IPAddress = getEnv(ipAddressEnv, "IP Address", false)
 	}
 
 	if len(configuration.Routes) == 0 {
@@ -118,4 +118,32 @@ func NSConfigurationFromUrl(configuration *NSConfiguration, url *tools.NSUrl) *N
 	}
 	conf.ClientLabels = labels.String()
 	return &conf
+}
+
+func NewNSConfigurationWithUrl(nsc *NSConfiguration, url *tools.NsUrl) *NSConfiguration {
+
+	nsc = NewNSConfiguration(nsc)
+	nsc.ClientNetworkService = url.NsName
+	var labels strings.Builder
+	separator := false
+	for k, v := range url.Params {
+		if separator {
+			labels.WriteRune(',')
+		} else {
+			separator = true
+		}
+		labels.WriteString(k)
+		labels.WriteRune('=')
+		labels.WriteString(v[0])
+	}
+	nsc.ClientLabels = labels.String()
+	return nsc
+}
+
+func NewNSConfiguration(nsc *NSConfiguration) *NSConfiguration {
+	if nsc == nil {
+		nsc = &NSConfiguration{}
+	}
+
+	return nsc
 }

--- a/sdk/common/configuration.go
+++ b/sdk/common/configuration.go
@@ -109,10 +109,10 @@ func (nsc *NSConfiguration) completeNSConfiguration() {
 		nsc.IPAddress = nsc.getEnv(ipAddressEnv, "IP Address", false)
 	}
 
-	if len(configuration.Routes) == 0 {
-		raw := getEnv(routesEnv, "Routes", false)
+	if len(nsc.Routes) == 0 {
+		raw := nsc.getEnv(routesEnv, "Routes", false)
 		if len(raw) > 1 {
-			configuration.Routes = strings.Split(raw, ",")
+			nsc.Routes = strings.Split(raw, ",")
 		}
 	}
 }

--- a/sdk/common/helpers.go
+++ b/sdk/common/helpers.go
@@ -18,27 +18,12 @@ package common
 import (
 	"encoding/binary"
 	"net"
-	"os"
 	"strings"
 
 	"github.com/sirupsen/logrus"
 
 	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/local/connection"
 )
-
-func getEnv(key, description string, mandatory bool) string {
-	value, ok := os.LookupEnv(key)
-	if !ok {
-		if mandatory {
-			logrus.Fatalf("Error getting %v: %v", key, ok)
-		} else {
-			logrus.Infof("%v not found.", key)
-			return ""
-		}
-	}
-	logrus.Infof("%s: %s", description, value)
-	return value
-}
 
 // Ip2int converts and IP address to 32-bit unsignet integer
 func Ip2int(ip net.IP) uint32 {

--- a/sdk/endpoint/client.go
+++ b/sdk/endpoint/client.go
@@ -93,9 +93,7 @@ func (cce *ClientEndpoint) GetOpaque(incoming interface{}) interface{} {
 // NewClientEndpoint creates a ClientEndpoint
 func NewClientEndpoint(configuration *common.NSConfiguration) *ClientEndpoint {
 	// ensure the env variables are processed
-	if configuration == nil {
-		configuration = &common.NSConfiguration{}
-	}
+	configuration = common.NewNSConfiguration(configuration)
 	configuration.CompleteNSConfiguration()
 
 	nsmClient, err := client.NewNSMClient(context.Background(), configuration)

--- a/sdk/endpoint/client.go
+++ b/sdk/endpoint/client.go
@@ -94,7 +94,6 @@ func (cce *ClientEndpoint) GetOpaque(incoming interface{}) interface{} {
 func NewClientEndpoint(configuration *common.NSConfiguration) *ClientEndpoint {
 	// ensure the env variables are processed
 	configuration = common.NewNSConfiguration(configuration)
-	configuration.CompleteNSConfiguration()
 
 	nsmClient, err := client.NewNSMClient(context.Background(), configuration)
 	if err != nil {

--- a/sdk/endpoint/connection.go
+++ b/sdk/endpoint/connection.go
@@ -105,7 +105,6 @@ func (cce *ConnectionEndpoint) generateIfName() string {
 func NewConnectionEndpoint(configuration *common.NSConfiguration) *ConnectionEndpoint {
 	// ensure the env variables are processed
 	configuration = common.NewNSConfiguration(configuration)
-	configuration.CompleteNSConfiguration()
 
 	rand.Seed(time.Now().UTC().UnixNano())
 

--- a/sdk/endpoint/connection.go
+++ b/sdk/endpoint/connection.go
@@ -104,9 +104,7 @@ func (cce *ConnectionEndpoint) generateIfName() string {
 // NewConnectionEndpoint creates a ConnectionEndpoint
 func NewConnectionEndpoint(configuration *common.NSConfiguration) *ConnectionEndpoint {
 	// ensure the env variables are processed
-	if configuration == nil {
-		configuration = &common.NSConfiguration{}
-	}
+	configuration = common.NewNSConfiguration(configuration)
 	configuration.CompleteNSConfiguration()
 
 	rand.Seed(time.Now().UTC().UnixNano())

--- a/sdk/endpoint/endpoint.go
+++ b/sdk/endpoint/endpoint.go
@@ -68,7 +68,7 @@ func (nsme *nsmEndpoint) serve(listener net.Listener) {
 func (nsme *nsmEndpoint) Start() error {
 
 	if nsme.Configuration.TracerEnabled {
-		tracer, closer := tools.InitJaeger(nsme.Configuration.AdvertiseNseName)
+		tracer, closer := tools.InitJaeger(nsme.Configuration.EndpointNetworkService)
 		opentracing.SetGlobalTracer(tracer)
 		nsme.tracerCloser = closer
 	}
@@ -100,13 +100,13 @@ func (nsme *nsmEndpoint) Start() error {
 	// Registering NSE API, it will listen for Connection requests from NSM and return information
 	// needed for NSE's dataplane programming.
 	nse := &registry.NetworkServiceEndpoint{
-		NetworkServiceName: nsme.Configuration.AdvertiseNseName,
+		NetworkServiceName: nsme.Configuration.EndpointNetworkService,
 		Payload:            "IP",
-		Labels:             tools.ParseKVStringToMap(nsme.Configuration.AdvertiseNseLabels, ",", "="),
+		Labels:             tools.ParseKVStringToMap(nsme.Configuration.EndpointLabels, ",", "="),
 	}
 	registration := &registry.NSERegistration{
 		NetworkService: &registry.NetworkService{
-			Name:    nsme.Configuration.AdvertiseNseName,
+			Name:    nsme.Configuration.EndpointNetworkService,
 			Payload: "IP",
 		},
 		NetworkServiceEndpoint: nse,

--- a/sdk/endpoint/endpoint.go
+++ b/sdk/endpoint/endpoint.go
@@ -164,7 +164,6 @@ func (nsme *nsmEndpoint) Close(ctx context.Context, incomingConnection *connecti
 // NewNSMEndpoint creates a new NSM endpoint
 func NewNSMEndpoint(ctx context.Context, configuration *common.NSConfiguration, service *CompositeEndpoint) (*nsmEndpoint, error) {
 	configuration = common.NewNSConfiguration(configuration)
-	configuration.CompleteNSConfiguration()
 
 	if service == nil {
 		service = &CompositeEndpoint{}

--- a/sdk/endpoint/endpoint.go
+++ b/sdk/endpoint/endpoint.go
@@ -163,9 +163,7 @@ func (nsme *nsmEndpoint) Close(ctx context.Context, incomingConnection *connecti
 
 // NewNSMEndpoint creates a new NSM endpoint
 func NewNSMEndpoint(ctx context.Context, configuration *common.NSConfiguration, service *CompositeEndpoint) (*nsmEndpoint, error) {
-	if configuration == nil {
-		configuration = &common.NSConfiguration{}
-	}
+	configuration = common.NewNSConfiguration(configuration)
 	configuration.CompleteNSConfiguration()
 
 	if service == nil {

--- a/sdk/endpoint/ipam.go
+++ b/sdk/endpoint/ipam.go
@@ -115,9 +115,7 @@ func (ice *IpamEndpoint) Name() string {
 // NewIpamEndpoint creates a IpamEndpoint
 func NewIpamEndpoint(configuration *common.NSConfiguration) *IpamEndpoint {
 	// ensure the env variables are processed
-	if configuration == nil {
-		configuration = &common.NSConfiguration{}
-	}
+	configuration = common.NewNSConfiguration(configuration)
 	configuration.CompleteNSConfiguration()
 
 	pool, err := prefix_pool.NewPrefixPool(configuration.IPAddress)

--- a/sdk/endpoint/ipam.go
+++ b/sdk/endpoint/ipam.go
@@ -116,7 +116,6 @@ func (ice *IpamEndpoint) Name() string {
 func NewIpamEndpoint(configuration *common.NSConfiguration) *IpamEndpoint {
 	// ensure the env variables are processed
 	configuration = common.NewNSConfiguration(configuration)
-	configuration.CompleteNSConfiguration()
 
 	pool, err := prefix_pool.NewPrefixPool(configuration.IPAddress)
 	if err != nil {

--- a/sdk/endpoint/monitor.go
+++ b/sdk/endpoint/monitor.go
@@ -85,7 +85,7 @@ func (mce *MonitorEndpoint) GetOpaque(incoming interface{}) interface{} {
 // NewMonitorEndpoint creates a MonitorEndpoint
 func NewMonitorEndpoint(configuration *common.NSConfiguration) *MonitorEndpoint {
 	// ensure the env variables are processed
-	configuration = common.NewNSConfiguration(configuration)
+	common.NewNSConfiguration(configuration)
 
 	self := &MonitorEndpoint{
 		monitorConnectionServer: local.NewMonitorServer(),

--- a/sdk/endpoint/monitor.go
+++ b/sdk/endpoint/monitor.go
@@ -86,7 +86,6 @@ func (mce *MonitorEndpoint) GetOpaque(incoming interface{}) interface{} {
 func NewMonitorEndpoint(configuration *common.NSConfiguration) *MonitorEndpoint {
 	// ensure the env variables are processed
 	configuration = common.NewNSConfiguration(configuration)
-	configuration.CompleteNSConfiguration()
 
 	self := &MonitorEndpoint{
 		monitorConnectionServer: local.NewMonitorServer(),

--- a/sdk/endpoint/monitor.go
+++ b/sdk/endpoint/monitor.go
@@ -85,9 +85,7 @@ func (mce *MonitorEndpoint) GetOpaque(incoming interface{}) interface{} {
 // NewMonitorEndpoint creates a MonitorEndpoint
 func NewMonitorEndpoint(configuration *common.NSConfiguration) *MonitorEndpoint {
 	// ensure the env variables are processed
-	if configuration == nil {
-		configuration = &common.NSConfiguration{}
-	}
+	configuration = common.NewNSConfiguration(configuration)
 	configuration.CompleteNSConfiguration()
 
 	self := &MonitorEndpoint{

--- a/sdk/vppagent/acl.go
+++ b/sdk/vppagent/acl.go
@@ -110,11 +110,6 @@ func (a *ACL) Name() string {
 
 // NewACL creates an ACL
 func NewACL(configuration *common.NSConfiguration, rules map[string]string) *ACL {
-	// ensure the env variables are processed
-	if configuration == nil {
-		configuration = &common.NSConfiguration{}
-	}
-	configuration.CompleteNSConfiguration()
 
 	return &ACL{
 		Rules:       rules,

--- a/sdk/vppagent/client_memif_connect.go
+++ b/sdk/vppagent/client_memif_connect.go
@@ -90,10 +90,7 @@ func (cmc *ClientMemifConnect) Name() string {
 // NewClientMemifConnect creates a ClientMemifConnect
 func NewClientMemifConnect(configuration *common.NSConfiguration) *ClientMemifConnect {
 	// ensure the env variables are processed
-	if configuration == nil {
-		configuration = &common.NSConfiguration{}
-	}
-	configuration.CompleteNSConfiguration()
+	configuration = common.NewNSConfiguration(configuration)
 
 	return &ClientMemifConnect{
 		Workspace:   configuration.Workspace,

--- a/sdk/vppagent/cross_connect.go
+++ b/sdk/vppagent/cross_connect.go
@@ -81,10 +81,7 @@ func (xc *XConnect) Name() string {
 // NewXConnect creates a XConnect
 func NewXConnect(configuration *common.NSConfiguration) *XConnect {
 	// ensure the env variables are processed
-	if configuration == nil {
-		configuration = &common.NSConfiguration{}
-	}
-	configuration.CompleteNSConfiguration()
+	configuration = common.NewNSConfiguration(configuration)
 
 	return &XConnect{
 		Workspace:   configuration.Workspace,

--- a/sdk/vppagent/flush.go
+++ b/sdk/vppagent/flush.go
@@ -94,11 +94,6 @@ func (f *Flush) Name() string {
 
 // NewFlush creates a Flush
 func NewFlush(configuration *common.NSConfiguration, endpoint string) *Flush {
-	// ensure the env variables are processed
-	if configuration == nil {
-		configuration = &common.NSConfiguration{}
-	}
-	configuration.CompleteNSConfiguration()
 
 	self := &Flush{
 		Endpoint: endpoint,

--- a/sdk/vppagent/memif_connect.go
+++ b/sdk/vppagent/memif_connect.go
@@ -94,10 +94,7 @@ func (mc *MemifConnect) Name() string {
 // NewMemifConnect creates a MemifConnect
 func NewMemifConnect(configuration *common.NSConfiguration) *MemifConnect {
 	// ensure the env variables are processed
-	if configuration == nil {
-		configuration = &common.NSConfiguration{}
-	}
-	configuration.CompleteNSConfiguration()
+	configuration = common.NewNSConfiguration(configuration)
 
 	return &MemifConnect{
 		Workspace:   configuration.Workspace,

--- a/test/applications/cmd/vppagent-firewall-nse/main.go
+++ b/test/applications/cmd/vppagent-firewall-nse/main.go
@@ -37,7 +37,7 @@ func main() {
 	logrus.SetOutput(os.Stdout)
 	logrus.SetLevel(logrus.TraceLevel)
 
-        initConfig()
+	initConfig()
 
 	configuration := common.NewNSConfiguration(&common.NSConfiguration{
 		MechanismType: "mem",

--- a/test/applications/cmd/vppagent-firewall-nse/main.go
+++ b/test/applications/cmd/vppagent-firewall-nse/main.go
@@ -37,11 +37,11 @@ func main() {
 	logrus.SetOutput(os.Stdout)
 	logrus.SetLevel(logrus.TraceLevel)
 
-	initConfig()
+        initConfig()
 
-	configuration := &common.NSConfiguration{
+	configuration := common.NewNSConfiguration(&common.NSConfiguration{
 		MechanismType: "mem",
-	}
+	})
 
 	composite := endpoint.NewCompositeEndpoint(
 		endpoint.NewMonitorEndpoint(configuration),

--- a/test/applications/cmd/vppagent-icmp-responder-nse/main.go
+++ b/test/applications/cmd/vppagent-icmp-responder-nse/main.go
@@ -32,9 +32,9 @@ func main() {
 	// Capture signals to cleanup before exiting
 	c := tools.NewOSSignalChannel()
 
-	configuration := &common.NSConfiguration{
+	configuration := common.NewNSConfiguration(&common.NSConfiguration{
 		MechanismType: "mem",
-	}
+	})
 
 	composite := endpoint.NewCompositeEndpoint(
 		endpoint.NewMonitorEndpoint(configuration),

--- a/test/integration/basic_excluded_prefixes_test.go
+++ b/test/integration/basic_excluded_prefixes_test.go
@@ -57,8 +57,8 @@ func TestExcludePrefixCheck(t *testing.T) {
 
 	nsc, err := clientset.CoreV1().Pods(k8s.GetK8sNamespace()).Create(pods.NSCPod("nsc", nodes[0].Node,
 		map[string]string{
-			"OUTGOING_NSC_LABELS": "app=icmp",
-			"OUTGOING_NSC_NAME":   "icmp-responder",
+			"CLIENT_NETWORK_SERVICE": "icmp-responder",
+			"CLIENT_LABELS":          "app=icmp",
 		},
 	))
 

--- a/test/integration/basic_nsmd_k8s_excluded_prefixes_test.go
+++ b/test/integration/basic_nsmd_k8s_excluded_prefixes_test.go
@@ -55,8 +55,8 @@ func TestK8sExcludedPrefixes(t *testing.T) {
 
 	nsc, err := clientset.CoreV1().Pods(k8s.GetK8sNamespace()).Create(pods.NSCPod("nsc", nodes[0].Node,
 		map[string]string{
-			"OUTGOING_NSC_LABELS": "app=icmp",
-			"OUTGOING_NSC_NAME":   "icmp-responder",
+			"CLIENT_LABELS":          "app=icmp",
+			"CLIENT_NETWORK_SERVICE": "icmp-responder",
 		},
 	))
 

--- a/test/integration/interdomain_death_handling_test.go
+++ b/test/integration/interdomain_death_handling_test.go
@@ -91,8 +91,8 @@ func testInterdomainNSMDies(t *testing.T, clustersCount int, killSrc bool) {
 	}
 
 	nscPodNode := kubetest.DeployNSCWithEnv(k8ss[0].K8s, k8ss[0].NodesSetup[0].Node, "nsc-1", defaultTimeout, map[string]string{
-		"OUTGOING_NSC_LABELS": "app=icmp",
-		"OUTGOING_NSC_NAME":   fmt.Sprintf("icmp-responder@%s", nseExternalIP),
+		"CLIENT_LABELS":          "app=icmp",
+		"CLIENT_NETWORK_SERVICE": fmt.Sprintf("icmp-responder@%s", nseExternalIP),
 	})
 
 	kubetest.CheckNSC(k8ss[0].K8s, nscPodNode)

--- a/test/integration/interdomain_nsc_icmp_configuration_test.go
+++ b/test/integration/interdomain_nsc_icmp_configuration_test.go
@@ -94,8 +94,8 @@ func testInterdomainNSCAndICMP(t *testing.T, clustersCount int, nodesCount int, 
 	}
 
 	nscPodNode := kubetest.DeployNSCWithEnv(k8ss[0].K8s, k8ss[0].NodesSetup[0].Node, "nsc-1", defaultTimeout, map[string]string{
-		"OUTGOING_NSC_LABELS": "app=icmp",
-		"OUTGOING_NSC_NAME":   fmt.Sprintf("icmp-responder@%s", nseExternalIP),
+		"CLIENT_LABELS":          "app=icmp",
+		"CLIENT_NETWORK_SERVICE": fmt.Sprintf("icmp-responder@%s", nseExternalIP),
 	})
 
 	kubetest.CheckNSC(k8ss[0].K8s, nscPodNode)

--- a/test/integration/interdomain_nse_dataplane_heal_test.go
+++ b/test/integration/interdomain_nse_dataplane_heal_test.go
@@ -85,8 +85,8 @@ func testInterdomainDataplaneHeal(t *testing.T, clustersCount int, nodesCount in
 	}
 
 	nscPodNode := kubetest.DeployNSCWithEnv(k8ss[0].K8s, k8ss[0].NodesSetup[0].Node, "nsc-1", defaultTimeout, map[string]string{
-		"OUTGOING_NSC_LABELS": "app=icmp",
-		"OUTGOING_NSC_NAME":   fmt.Sprintf("icmp-responder@%s", nseExternalIP),
+		"CLIENT_LABELS":          "app=icmp",
+		"CLIENT_NETWORK_SERVICE": fmt.Sprintf("icmp-responder@%s", nseExternalIP),
 	})
 
 	kubetest.CheckNSC(k8ss[0].K8s, nscPodNode)

--- a/test/integration/interdomain_nse_heal_test.go
+++ b/test/integration/interdomain_nse_heal_test.go
@@ -109,8 +109,8 @@ func testInterdomainNSEHeal(t *testing.T, clustersCount int, nodesCount int, aff
 	}
 
 	nscPodNode := kubetest.DeployNSCWithEnv(k8ss[0].K8s, k8ss[0].NodesSetup[0].Node, "nsc-1", defaultTimeout, map[string]string{
-		"OUTGOING_NSC_LABELS": "app=icmp",
-		"OUTGOING_NSC_NAME":   fmt.Sprintf("icmp-responder@%s", nseExternalIP),
+		"CLIENT_LABELS":          "app=icmp",
+		"CLIENT_NETWORK_SERVICE": fmt.Sprintf("icmp-responder@%s", nseExternalIP),
 	})
 
 	kubetest.CheckNSC(k8ss[0].K8s, nscPodNode)

--- a/test/integration/interdomain_nse_nsm_heal_test.go
+++ b/test/integration/interdomain_nse_nsm_heal_test.go
@@ -99,8 +99,8 @@ func testInterdomainNSMHeal(t *testing.T, clustersCount int, killIndex int, dele
 	}
 
 	nscPodNode := kubetest.DeployNSCWithEnv(k8ss[0].K8s, k8ss[0].NodesSetup[0].Node, "nsc-1", defaultTimeout, map[string]string{
-		"OUTGOING_NSC_LABELS": "app=icmp",
-		"OUTGOING_NSC_NAME":   fmt.Sprintf("icmp-responder@%s", nseExternalIP),
+		"CLIENT_LABELS":          "app=icmp",
+		"CLIENT_NETWORK_SERVICE": fmt.Sprintf("icmp-responder@%s", nseExternalIP),
 	})
 
 	kubetest.CheckNSC(k8ss[0].K8s, nscPodNode)

--- a/test/integration/interdomain_vpn_test.go
+++ b/test/integration/interdomain_vpn_test.go
@@ -179,10 +179,10 @@ func testInterdomainVPN(t *testing.T, ptnum, clustersCount int, nodesCount int, 
 	g.Expect(err).To(BeNil())
 	vppagentFirewallNode := k8ss[firewallCluster].K8s.CreatePod(pods.VppAgentFirewallNSEPodWithConfigMap("vppagent-firewall-nse-1", &clusterNodes[firewallCluster][0],
 		map[string]string{
-			"ADVERTISE_NSE_NAME":   "secure-intranet-connectivity",
-			"ADVERTISE_NSE_LABELS": "app=firewall",
-			"OUTGOING_NSC_NAME":    nscOutgoingName,
-			"OUTGOING_NSC_LABELS":  "app=firewall",
+			"ENDPOINT_NETWORK_SERVICE": "secure-intranet-connectivity",
+			"ENDPOINT_LABELS":          "app=firewall",
+			"CLIENT_NETWORK_SERVICE":   nscOutgoingName,
+			"CLIENT_LABELS":            "app=firewall",
 		},
 	))
 	g.Expect(vppagentFirewallNode.Name).To(Equal("vppagent-firewall-nse-1"))
@@ -199,10 +199,10 @@ func testInterdomainVPN(t *testing.T, ptnum, clustersCount int, nodesCount int, 
 
 		vppagentPassthroughNode := k8ss[passthroughCluster].K8s.CreatePod(pods.VppAgentFirewallNSEPod("vppagent-passthrough-nse-"+id, &clusterNodes[passthroughCluster][0],
 			map[string]string{
-				"ADVERTISE_NSE_NAME":   "secure-intranet-connectivity",
-				"ADVERTISE_NSE_LABELS": "app=passthrough-" + id,
-				"OUTGOING_NSC_NAME":    "secure-intranet-connectivity",
-				"OUTGOING_NSC_LABELS":  "app=passthrough-" + id,
+				"ENDPOINT_NETWORK_SERVICE": "secure-intranet-connectivity",
+				"ENDPOINT_LABELS":          "app=passthrough-" + id,
+				"CLIENT_NETWORK_SERVICE":   "secure-intranet-connectivity",
+				"CLIENT_LABELS":            "app=passthrough-" + id,
 			},
 		))
 		g.Expect(vppagentPassthroughNode.Name).To(Equal("vppagent-passthrough-nse-" + id))
@@ -216,9 +216,9 @@ func testInterdomainVPN(t *testing.T, ptnum, clustersCount int, nodesCount int, 
 	logrus.Infof("Starting VPN Gateway NSE on node: %d", nseCluster)
 	vpnGatewayPodNode := k8ss[nseCluster].K8s.CreatePod(pods.VPNGatewayNSEPod("vpn-gateway-nse-1", &clusterNodes[nseCluster][0],
 		map[string]string{
-			"ADVERTISE_NSE_NAME":   "secure-intranet-connectivity",
-			"ADVERTISE_NSE_LABELS": "app=vpn-gateway",
-			"IP_ADDRESS":           addressPool,
+			"ENDPOINT_NETWORK_SERVICE": "secure-intranet-connectivity",
+			"ENDPOINT_LABELS":          "app=vpn-gateway",
+			"IP_ADDRESS":               addressPool,
 		},
 	))
 	g.Expect(vpnGatewayPodNode).ToNot(BeNil())
@@ -235,7 +235,7 @@ func testInterdomainVPN(t *testing.T, ptnum, clustersCount int, nodesCount int, 
 	}
 	nscPodNode := k8ss[nscCluster].K8s.CreatePod(pods.NSCPod("vpn-gateway-nsc-1", &clusterNodes[nscCluster][0],
 		map[string]string{
-			"OUTGOING_NSC_NAME": nscOutgoingName,
+			"CLIENT_NETWORK_SERVICE": nscOutgoingName,
 		},
 	))
 	g.Expect(nscPodNode.Name).To(Equal("vpn-gateway-nsc-1"))

--- a/test/integration/usecase_vpn_test.go
+++ b/test/integration/usecase_vpn_test.go
@@ -155,10 +155,10 @@ func testVPN(t *testing.T, ptnum, nodesCount int, affinity map[string]int, verbo
 
 		vppagentPassthroughNode := k8s.CreatePod(pods.VppAgentFirewallNSEPod("vppagent-passthrough-nse-"+id, &nodes[node],
 			map[string]string{
-				"ENDPOINT_NETWORK_SERVICE":   "secure-intranet-connectivity",
-				"ENDPOINT_LABELS": "app=passthrough-" + id,
-				"CLIENT_NETWORK_SERVICE":    "secure-intranet-connectivity",
-				"CLIENT_LABELS":  "app=passthrough-" + id,
+				"ENDPOINT_NETWORK_SERVICE": "secure-intranet-connectivity",
+				"ENDPOINT_LABELS":          "app=passthrough-" + id,
+				"CLIENT_NETWORK_SERVICE":   "secure-intranet-connectivity",
+				"CLIENT_LABELS":            "app=passthrough-" + id,
 			},
 		))
 		g.Expect(vppagentPassthroughNode.Name).To(Equal("vppagent-passthrough-nse-" + id))

--- a/test/integration/usecase_vpn_test.go
+++ b/test/integration/usecase_vpn_test.go
@@ -155,10 +155,10 @@ func testVPN(t *testing.T, ptnum, nodesCount int, affinity map[string]int, verbo
 
 		vppagentPassthroughNode := k8s.CreatePod(pods.VppAgentFirewallNSEPod("vppagent-passthrough-nse-"+id, &nodes[node],
 			map[string]string{
-				"ADVERTISE_NSE_NAME":   "secure-intranet-connectivity",
-				"ADVERTISE_NSE_LABELS": "app=passthrough-" + id,
-				"OUTGOING_NSC_NAME":    "secure-intranet-connectivity",
-				"OUTGOING_NSC_LABELS":  "app=passthrough-" + id,
+				"ENDPOINT_NETWORK_SERVICE":   "secure-intranet-connectivity",
+				"ENDPOINT_LABELS": "app=passthrough-" + id,
+				"CLIENT_NETWORK_SERVICE":    "secure-intranet-connectivity",
+				"CLIENT_LABELS":  "app=passthrough-" + id,
 			},
 		))
 		g.Expect(vppagentPassthroughNode.Name).To(Equal("vppagent-passthrough-nse-" + id))

--- a/test/integration/usecase_vpn_test.go
+++ b/test/integration/usecase_vpn_test.go
@@ -135,10 +135,10 @@ func testVPN(t *testing.T, ptnum, nodesCount int, affinity map[string]int, verbo
 	g.Expect(err).To(BeNil())
 	vppagentFirewallNode := k8s.CreatePod(pods.VppAgentFirewallNSEPodWithConfigMap("vppagent-firewall-nse-1", &nodes[node],
 		map[string]string{
-			"ADVERTISE_NSE_NAME":   "secure-intranet-connectivity",
-			"ADVERTISE_NSE_LABELS": "app=firewall",
-			"OUTGOING_NSC_NAME":    "secure-intranet-connectivity",
-			"OUTGOING_NSC_LABELS":  "app=firewall",
+			"ENDPOINT_NETWORK_SERVICE":   "secure-intranet-connectivity",
+			"ENDPOINT_LABELS": "app=firewall",
+			"CLIENT_NETWORK_SERVICE":    "secure-intranet-connectivity",
+			"CLIENT_LABELS":  "app=firewall",
 		},
 	))
 	g.Expect(vppagentFirewallNode.Name).To(Equal("vppagent-firewall-nse-1"))
@@ -173,8 +173,8 @@ func testVPN(t *testing.T, ptnum, nodesCount int, affinity map[string]int, verbo
 	logrus.Infof("Starting VPN Gateway NSE on node: %d", node)
 	vpnGatewayPodNode := k8s.CreatePod(pods.VPNGatewayNSEPod("vpn-gateway-nse-1", &nodes[node],
 		map[string]string{
-			"ADVERTISE_NSE_NAME":   "secure-intranet-connectivity",
-			"ADVERTISE_NSE_LABELS": "app=vpn-gateway",
+			"ENDPOINT_NETWORK_SERVICE":   "secure-intranet-connectivity",
+			"ENDPOINT_LABELS": "app=vpn-gateway",
 			"IP_ADDRESS":           addressPool,
 		},
 	))
@@ -189,7 +189,7 @@ func testVPN(t *testing.T, ptnum, nodesCount int, affinity map[string]int, verbo
 	node = affinity["vpn-gateway-nsc-1"]
 	nscPodNode := k8s.CreatePod(pods.NSCPod("vpn-gateway-nsc-1", &nodes[node],
 		map[string]string{
-			"OUTGOING_NSC_NAME": "secure-intranet-connectivity",
+			"CLIENT_NETWORK_SERVICE": "secure-intranet-connectivity",
 		},
 	))
 	g.Expect(nscPodNode.Name).To(Equal("vpn-gateway-nsc-1"))

--- a/test/integration/usecase_vpn_test.go
+++ b/test/integration/usecase_vpn_test.go
@@ -135,10 +135,10 @@ func testVPN(t *testing.T, ptnum, nodesCount int, affinity map[string]int, verbo
 	g.Expect(err).To(BeNil())
 	vppagentFirewallNode := k8s.CreatePod(pods.VppAgentFirewallNSEPodWithConfigMap("vppagent-firewall-nse-1", &nodes[node],
 		map[string]string{
-			"ENDPOINT_NETWORK_SERVICE":   "secure-intranet-connectivity",
-			"ENDPOINT_LABELS": "app=firewall",
-			"CLIENT_NETWORK_SERVICE":    "secure-intranet-connectivity",
-			"CLIENT_LABELS":  "app=firewall",
+			"ENDPOINT_NETWORK_SERVICE": "secure-intranet-connectivity",
+			"ENDPOINT_LABELS":          "app=firewall",
+			"CLIENT_NETWORK_SERVICE":   "secure-intranet-connectivity",
+			"CLIENT_LABELS":            "app=firewall",
 		},
 	))
 	g.Expect(vppagentFirewallNode.Name).To(Equal("vppagent-firewall-nse-1"))
@@ -173,9 +173,9 @@ func testVPN(t *testing.T, ptnum, nodesCount int, affinity map[string]int, verbo
 	logrus.Infof("Starting VPN Gateway NSE on node: %d", node)
 	vpnGatewayPodNode := k8s.CreatePod(pods.VPNGatewayNSEPod("vpn-gateway-nse-1", &nodes[node],
 		map[string]string{
-			"ENDPOINT_NETWORK_SERVICE":   "secure-intranet-connectivity",
-			"ENDPOINT_LABELS": "app=vpn-gateway",
-			"IP_ADDRESS":           addressPool,
+			"ENDPOINT_NETWORK_SERVICE": "secure-intranet-connectivity",
+			"ENDPOINT_LABELS":          "app=vpn-gateway",
+			"IP_ADDRESS":               addressPool,
 		},
 	))
 	g.Expect(vpnGatewayPodNode).ToNot(BeNil())

--- a/test/kubetest/utils.go
+++ b/test/kubetest/utils.go
@@ -324,22 +324,22 @@ func NoHealNSMgrPodConfig(k8s *K8s) []*pods.NSMgrPodConfig {
 func defaultICMPEnv(useIPv6 bool) map[string]string {
 	if !useIPv6 {
 		return map[string]string{
-			"ADVERTISE_NSE_NAME":   "icmp-responder",
-			"ADVERTISE_NSE_LABELS": "app=icmp",
+			"ENDPOINT_NETWORK_SERVICE":   "icmp-responder",
+			"ENDPOINT_LABELS": "app=icmp",
 			"IP_ADDRESS":           "172.16.1.0/24",
 		}
 	}
 	return map[string]string{
-		"ADVERTISE_NSE_NAME":   "icmp-responder",
-		"ADVERTISE_NSE_LABELS": "app=icmp",
+		"ENDPOINT_NETWORK_SERVICE":   "icmp-responder",
+		"ENDPOINT_LABELS": "app=icmp",
 		"IP_ADDRESS":           "100::/64",
 	}
 }
 
 func defaultNSCEnv() map[string]string {
 	return map[string]string{
-		"OUTGOING_NSC_LABELS": "app=icmp",
-		"OUTGOING_NSC_NAME":   "icmp-responder",
+		"CLIENT_LABELS": "app=icmp",
+		"CLIENT_NETWORK_SERVICE":   "icmp-responder",
 	}
 }
 

--- a/test/kubetest/utils.go
+++ b/test/kubetest/utils.go
@@ -324,22 +324,22 @@ func NoHealNSMgrPodConfig(k8s *K8s) []*pods.NSMgrPodConfig {
 func defaultICMPEnv(useIPv6 bool) map[string]string {
 	if !useIPv6 {
 		return map[string]string{
-			"ENDPOINT_NETWORK_SERVICE":   "icmp-responder",
-			"ENDPOINT_LABELS": "app=icmp",
-			"IP_ADDRESS":           "172.16.1.0/24",
+			"ENDPOINT_NETWORK_SERVICE": "icmp-responder",
+			"ENDPOINT_LABELS":          "app=icmp",
+			"IP_ADDRESS":               "172.16.1.0/24",
 		}
 	}
 	return map[string]string{
-		"ENDPOINT_NETWORK_SERVICE":   "icmp-responder",
-		"ENDPOINT_LABELS": "app=icmp",
-		"IP_ADDRESS":           "100::/64",
+		"ENDPOINT_NETWORK_SERVICE": "icmp-responder",
+		"ENDPOINT_LABELS":          "app=icmp",
+		"IP_ADDRESS":               "100::/64",
 	}
 }
 
 func defaultNSCEnv() map[string]string {
 	return map[string]string{
-		"CLIENT_LABELS": "app=icmp",
-		"CLIENT_NETWORK_SERVICE":   "icmp-responder",
+		"CLIENT_LABELS":          "app=icmp",
+		"CLIENT_NETWORK_SERVICE": "icmp-responder",
 	}
 }
 


### PR DESCRIPTION


## Description
spf13/viper is a better wayt o handle configuration from mixed sources - defaults, env, config files, config flags. MIgrate the default SDK configurator to it. Also, rename the en variables in accordance with #866.

## Motivation and Context
Use viper so we can enable configuration files and command line arguments later.

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [x] Covered by existing integration testing
- [ ] Added integration testing to cover
- [x] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
