### PR TITLE
test: fix VPN with namespace tests

### DIFF
--- a/test/integration/usecase_vpn_test.go
+++ b/test/integration/usecase_vpn_test.go
@@ -116,7 +116,7 @@ func testVPN(t *testing.T, nodesCount int, affinity map[string]int, verbose bool
 	}
 
 	{
-		nscrd, err := crds.NewNSCRD()
+		nscrd, err := crds.NewNSCRD(k8s.GetK8sNamespace())
 		Expect(err).To(BeNil())
 
 		nsSecureIntranetConnectivity := crds.SecureIntranetConnectivity()

--- a/test/kube_testing/crds/networkservice.go
+++ b/test/kube_testing/crds/networkservice.go
@@ -20,7 +20,6 @@ import (
 
 	nsapiv1 "github.com/networkservicemesh/networkservicemesh/k8s/pkg/apis/networkservice/v1"
 	nscrd "github.com/networkservicemesh/networkservicemesh/k8s/pkg/networkservice/clientset/versioned"
-	"github.com/networkservicemesh/networkservicemesh/k8s/pkg/networkservice/namespace"
 	. "github.com/onsi/gomega"
 	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v12 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -66,7 +65,7 @@ func (nscrd *NSCRD) Get(name string) (*nsapiv1.NetworkService, error) {
 	return &result, err
 }
 
-func NewNSCRD() (*NSCRD, error) {
+func NewNSCRD(namespace string) (*NSCRD, error) {
 
 	path := os.Getenv("KUBECONFIG")
 	if len(path) == 0 {
@@ -76,7 +75,7 @@ func NewNSCRD() (*NSCRD, error) {
 	config, err := clientcmd.BuildConfigFromFlags("", path)
 	Expect(err).To(BeNil())
 
-	nsmNamespace := namespace.GetNamespace()
+	nsmNamespace := namespace
 	client := NSCRD{
 		namespace: nsmNamespace,
 		resource:  "networkservices",


### PR DESCRIPTION
Signed-off-by: Nikolay Nikolaev <nnikolay@vmware.com>

## Description
Since the VPN tests were disabled for a while, the Namespace PR #770 missed it while testing.

## Motivation and Context
Fix CI.

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [x] Covered by existing integration testing
- [ ] Added integration testing to cover
- [x] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
