### PR TITLE
circleci: increase resource_class for license-scan

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -292,6 +292,7 @@ jobs:
               docker push ${REPO}/${c}:${TAG}
             done
   license-scan:
+    resource_class: medium+
     working_directory: /go/src/github.com/networkservicemesh/networkservicemesh/
     docker:
       - image: circleci/golang

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -315,7 +315,7 @@ jobs:
           command: |
             fossa init
             fossa
-            fossa test
+            fossa test --timeout 1800
     environment:
       GO111MODULE: "on"
 


### PR DESCRIPTION
Signed-off-by: Nikolay Nikolaev <nnikolay@vmware.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
Increase the resource class to allow license-scan to pass.

## Motivation and Context
FOSSA license scan fails recently. It is very likely that it needs more resources as it scans through a lot of dependcies.

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [ ] Covered by existing integration testing
- [ ] Added integration testing to cover
- [ ] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
