### PR TITLE
Cleanup workspace if exist content on workspace creation

### DIFF
--- a/controlplane/pkg/nsmd/nsmd.go
+++ b/controlplane/pkg/nsmd/nsmd.go
@@ -103,7 +103,7 @@ func RequestWorkspace(serviceRegistry serviceregistry.ServiceRegistry, id string
 func (nsm *nsmServer) RequestClientConnection(context context.Context, request *nsmdapi.ClientConnectionRequest) (*nsmdapi.ClientConnectionReply, error) {
 	logrus.Infof("Requested client connection to nsmd : %+v", request)
 
-	workspace, err := NewWorkSpace(nsm, request.Workspace)
+	workspace, err := NewWorkSpace(nsm, request.Workspace, false)
 	if err != nil {
 		logrus.Error(err)
 		return nil, err
@@ -187,7 +187,7 @@ func (nsm *nsmServer) restoreClients(registeredEndpoints *registry.NetworkServic
 			if len(client) == 0 {
 				continue
 			}
-			workspace, err := NewWorkSpace(nsm, client)
+			workspace, err := NewWorkSpace(nsm, client, true)
 			if err != nil {
 				logrus.Errorf("NSMServer: Failed to create workspace %s %v. Ignoring...", client, err)
 				continue

--- a/controlplane/pkg/nsmd/workspace.go
+++ b/controlplane/pkg/nsmd/workspace.go
@@ -65,6 +65,14 @@ func NewWorkSpace(nsm *nsmServer, name string) (*Workspace, error) {
 
 	defer w.cleanup() // Cleans up if and only iff we are not in state RUNNING
 	logrus.Infof("Creating new directory: %s", w.NsmDirectory())
+	if _, err := os.Stat(w.NsmDirectory()); err == nil {
+		logrus.Infof("Removing exist content: %s, error: %v", w.NsmDirectory(), err)
+		err := os.RemoveAll(w.NsmDirectory())
+		if err != nil {
+			logrus.Errorf("Can't delete folder: %s, error: %v", w.NsmDirectory(), err)
+			return nil, err
+		}
+	}
 	if err := os.MkdirAll(w.NsmDirectory(), folderMask); err != nil {
 		logrus.Errorf("can't create folder: %s, error: %v", w.NsmDirectory(), err)
 		return nil, err

--- a/controlplane/pkg/nsmd/workspace.go
+++ b/controlplane/pkg/nsmd/workspace.go
@@ -64,7 +64,7 @@ func NewWorkSpace(nsm *nsmServer, name string, restore bool) (*Workspace, error)
 	}
 	defer w.cleanup() // Cleans up if and only iff we are not in state RUNNING
 	if !restore {
-		if err := w.cleanContent(); err != nil {
+		if err := w.clearContents(); err != nil {
 			return nil, err
 		}
 	}
@@ -166,7 +166,7 @@ func (w *Workspace) Close() {
 func (w *Workspace) cleanup() {
 	if w.state != RUNNING {
 		if w.NsmDirectory() != "" {
-			w.cleanContent()
+			w.clearContents()
 		}
 		if w.grpcServer != nil {
 			// TODO switch to Graceful stop once we think through possible long running connections
@@ -178,7 +178,7 @@ func (w *Workspace) cleanup() {
 	}
 }
 
-func (w *Workspace) cleanContent() error {
+func (w *Workspace) clearContents() error {
 	if _, err := os.Stat(w.NsmDirectory()); err != nil {
 		if os.IsNotExist(err) {
 			return nil

--- a/controlplane/pkg/nsmd/workspace.go
+++ b/controlplane/pkg/nsmd/workspace.go
@@ -54,7 +54,7 @@ type Workspace struct {
 	localRegistry    *nseregistry.NSERegistry
 }
 
-func NewWorkSpace(nsm *nsmServer, name string) (*Workspace, error) {
+func NewWorkSpace(nsm *nsmServer, name string, restore bool) (*Workspace, error) {
 	logrus.Infof("Creating new workspace: %s", name)
 	w := &Workspace{
 		locationProvider: nsm.locationProvider,
@@ -62,17 +62,13 @@ func NewWorkSpace(nsm *nsmServer, name string) (*Workspace, error) {
 		state:            NEW,
 		localRegistry:    nsm.localRegistry,
 	}
-
 	defer w.cleanup() // Cleans up if and only iff we are not in state RUNNING
-	logrus.Infof("Creating new directory: %s", w.NsmDirectory())
-	if _, err := os.Stat(w.NsmDirectory()); err == nil {
-		logrus.Infof("Removing exist content: %s, error: %v", w.NsmDirectory(), err)
-		err := os.RemoveAll(w.NsmDirectory())
-		if err != nil {
-			logrus.Errorf("Can't delete folder: %s, error: %v", w.NsmDirectory(), err)
+	if !restore {
+		if err := w.cleanContent(); err != nil {
 			return nil, err
 		}
 	}
+	logrus.Infof("Creating new directory: %s", w.NsmDirectory())
 	if err := os.MkdirAll(w.NsmDirectory(), folderMask); err != nil {
 		logrus.Errorf("can't create folder: %s, error: %v", w.NsmDirectory(), err)
 		return nil, err
@@ -170,7 +166,7 @@ func (w *Workspace) Close() {
 func (w *Workspace) cleanup() {
 	if w.state != RUNNING {
 		if w.NsmDirectory() != "" {
-			os.RemoveAll(w.NsmDirectory())
+			w.cleanContent()
 		}
 		if w.grpcServer != nil {
 			// TODO switch to Graceful stop once we think through possible long running connections
@@ -180,4 +176,16 @@ func (w *Workspace) cleanup() {
 			w.listener.Close()
 		}
 	}
+}
+
+func (w *Workspace) cleanContent() error {
+	if _, err := os.Stat(w.NsmDirectory()); err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	logrus.Infof("Removing exist content im %s", w.NsmDirectory())
+	err := os.RemoveAll(w.NsmDirectory())
+	return err
 }

--- a/test/integration/nsmd_test_utils/test_utils.go
+++ b/test/integration/nsmd_test_utils/test_utils.go
@@ -168,7 +168,6 @@ func deployNSC(k8s *kube_testing.K8s, node *v1.Node, name, container string, tim
 	nsc := k8s.CreatePod(template)
 
 	Expect(nsc.Name).To(Equal(name))
-
 	k8s.WaitLogsContains(nsc, container, "nsm client: initialization is completed successfully", timeout)
 
 	logrus.Printf("NSC started done: %v", time.Since(startTime))


### PR DESCRIPTION
Signed-off-by: denis-tingajkin <denis.tingajkin@xored.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
This fix can solve problems when in new workspace exist outdated content from the previous session. A most potential problem that if in workspace exist .sock files than it's can throw error 'address already in use'

## Motivation and Context


## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [X] Covered by existing integration testing
- [ ] Added integration testing to cover
- [X] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
