### PR TITLE
Add separate make targets for the integration test groups

### DIFF
--- a/.mk/integration.mk
+++ b/.mk/integration.mk
@@ -21,6 +21,18 @@ k8s-integration-config:
 k8s-integration-tests: k8s-integration-config
 	@GO111MODULE=on go test -v ./test/... -failfast -timeout 30m -tags="basic recover usecase"
 
+.PHONY: k8s-integration-tests
+k8s-integration-basic-tests: k8s-integration-config
+	@GO111MODULE=on go test -v ./test/... -failfast -timeout 30m -tags="basic"
+
+.PHONY: k8s-integration-tests
+k8s-integration-recover-tests: k8s-integration-config
+	@GO111MODULE=on go test -v ./test/... -failfast -timeout 30m -tags="recover"
+
+.PHONY: k8s-integration-tests
+k8s-integration-usecase-tests: k8s-integration-config
+	@GO111MODULE=on go test -v ./test/... -failfast -timeout 30m -tags="usecase"
+
 .PHONY: k8s-integration-%-test
 k8s-integration-%-test: k8s-integration-config
 	@GO111MODULE=on BROKEN_TESTS_ENABLED=on go test -v ./test/... -failfast -tags="basic recover usecase" -run $*

--- a/.mk/integration.mk
+++ b/.mk/integration.mk
@@ -21,15 +21,15 @@ k8s-integration-config:
 k8s-integration-tests: k8s-integration-config
 	@GO111MODULE=on go test -v ./test/... -failfast -timeout 30m -tags="basic recover usecase"
 
-.PHONY: k8s-integration-tests
+.PHONY: k8s-integration-basic-tests
 k8s-integration-basic-tests: k8s-integration-config
 	@GO111MODULE=on go test -v ./test/... -failfast -timeout 30m -tags="basic"
 
-.PHONY: k8s-integration-tests
+.PHONY: k8s-integration-recover-tests
 k8s-integration-recover-tests: k8s-integration-config
 	@GO111MODULE=on go test -v ./test/... -failfast -timeout 30m -tags="recover"
 
-.PHONY: k8s-integration-tests
+.PHONY: k8s-integration-usecase-tests
 k8s-integration-usecase-tests: k8s-integration-config
 	@GO111MODULE=on go test -v ./test/... -failfast -timeout 30m -tags="usecase"
 

--- a/.mk/integration.mk
+++ b/.mk/integration.mk
@@ -21,17 +21,9 @@ k8s-integration-config:
 k8s-integration-tests: k8s-integration-config
 	@GO111MODULE=on go test -v ./test/... -failfast -timeout 30m -tags="basic recover usecase"
 
-.PHONY: k8s-integration-basic-tests
-k8s-integration-basic-tests: k8s-integration-config
-	@GO111MODULE=on go test -v ./test/... -failfast -timeout 30m -tags="basic"
-
-.PHONY: k8s-integration-recover-tests
-k8s-integration-recover-tests: k8s-integration-config
-	@GO111MODULE=on go test -v ./test/... -failfast -timeout 30m -tags="recover"
-
-.PHONY: k8s-integration-usecase-tests
-k8s-integration-usecase-tests: k8s-integration-config
-	@GO111MODULE=on go test -v ./test/... -failfast -timeout 30m -tags="usecase"
+.PHONY: k8s-integration-tests-%
+k8s-integration-tests-%: k8s-integration-config
+	@GO111MODULE=on go test -v ./test/... -failfast -timeout 30m -tags="$*"
 
 .PHONY: k8s-integration-%-test
 k8s-integration-%-test: k8s-integration-config


### PR DESCRIPTION
Signed-off-by: Radoslav Dimitrov <dimitrovr@vmware.com>

<!--- Provide a general summary of your changes in the Title above -->
Add separate make targets for the integration test groups for basic, usecase and recover.
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Sometimes when testing you don't want to test against the whole `make k8s-integration-tests` suite or on the other hand against a single one.

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [ ] Covered by existing integration testing
- [ ] Added integration testing to cover
- [ ] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.