### PR TITLE
Limit dependencies download attempts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ jobs:
       - run:
           name: golint
           command: |
-            go get golang.org/x/lint/golint@v0.0.0-20190227174305-8f45f776aaf1
+            go get golang.org/x/lint/golint
             golint ./...
       - run: make vet check
       - run: go install k8s.io/code-generator/cmd/deepcopy-gen

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,8 +18,7 @@ jobs:
       - run:
           name: Download Go Dependencies
           command: |
-            attempt=1
-            until go mod download || (( $attempt >= 10 )); do attempt=$(( $attempt + 1 )); echo "Trying again, attempt $attempt"; done
+            ./scripts/go-mod-download.sh
       - run: "! go fmt ./... 2>&1 | read"
       - run:
           name: golint

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -144,7 +144,7 @@ jobs:
             # export CONTAINER_FORCE_PULL="true"
             ./scripts/prepare-circle-integration-tests.sh
             mkdir -p ~/junit/
-            go mod download
+            ./scripts/go-mod-download.sh
           no_output_timeout: 40m
       - run:
           name: Running integration tests - <<parameters.test_tags>>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,11 @@ jobs:
             ./.circleci/install-shellcheck.sh
       - run: yamllint -c .yamllint.yml $(git ls-files '*.yaml' '*.yml')
       - run: go version
-      - run: until go mod download;do echo "Trying again";done
+      - run:
+          name: Download Go Dependencies
+          command: |
+            attempt=1
+            until go mod download || (( $attempt >= 10 )); do attempt=$(( $attempt + 1 )); echo "Trying again, attempt $attempt"; done
       - run: "! go fmt ./... 2>&1 | read"
       - run:
           name: golint

--- a/.dockerignore
+++ b/.dockerignore
@@ -15,3 +15,4 @@
 !sdk
 !utils
 !vendor
+!scripts/go-mod-download.sh

--- a/build/Dockerfile.nsmd-k8s
+++ b/build/Dockerfile.nsmd-k8s
@@ -5,8 +5,9 @@ ENV GO111MODULE=on
 
 RUN mkdir /root/networkservicemesh
 ADD ["go.mod","/root/networkservicemesh"]
+ADD ["./scripts/go-mod-download.sh","/root/networkservicemesh"]
 WORKDIR /root/networkservicemesh/
-RUN ./scripts/go-mod-download.sh
+RUN ./go-mod-download.sh
 
 ADD [".","/root/networkservicemesh"]
 RUN CGO_ENABLED=0 GOOS=linux go build -ldflags '-extldflags "-static"' -o /go/bin/nsmd-k8s ./k8s/cmd/nsmd-k8s/main.go

--- a/build/Dockerfile.nsmd-k8s
+++ b/build/Dockerfile.nsmd-k8s
@@ -6,7 +6,7 @@ ENV GO111MODULE=on
 RUN mkdir /root/networkservicemesh
 ADD ["go.mod","/root/networkservicemesh"]
 WORKDIR /root/networkservicemesh/
-RUN attempt=1; until go mod download || (( $attempt >= 10 )); do attempt=$(( $attempt + 1 )); echo "Trying again, attempt $attempt"; done
+RUN ./scripts/go-mod-download.sh
 
 ADD [".","/root/networkservicemesh"]
 RUN CGO_ENABLED=0 GOOS=linux go build -ldflags '-extldflags "-static"' -o /go/bin/nsmd-k8s ./k8s/cmd/nsmd-k8s/main.go

--- a/build/Dockerfile.nsmd-k8s
+++ b/build/Dockerfile.nsmd-k8s
@@ -6,7 +6,7 @@ ENV GO111MODULE=on
 RUN mkdir /root/networkservicemesh
 ADD ["go.mod","/root/networkservicemesh"]
 WORKDIR /root/networkservicemesh/
-RUN until go mod download;do echo "Trying again";done
+RUN attempt=1; until go mod download || (( $attempt >= 10 )); do attempt=$(( $attempt + 1 )); echo "Trying again, attempt $attempt"; done
 
 ADD [".","/root/networkservicemesh"]
 RUN CGO_ENABLED=0 GOOS=linux go build -ldflags '-extldflags "-static"' -o /go/bin/nsmd-k8s ./k8s/cmd/nsmd-k8s/main.go

--- a/controlplane/build/Dockerfile.nsmd
+++ b/controlplane/build/Dockerfile.nsmd
@@ -6,7 +6,7 @@ ENV GO111MODULE=on
 RUN mkdir /root/networkservicemesh
 ADD ["go.mod","/root/networkservicemesh"]
 WORKDIR /root/networkservicemesh/
-RUN attempt=1; until go mod download || (( $attempt >= 10 )); do attempt=$(( $attempt + 1 )); echo "Trying again, attempt $attempt"; done
+RUN ./scripts/go-mod-download.sh
 
 ADD [".","/root/networkservicemesh"]
 RUN CGO_ENABLED=0 GOOS=linux go build -ldflags '-extldflags "-static"' -o /go/bin/nsmd ./controlplane/cmd/nsmd/nsmd.go

--- a/controlplane/build/Dockerfile.nsmd
+++ b/controlplane/build/Dockerfile.nsmd
@@ -5,8 +5,9 @@ ENV GO111MODULE=on
 
 RUN mkdir /root/networkservicemesh
 ADD ["go.mod","/root/networkservicemesh"]
+ADD ["./scripts/go-mod-download.sh","/root/networkservicemesh"]
 WORKDIR /root/networkservicemesh/
-RUN ./scripts/go-mod-download.sh
+RUN ./go-mod-download.sh
 
 ADD [".","/root/networkservicemesh"]
 RUN CGO_ENABLED=0 GOOS=linux go build -ldflags '-extldflags "-static"' -o /go/bin/nsmd ./controlplane/cmd/nsmd/nsmd.go

--- a/controlplane/build/Dockerfile.nsmd
+++ b/controlplane/build/Dockerfile.nsmd
@@ -6,7 +6,7 @@ ENV GO111MODULE=on
 RUN mkdir /root/networkservicemesh
 ADD ["go.mod","/root/networkservicemesh"]
 WORKDIR /root/networkservicemesh/
-RUN until go mod download;do echo "Trying again";done
+RUN attempt=1; until go mod download || (( $attempt >= 10 )); do attempt=$(( $attempt + 1 )); echo "Trying again, attempt $attempt"; done
 
 ADD [".","/root/networkservicemesh"]
 RUN CGO_ENABLED=0 GOOS=linux go build -ldflags '-extldflags "-static"' -o /go/bin/nsmd ./controlplane/cmd/nsmd/nsmd.go

--- a/dataplane/vppagent/build/Dockerfile.vppagent-dataplane
+++ b/dataplane/vppagent/build/Dockerfile.vppagent-dataplane
@@ -8,7 +8,7 @@ ENV GO111MODULE=on
 RUN mkdir /root/networkservicemesh
 ADD ["go.mod","/root/networkservicemesh"]
 WORKDIR /root/networkservicemesh/
-RUN until go mod download;do echo "Trying again";done
+RUN attempt=1; until go mod download || (( $attempt >= 10 )); do attempt=$(( $attempt + 1 )); echo "Trying again, attempt $attempt"; done
 
 ADD [".","/root/networkservicemesh"]
 RUN CGO_ENABLED=0 GOOS=linux go build -ldflags '-extldflags "-static"' -o /go/bin/vppagent-dataplane ./dataplane/vppagent/cmd/vppagent-dataplane.go

--- a/dataplane/vppagent/build/Dockerfile.vppagent-dataplane
+++ b/dataplane/vppagent/build/Dockerfile.vppagent-dataplane
@@ -8,7 +8,7 @@ ENV GO111MODULE=on
 RUN mkdir /root/networkservicemesh
 ADD ["go.mod","/root/networkservicemesh"]
 WORKDIR /root/networkservicemesh/
-RUN attempt=1; until go mod download || (( $attempt >= 10 )); do attempt=$(( $attempt + 1 )); echo "Trying again, attempt $attempt"; done
+RUN ./scripts/go-mod-download.sh
 
 ADD [".","/root/networkservicemesh"]
 RUN CGO_ENABLED=0 GOOS=linux go build -ldflags '-extldflags "-static"' -o /go/bin/vppagent-dataplane ./dataplane/vppagent/cmd/vppagent-dataplane.go

--- a/dataplane/vppagent/build/Dockerfile.vppagent-dataplane
+++ b/dataplane/vppagent/build/Dockerfile.vppagent-dataplane
@@ -7,8 +7,9 @@ ENV GO111MODULE=on
 
 RUN mkdir /root/networkservicemesh
 ADD ["go.mod","/root/networkservicemesh"]
+ADD ["./scripts/go-mod-download.sh","/root/networkservicemesh"]
 WORKDIR /root/networkservicemesh/
-RUN ./scripts/go-mod-download.sh
+RUN ./go-mod-download.sh
 
 ADD [".","/root/networkservicemesh"]
 RUN CGO_ENABLED=0 GOOS=linux go build -ldflags '-extldflags "-static"' -o /go/bin/vppagent-dataplane ./dataplane/vppagent/cmd/vppagent-dataplane.go

--- a/dataplane/vppagent/build/Dockerfile.vppagent-dataplane-dev
+++ b/dataplane/vppagent/build/Dockerfile.vppagent-dataplane-dev
@@ -35,7 +35,7 @@ ENV GO111MODULE=on
 RUN mkdir /root/networkservicemesh
 ADD ["go.mod","/root/networkservicemesh"]
 WORKDIR /root/networkservicemesh/
-RUN until go mod download;do echo "Trying again";done
+RUN attempt=1; until go mod download || (( $attempt >= 10 )); do attempt=$(( $attempt + 1 )); echo "Trying again, attempt $attempt"; done
 
 ADD [".","/root/networkservicemesh"]
 RUN CGO_ENABLED=0 GOOS=linux go build -ldflags '-extldflags "-static"' -o /go/bin/vppagent-dataplane ./dataplane/vppagent/cmd/vppagent-dataplane.go

--- a/dataplane/vppagent/build/Dockerfile.vppagent-dataplane-dev
+++ b/dataplane/vppagent/build/Dockerfile.vppagent-dataplane-dev
@@ -35,7 +35,7 @@ ENV GO111MODULE=on
 RUN mkdir /root/networkservicemesh
 ADD ["go.mod","/root/networkservicemesh"]
 WORKDIR /root/networkservicemesh/
-RUN attempt=1; until go mod download || (( $attempt >= 10 )); do attempt=$(( $attempt + 1 )); echo "Trying again, attempt $attempt"; done
+RUN ./scripts/go-mod-download.sh
 
 ADD [".","/root/networkservicemesh"]
 RUN CGO_ENABLED=0 GOOS=linux go build -ldflags '-extldflags "-static"' -o /go/bin/vppagent-dataplane ./dataplane/vppagent/cmd/vppagent-dataplane.go

--- a/dataplane/vppagent/build/Dockerfile.vppagent-dataplane-dev
+++ b/dataplane/vppagent/build/Dockerfile.vppagent-dataplane-dev
@@ -34,8 +34,9 @@ ENV GO111MODULE=on
 
 RUN mkdir /root/networkservicemesh
 ADD ["go.mod","/root/networkservicemesh"]
+ADD ["./scripts/go-mod-download.sh","/root/networkservicemesh"]
 WORKDIR /root/networkservicemesh/
-RUN ./scripts/go-mod-download.sh
+RUN ./go-mod-download.sh
 
 ADD [".","/root/networkservicemesh"]
 RUN CGO_ENABLED=0 GOOS=linux go build -ldflags '-extldflags "-static"' -o /go/bin/vppagent-dataplane ./dataplane/vppagent/cmd/vppagent-dataplane.go

--- a/docker/Dockerfile.admission-webhook
+++ b/docker/Dockerfile.admission-webhook
@@ -6,7 +6,7 @@ ENV GO111MODULE=on
 RUN mkdir /root/networkservicemesh
 ADD ["go.mod","/root/networkservicemesh"]
 WORKDIR /root/networkservicemesh/
-RUN until go mod download;do echo "Trying again";done
+RUN attempt=1; until go mod download || (( $attempt >= 10 )); do attempt=$(( $attempt + 1 )); echo "Trying again, attempt $attempt"; done
 
 ADD [".","/root/networkservicemesh"]
 RUN CGO_ENABLED=0 GOOS=linux go build -ldflags '-extldflags "-static"' -o /go/bin/admission-webhook ./k8s/cmd/admission-webhook/main.go

--- a/docker/Dockerfile.admission-webhook
+++ b/docker/Dockerfile.admission-webhook
@@ -5,8 +5,9 @@ ENV GO111MODULE=on
 
 RUN mkdir /root/networkservicemesh
 ADD ["go.mod","/root/networkservicemesh"]
+ADD ["./scripts/go-mod-download.sh","/root/networkservicemesh"]
 WORKDIR /root/networkservicemesh/
-RUN ./scripts/go-mod-download.sh
+RUN ./go-mod-download.sh
 
 ADD [".","/root/networkservicemesh"]
 RUN CGO_ENABLED=0 GOOS=linux go build -ldflags '-extldflags "-static"' -o /go/bin/admission-webhook ./k8s/cmd/admission-webhook/main.go

--- a/docker/Dockerfile.admission-webhook
+++ b/docker/Dockerfile.admission-webhook
@@ -6,7 +6,7 @@ ENV GO111MODULE=on
 RUN mkdir /root/networkservicemesh
 ADD ["go.mod","/root/networkservicemesh"]
 WORKDIR /root/networkservicemesh/
-RUN attempt=1; until go mod download || (( $attempt >= 10 )); do attempt=$(( $attempt + 1 )); echo "Trying again, attempt $attempt"; done
+RUN ./scripts/go-mod-download.sh
 
 ADD [".","/root/networkservicemesh"]
 RUN CGO_ENABLED=0 GOOS=linux go build -ldflags '-extldflags "-static"' -o /go/bin/admission-webhook ./k8s/cmd/admission-webhook/main.go

--- a/docker/Dockerfile.crossconnect-monitor
+++ b/docker/Dockerfile.crossconnect-monitor
@@ -5,8 +5,9 @@ ENV GO111MODULE=on
 
 RUN mkdir /root/networkservicemesh
 ADD ["go.mod","/root/networkservicemesh"]
+ADD ["./scripts/go-mod-download.sh","/root/networkservicemesh"]
 WORKDIR /root/networkservicemesh/
-RUN ./scripts/go-mod-download.sh
+RUN ./go-mod-download.sh
 
 ADD [".","/root/networkservicemesh"]
 RUN CGO_ENABLED=0 GOOS=linux go build -ldflags '-extldflags "-static"' -o /go/bin/crossconnect-monitor ./k8s/cmd/crossconnect-monitor

--- a/docker/Dockerfile.crossconnect-monitor
+++ b/docker/Dockerfile.crossconnect-monitor
@@ -6,7 +6,7 @@ ENV GO111MODULE=on
 RUN mkdir /root/networkservicemesh
 ADD ["go.mod","/root/networkservicemesh"]
 WORKDIR /root/networkservicemesh/
-RUN until go mod download;do echo "Trying again";done
+RUN attempt=1; until go mod download || (( $attempt >= 10 )); do attempt=$(( $attempt + 1 )); echo "Trying again, attempt $attempt"; done
 
 ADD [".","/root/networkservicemesh"]
 RUN CGO_ENABLED=0 GOOS=linux go build -ldflags '-extldflags "-static"' -o /go/bin/crossconnect-monitor ./k8s/cmd/crossconnect-monitor

--- a/docker/Dockerfile.crossconnect-monitor
+++ b/docker/Dockerfile.crossconnect-monitor
@@ -6,7 +6,7 @@ ENV GO111MODULE=on
 RUN mkdir /root/networkservicemesh
 ADD ["go.mod","/root/networkservicemesh"]
 WORKDIR /root/networkservicemesh/
-RUN attempt=1; until go mod download || (( $attempt >= 10 )); do attempt=$(( $attempt + 1 )); echo "Trying again, attempt $attempt"; done
+RUN ./scripts/go-mod-download.sh
 
 ADD [".","/root/networkservicemesh"]
 RUN CGO_ENABLED=0 GOOS=linux go build -ldflags '-extldflags "-static"' -o /go/bin/crossconnect-monitor ./k8s/cmd/crossconnect-monitor

--- a/docker/Dockerfile.vppagent-firewall-nse
+++ b/docker/Dockerfile.vppagent-firewall-nse
@@ -7,8 +7,9 @@ ENV GO111MODULE=on
 
 RUN mkdir /root/networkservicemesh
 ADD ["go.mod","/root/networkservicemesh"]
+ADD ["./scripts/go-mod-download.sh","/root/networkservicemesh"]
 WORKDIR /root/networkservicemesh/
-RUN ./scripts/go-mod-download.sh
+RUN ./go-mod-download.sh
 
 ADD [".","/root/networkservicemesh"]
 RUN CGO_ENABLED=0 GOOS=linux go build -ldflags '-extldflags "-static"' -o /go/bin/vppagent-firewall-nse ./examples/cmd/vppagent-firewall-nse

--- a/docker/Dockerfile.vppagent-firewall-nse
+++ b/docker/Dockerfile.vppagent-firewall-nse
@@ -8,7 +8,7 @@ ENV GO111MODULE=on
 RUN mkdir /root/networkservicemesh
 ADD ["go.mod","/root/networkservicemesh"]
 WORKDIR /root/networkservicemesh/
-RUN attempt=1; until go mod download || (( $attempt >= 10 )); do attempt=$(( $attempt + 1 )); echo "Trying again, attempt $attempt"; done
+RUN ./scripts/go-mod-download.sh
 
 ADD [".","/root/networkservicemesh"]
 RUN CGO_ENABLED=0 GOOS=linux go build -ldflags '-extldflags "-static"' -o /go/bin/vppagent-firewall-nse ./examples/cmd/vppagent-firewall-nse

--- a/docker/Dockerfile.vppagent-firewall-nse
+++ b/docker/Dockerfile.vppagent-firewall-nse
@@ -8,7 +8,7 @@ ENV GO111MODULE=on
 RUN mkdir /root/networkservicemesh
 ADD ["go.mod","/root/networkservicemesh"]
 WORKDIR /root/networkservicemesh/
-RUN until go mod download;do echo "Trying again";done
+RUN attempt=1; until go mod download || (( $attempt >= 10 )); do attempt=$(( $attempt + 1 )); echo "Trying again, attempt $attempt"; done
 
 ADD [".","/root/networkservicemesh"]
 RUN CGO_ENABLED=0 GOOS=linux go build -ldflags '-extldflags "-static"' -o /go/bin/vppagent-firewall-nse ./examples/cmd/vppagent-firewall-nse

--- a/docker/Dockerfile.vppagent-icmp-responder-nse
+++ b/docker/Dockerfile.vppagent-icmp-responder-nse
@@ -8,7 +8,7 @@ ENV GO111MODULE=on
 RUN mkdir /root/networkservicemesh
 ADD ["go.mod","/root/networkservicemesh"]
 WORKDIR /root/networkservicemesh/
-RUN until go mod download;do echo "Trying again";done
+RUN attempt=1; until go mod download || (( $attempt >= 10 )); do attempt=$(( $attempt + 1 )); echo "Trying again, attempt $attempt"; done
 
 ADD [".","/root/networkservicemesh"]
 RUN CGO_ENABLED=0 GOOS=linux go build -ldflags '-extldflags "-static"' -o /go/bin/vppagent-icmp-responder-nse ./examples/cmd/vppagent-icmp-responder-nse

--- a/docker/Dockerfile.vppagent-icmp-responder-nse
+++ b/docker/Dockerfile.vppagent-icmp-responder-nse
@@ -8,7 +8,7 @@ ENV GO111MODULE=on
 RUN mkdir /root/networkservicemesh
 ADD ["go.mod","/root/networkservicemesh"]
 WORKDIR /root/networkservicemesh/
-RUN attempt=1; until go mod download || (( $attempt >= 10 )); do attempt=$(( $attempt + 1 )); echo "Trying again, attempt $attempt"; done
+RUN ./scripts/go-mod-download.sh
 
 ADD [".","/root/networkservicemesh"]
 RUN CGO_ENABLED=0 GOOS=linux go build -ldflags '-extldflags "-static"' -o /go/bin/vppagent-icmp-responder-nse ./examples/cmd/vppagent-icmp-responder-nse

--- a/docker/Dockerfile.vppagent-icmp-responder-nse
+++ b/docker/Dockerfile.vppagent-icmp-responder-nse
@@ -7,8 +7,9 @@ ENV GO111MODULE=on
 
 RUN mkdir /root/networkservicemesh
 ADD ["go.mod","/root/networkservicemesh"]
+ADD ["./scripts/go-mod-download.sh","/root/networkservicemesh"]
 WORKDIR /root/networkservicemesh/
-RUN ./scripts/go-mod-download.sh
+RUN ./go-mod-download.sh
 
 ADD [".","/root/networkservicemesh"]
 RUN CGO_ENABLED=0 GOOS=linux go build -ldflags '-extldflags "-static"' -o /go/bin/vppagent-icmp-responder-nse ./examples/cmd/vppagent-icmp-responder-nse

--- a/docker/Dockerfile.vppagent-nsc
+++ b/docker/Dockerfile.vppagent-nsc
@@ -8,7 +8,7 @@ ENV GO111MODULE=on
 RUN mkdir /root/networkservicemesh
 ADD ["go.mod","/root/networkservicemesh"]
 WORKDIR /root/networkservicemesh/
-RUN attempt=1; until go mod download || (( $attempt >= 10 )); do attempt=$(( $attempt + 1 )); echo "Trying again, attempt $attempt"; done
+RUN ./scripts/go-mod-download.sh
 
 ADD [".","/root/networkservicemesh"]
 RUN CGO_ENABLED=0 GOOS=linux go build -ldflags '-extldflags "-static"' -o /go/bin/vppagent-nsc ./examples/cmd/vppagent-nsc

--- a/docker/Dockerfile.vppagent-nsc
+++ b/docker/Dockerfile.vppagent-nsc
@@ -8,7 +8,7 @@ ENV GO111MODULE=on
 RUN mkdir /root/networkservicemesh
 ADD ["go.mod","/root/networkservicemesh"]
 WORKDIR /root/networkservicemesh/
-RUN until go mod download;do echo "Trying again";done
+RUN attempt=1; until go mod download || (( $attempt >= 10 )); do attempt=$(( $attempt + 1 )); echo "Trying again, attempt $attempt"; done
 
 ADD [".","/root/networkservicemesh"]
 RUN CGO_ENABLED=0 GOOS=linux go build -ldflags '-extldflags "-static"' -o /go/bin/vppagent-nsc ./examples/cmd/vppagent-nsc

--- a/docker/Dockerfile.vppagent-nsc
+++ b/docker/Dockerfile.vppagent-nsc
@@ -7,8 +7,9 @@ ENV GO111MODULE=on
 
 RUN mkdir /root/networkservicemesh
 ADD ["go.mod","/root/networkservicemesh"]
+ADD ["./scripts/go-mod-download.sh","/root/networkservicemesh"]
 WORKDIR /root/networkservicemesh/
-RUN ./scripts/go-mod-download.sh
+RUN ./go-mod-download.sh
 
 ADD [".","/root/networkservicemesh"]
 RUN CGO_ENABLED=0 GOOS=linux go build -ldflags '-extldflags "-static"' -o /go/bin/vppagent-nsc ./examples/cmd/vppagent-nsc

--- a/examples/build/Dockerfile.icmp-responder-nse
+++ b/examples/build/Dockerfile.icmp-responder-nse
@@ -6,7 +6,7 @@ ENV GO111MODULE=on
 RUN mkdir /root/networkservicemesh
 ADD ["go.mod","/root/networkservicemesh"]
 WORKDIR /root/networkservicemesh/
-RUN attempt=1; until go mod download || (( $attempt >= 10 )); do attempt=$(( $attempt + 1 )); echo "Trying again, attempt $attempt"; done
+RUN ./scripts/go-mod-download.sh
 
 ADD [".","/root/networkservicemesh"]
 RUN CGO_ENABLED=0 GOOS=linux go build -ldflags '-extldflags "-static"' -o /go/bin/icmp-responder-nse ./examples/cmd/icmp-responder-nse

--- a/examples/build/Dockerfile.icmp-responder-nse
+++ b/examples/build/Dockerfile.icmp-responder-nse
@@ -6,7 +6,7 @@ ENV GO111MODULE=on
 RUN mkdir /root/networkservicemesh
 ADD ["go.mod","/root/networkservicemesh"]
 WORKDIR /root/networkservicemesh/
-RUN until go mod download;do echo "Trying again";done
+RUN attempt=1; until go mod download || (( $attempt >= 10 )); do attempt=$(( $attempt + 1 )); echo "Trying again, attempt $attempt"; done
 
 ADD [".","/root/networkservicemesh"]
 RUN CGO_ENABLED=0 GOOS=linux go build -ldflags '-extldflags "-static"' -o /go/bin/icmp-responder-nse ./examples/cmd/icmp-responder-nse

--- a/examples/build/Dockerfile.icmp-responder-nse
+++ b/examples/build/Dockerfile.icmp-responder-nse
@@ -5,8 +5,9 @@ ENV GO111MODULE=on
 
 RUN mkdir /root/networkservicemesh
 ADD ["go.mod","/root/networkservicemesh"]
+ADD ["./scripts/go-mod-download.sh","/root/networkservicemesh"]
 WORKDIR /root/networkservicemesh/
-RUN ./scripts/go-mod-download.sh
+RUN ./go-mod-download.sh
 
 ADD [".","/root/networkservicemesh"]
 RUN CGO_ENABLED=0 GOOS=linux go build -ldflags '-extldflags "-static"' -o /go/bin/icmp-responder-nse ./examples/cmd/icmp-responder-nse

--- a/examples/build/Dockerfile.nsc
+++ b/examples/build/Dockerfile.nsc
@@ -6,7 +6,7 @@ ENV GO111MODULE=on
 RUN mkdir /root/networkservicemesh
 ADD ["go.mod","/root/networkservicemesh"]
 WORKDIR /root/networkservicemesh/
-RUN attempt=1; until go mod download || (( $attempt >= 10 )); do attempt=$(( $attempt + 1 )); echo "Trying again, attempt $attempt"; done
+RUN ./scripts/go-mod-download.sh
 
 ADD [".","/root/networkservicemesh"]
 RUN CGO_ENABLED=0 GOOS=linux go build -ldflags '-extldflags "-static"' -o /go/bin/nsc ./examples/cmd/nsc/nsc.go

--- a/examples/build/Dockerfile.nsc
+++ b/examples/build/Dockerfile.nsc
@@ -5,8 +5,9 @@ ENV GO111MODULE=on
 
 RUN mkdir /root/networkservicemesh
 ADD ["go.mod","/root/networkservicemesh"]
+ADD ["./scripts/go-mod-download.sh","/root/networkservicemesh"]
 WORKDIR /root/networkservicemesh/
-RUN ./scripts/go-mod-download.sh
+RUN ./go-mod-download.sh
 
 ADD [".","/root/networkservicemesh"]
 RUN CGO_ENABLED=0 GOOS=linux go build -ldflags '-extldflags "-static"' -o /go/bin/nsc ./examples/cmd/nsc/nsc.go

--- a/examples/build/Dockerfile.nsc
+++ b/examples/build/Dockerfile.nsc
@@ -6,7 +6,7 @@ ENV GO111MODULE=on
 RUN mkdir /root/networkservicemesh
 ADD ["go.mod","/root/networkservicemesh"]
 WORKDIR /root/networkservicemesh/
-RUN until go mod download;do echo "Trying again";done
+RUN attempt=1; until go mod download || (( $attempt >= 10 )); do attempt=$(( $attempt + 1 )); echo "Trying again, attempt $attempt"; done
 
 ADD [".","/root/networkservicemesh"]
 RUN CGO_ENABLED=0 GOOS=linux go build -ldflags '-extldflags "-static"' -o /go/bin/nsc ./examples/cmd/nsc/nsc.go

--- a/k8s/build/Dockerfile.nsmdp
+++ b/k8s/build/Dockerfile.nsmdp
@@ -5,8 +5,9 @@ ENV GO111MODULE=on
 
 RUN mkdir /root/networkservicemesh
 ADD ["go.mod","/root/networkservicemesh"]
+ADD ["./scripts/go-mod-download.sh","/root/networkservicemesh"]
 WORKDIR /root/networkservicemesh/
-RUN ./scripts/go-mod-download.sh
+RUN ./go-mod-download.sh
 
 ADD [".","/root/networkservicemesh"]
 RUN CGO_ENABLED=0 GOOS=linux go build -ldflags '-extldflags "-static"' -o /go/bin/nsmdp ./k8s/cmd/nsmdp/nsmdp.go

--- a/k8s/build/Dockerfile.nsmdp
+++ b/k8s/build/Dockerfile.nsmdp
@@ -6,7 +6,7 @@ ENV GO111MODULE=on
 RUN mkdir /root/networkservicemesh
 ADD ["go.mod","/root/networkservicemesh"]
 WORKDIR /root/networkservicemesh/
-RUN until go mod download;do echo "Trying again";done
+RUN attempt=1; until go mod download || (( $attempt >= 10 )); do attempt=$(( $attempt + 1 )); echo "Trying again, attempt $attempt"; done
 
 ADD [".","/root/networkservicemesh"]
 RUN CGO_ENABLED=0 GOOS=linux go build -ldflags '-extldflags "-static"' -o /go/bin/nsmdp ./k8s/cmd/nsmdp/nsmdp.go

--- a/k8s/build/Dockerfile.nsmdp
+++ b/k8s/build/Dockerfile.nsmdp
@@ -6,7 +6,7 @@ ENV GO111MODULE=on
 RUN mkdir /root/networkservicemesh
 ADD ["go.mod","/root/networkservicemesh"]
 WORKDIR /root/networkservicemesh/
-RUN attempt=1; until go mod download || (( $attempt >= 10 )); do attempt=$(( $attempt + 1 )); echo "Trying again, attempt $attempt"; done
+RUN ./scripts/go-mod-download.sh
 
 ADD [".","/root/networkservicemesh"]
 RUN CGO_ENABLED=0 GOOS=linux go build -ldflags '-extldflags "-static"' -o /go/bin/nsmdp ./k8s/cmd/nsmdp/nsmdp.go

--- a/scripts/go-mod-download.sh
+++ b/scripts/go-mod-download.sh
@@ -5,6 +5,7 @@ attempt=1;
 
 until (( attempt > limit )) || go mod download; do
     attempt=$(( attempt + 1 ));
+    rm -rf "$GOPATH"/pkg/mod/cache/vcs/* # wipe out the vcs cache to overwrite corrupted repos
     (( attempt <= limit )) && echo "Trying again, attempt $attempt";
 done
 

--- a/scripts/go-mod-download.sh
+++ b/scripts/go-mod-download.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+limit=10;
+attempt=1;
+
+until (( $attempt > $limit )) || go mod download; do
+    attempt=$(( $attempt + 1 ));
+    (( $attempt <= $limit )) && echo "Trying again, attempt $attempt";
+done
+
+(( $attempt <= $limit )) # ensure correct exit code

--- a/scripts/go-mod-download.sh
+++ b/scripts/go-mod-download.sh
@@ -3,9 +3,9 @@
 limit=10;
 attempt=1;
 
-until (( $attempt > $limit )) || go mod download; do
-    attempt=$(( $attempt + 1 ));
-    (( $attempt <= $limit )) && echo "Trying again, attempt $attempt";
+until (( attempt > limit )) || go mod download; do
+    attempt=$(( attempt + 1 ));
+    (( attempt <= limit )) && echo "Trying again, attempt $attempt";
 done
 
-(( $attempt <= $limit )) # ensure correct exit code
+(( attempt <= limit )) # ensure correct exit code

--- a/scripts/go-mod-download.sh
+++ b/scripts/go-mod-download.sh
@@ -1,12 +1,12 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 
 limit=10;
 attempt=1;
 
-until (( attempt > limit )) || go mod download; do
+until test "$attempt" -gt "$limit"  || go mod download; do
     attempt=$(( attempt + 1 ));
     rm -rf "$GOPATH"/pkg/mod/cache/vcs/* # wipe out the vcs cache to overwrite corrupted repos
-    (( attempt <= limit )) && echo "Trying again, attempt $attempt";
+    test "$attempt" -le "$limit" && echo "Trying again, attempt $attempt";
 done
 
-(( attempt <= limit )) # ensure correct exit code
+test "$attempt" -le "$limit" # ensure correct exit code


### PR DESCRIPTION
Signed-off-by: Stepan Anokhin <stepan.anokhin@gmail.com>

Prevent infinite loop of `go mod download` attempts

## Description
In case of invalid/inaccessible go dependencies sanity-check will lust forever.  This PR limits a number of attempts. 

## Motivation and Context
Prevent infinite loop of `go mod download` attempts

## How Has This Been Tested?
- [x] Covered by existing integration testing
- [ ] Added integration testing to cover
- [x] Tested locally
- [ ] Have not tested

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
