### PR TITLE
Memif file socket descriptor is using on memif proxy closing

### DIFF
--- a/dataplane/pkg/memifproxy/memif_proxy.go
+++ b/dataplane/pkg/memifproxy/memif_proxy.go
@@ -1,6 +1,7 @@
 package memifproxy
 
 import (
+	"errors"
 	"github.com/sirupsen/logrus"
 	"net"
 	"sync"
@@ -8,76 +9,108 @@ import (
 )
 
 const (
-	bufferSize = 128
-	cmsgSize   = 24
-	network    = "unixpacket"
+	bufferSize     = 128
+	cmsgSize       = 24
+	defaultNetwork = "unixpacket"
 )
 
 type Proxy struct {
 	sourceSocket string
 	targetSocket string
+	network      string
 	stopCh       chan struct{}
+	errCh        chan error
+}
+
+type connectionResult struct {
+	err error
+	conn *net.UnixConn
 }
 
 func NewProxy(sourceSocket, targetSocket string) *Proxy {
+	return NewCustomProxy(sourceSocket, targetSocket, defaultNetwork)
+}
+
+func NewCustomProxy(sourceSocket, targetSocket, network string) *Proxy {
 	return &Proxy{
 		sourceSocket: sourceSocket,
 		targetSocket: targetSocket,
-	}
+		network:      network}
 }
 
 func (mp *Proxy) Start() error {
+	if (mp.stopCh != nil) {
+		return errors.New("Proxy already started")
+	}
+	mp.stopCh = make(chan struct{}, 1)
+	mp.errCh = make(chan error, 1)
 	logrus.Infof("Request proxy source: %s, target: %s", mp.sourceSocket, mp.targetSocket)
 
-	mp.stopCh = make(chan struct{})
-
-	logrus.Infof("Resolving source socket unix address: %v", mp.sourceSocket)
-	source, err := net.ResolveUnixAddr(network, mp.sourceSocket)
+	source, err := net.ResolveUnixAddr(mp.network, mp.sourceSocket)
 	if err != nil {
 		return err
 	}
+	logrus.Infof("Resolved source socket unix address: %v", mp.sourceSocket)
 
-	logrus.Infof("Resolving target socket unix address: %v", mp.targetSocket)
-	target, err := net.ResolveUnixAddr(network, mp.targetSocket)
+	target, err := net.ResolveUnixAddr(mp.network, mp.targetSocket)
 	if err != nil {
 		return err
 	}
+	logrus.Infof("Resolved target socket unix address: %v", mp.targetSocket)
 
-	go proxy(source, target, mp.stopCh)
+	go func() {
+		mp.errCh <- proxy(source, target, mp.network, mp.stopCh)
+	}();
 	return nil
 }
 
-func (mp *Proxy) Stop() {
+func (mp *Proxy) Stop() error {
 	close(mp.stopCh)
+	err := <-mp.errCh
+	close(mp.errCh)
+	mp.stopCh = nil
+	mp.errCh = nil
+	return err;
 }
 
-func proxy(source, target *net.UnixAddr, stopCh <-chan struct{}) {
+func proxy(source, target *net.UnixAddr, network string, stopCh <- chan struct{}) error {
 	logrus.Info("Listening source socket...")
 	sourceListener, err := net.ListenUnix(network, source)
 	if err != nil {
 		logrus.Error(err)
-		return
+		return err
 	}
-	logrus.Info("Accepting connections to source socket...")
-	sourceConn, err := sourceListener.AcceptUnix()
-	if err != nil {
-		logrus.Error(err)
-		return
-	}
-	logrus.Info("Connection from source socket successfully accepted")
+	defer sourceListener.Close()
+	sourceConn, err := acceptConnectionAsync(sourceListener, stopCh)
 
-	logrus.Info("Connecting to target socket...")
-	targetConn, err := net.DialUnix(network, nil, target)
 	if err != nil {
 		logrus.Error(err)
-		return
+		return err
 	}
-	logrus.Info("Successfully connected to target socket")
+
+	if sourceConn == nil {
+		return nil
+	}
+
+	defer sourceConn.Close()
+
+	targetConn, err := connectToTargetAsync(target, network, stopCh)
+
+	if err != nil {
+		logrus.Error(err)
+		return err
+	}
+
+	if targetConn == nil {
+		return nil
+	}
+
+	defer targetConn.Close()
 
 	sourceFd, closeSourceFd, err := getConnFd(sourceConn)
 	if err != nil {
 		logrus.Error(err)
-		return
+		return  err
 	}
 	defer closeSourceFd()
 	logrus.Infof("Source connection fd: %v", sourceFd)
@@ -85,7 +118,7 @@ func proxy(source, target *net.UnixAddr, stopCh <-chan struct{}) {
 	targetFd, closeTargetFd, err := getConnFd(targetConn)
 	if err != nil {
 		logrus.Error(err)
-		return
+		return err
 	}
 	defer closeTargetFd()
 	logrus.Infof("Target connection fd: %v", targetFd)
@@ -104,6 +137,52 @@ func proxy(source, target *net.UnixAddr, stopCh <-chan struct{}) {
 	}()
 
 	wg.Wait()
+	logrus.Info("Proxy has stopped")
+	return  nil
+}
+
+func connectToTargetAsync(target *net.UnixAddr, network string, stopCh <- chan struct{}) (*net.UnixConn, error) {
+	logrus.Info("Connecting to target socket...")
+	connResCh := make(chan connectionResult, 1)
+	go func() {
+		defer close(connResCh)
+		conn, err := net.DialUnix(network, nil, target)
+		connResCh <- connectionResult{
+			conn: conn,
+			err:  err}
+		logrus.Info("Connected to target socket")
+	}()
+	for {
+		select {
+		case conn := <-connResCh:
+			return conn.conn, conn.err
+		case <-stopCh:
+			logrus.Info("Connecting to target has stopped")
+			return nil, nil
+		}
+	}
+}
+
+func acceptConnectionAsync(listener *net.UnixListener, stopCh <- chan struct{}) (*net.UnixConn, error) {
+	logrus.Info("Accepting connections to source socket...")
+	connResCh := make(chan connectionResult, 1)
+	go func() {
+		defer close(connResCh)
+		conn, err := listener.AcceptUnix()
+		connResCh <- connectionResult{
+			conn: conn,
+			err:  err}
+		logrus.Info("Connection from source socket successfully accepted")
+	}()
+	for {
+		select {
+		case conn := <-connResCh:
+			return conn.conn, conn.err
+		case <-stopCh:
+			logrus.Info("Accept connection has stopped")
+			return nil, nil
+		}
+	}
 }
 
 func transfer(fromFd, toFd int, stopCh <-chan struct{}) {

--- a/dataplane/pkg/tests/memif_proxy_test.go
+++ b/dataplane/pkg/tests/memif_proxy_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 )
 
-func TestDataplaneCrossConnectBasic(t *testing.T) {
+func TestMemifProxy(t *testing.T) {
 	RegisterTestingT(t)
 	proxy := memifproxy.NewCustomProxy("source.sock", "target.sock", "unix")
 	for i := 0; i < 10; i++ {

--- a/dataplane/pkg/tests/memif_proxy_test.go
+++ b/dataplane/pkg/tests/memif_proxy_test.go
@@ -3,16 +3,52 @@ package tests
 import (
 	"github.com/networkservicemesh/networkservicemesh/dataplane/pkg/memifproxy"
 	. "github.com/onsi/gomega"
+	"net"
 	"testing"
+	"time"
 )
 
-func TestMemifProxy(t *testing.T) {
+func TestClosingOpeningMemifProxy(t *testing.T) {
 	RegisterTestingT(t)
 	proxy := memifproxy.NewCustomProxy("source.sock", "target.sock", "unix")
 	for i := 0; i < 10; i++ {
-		err := proxy.Start()
-		Expect(err).To(BeNil())
-		err = proxy.Stop();
-		Expect(err).To(BeNil())
+		startProxy(proxy)
+		stopProxy(proxy)
 	}
+}
+
+func TestTransferBetweenMemifProxies(t *testing.T) {
+	RegisterTestingT(t)
+	proxy1 := memifproxy.NewCustomProxy("source.sock", "target.sock", "unix")
+	proxy2 := memifproxy.NewCustomProxy("target.sock", "source.sock", "unix")
+	proxy1.Start()
+	proxy2.Start()
+	time.Sleep(time.Millisecond * 10)
+	connectAndSendMsg("source.sock")
+	connectAndSendMsg("target.sock")
+	time.Sleep(time.Millisecond * 10)
+	stopProxy(proxy1)
+	stopProxy(proxy2)
+
+}
+
+func connectAndSendMsg(sock string) {
+	addr, err := net.ResolveUnixAddr("unix", sock)
+	Expect(err).To(BeNil())
+	conn, err := net.DialUnix("unix", nil, addr)
+	defer conn.Close();
+	Expect(err).To(BeNil())
+	_, err = conn.Write([]byte("secret"))
+	Expect(err).To(BeNil())
+
+}
+
+func startProxy(proxy *memifproxy.Proxy) {
+	err := proxy.Start()
+	Expect(err).To(BeNil())
+}
+
+func stopProxy(proxy *memifproxy.Proxy) {
+	err := proxy.Stop()
+	Expect(err).To(BeNil())
 }

--- a/dataplane/pkg/tests/memif_proxy_test.go
+++ b/dataplane/pkg/tests/memif_proxy_test.go
@@ -1,0 +1,18 @@
+package tests
+
+import (
+	"github.com/networkservicemesh/networkservicemesh/dataplane/pkg/memifproxy"
+	. "github.com/onsi/gomega"
+	"testing"
+)
+
+func TestDataplaneCrossConnectBasic(t *testing.T) {
+	RegisterTestingT(t)
+	proxy := memifproxy.NewCustomProxy("source.sock", "target.sock", "unix")
+	for i := 0; i < 10; i++ {
+		err := proxy.Start()
+		Expect(err).To(BeNil())
+		err = proxy.Stop();
+		Expect(err).To(BeNil())
+	}
+}


### PR DESCRIPTION
Signed-off-by: denis-tingajkin <denis.tingajkin@xored.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
Fix for issue  https://github.com/networkservicemesh/networkservicemesh/issues/926

## Motivation and Context
This fix will close the memif_socket connection on getting stop request

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [ ] Covered by existing integration testing
- [x] Added unit testing to cover
- [x] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
