### PR TITLE
Set number of workers with venv

### DIFF
--- a/.mk/vagrant.mk
+++ b/.mk/vagrant.mk
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
-
 .PHONY: vagrant-start
 vagrant-start:
 	@cd scripts/vagrant; vagrant up --no-parallel;
@@ -47,7 +45,7 @@ vagrant-restart-kubelet:
 	@cd scripts/vagrant; vagrant ssh master -c "sudo service kubelet restart"; \
 	number=1 ; while [[ $$number -le ${WORKER_COUNT} ]] ; do \
 		vagrant ssh worker$$number	-c "sudo service kubelet restart" ; \
-		((number = number + 1)) ; \
+		((number++)) ; \
 	done
 
 .PHONY: vagrant-%-load-images
@@ -59,7 +57,7 @@ vagrant-%-load-images:
 		number=1 ; while [[ $$number -le ${WORKER_COUNT} ]] ; do \
 			echo "Loading image $*.tar to worker$$number"; \
 			vagrant ssh worker$$number	"sudo docker load -i /vagrant/images/$*.tar" > /dev/null 2>&1; \
-			((number = number + 1)) ; \
+			((number++)) ; \
 		done
 	else \
 		echo "Cannot load $*.tar: scripts/vagrant/images/$*.tar does not exist.  Try running 'make k8s-$*-save'"; \

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@
 
 # We want to use bash
 SHELL:=/bin/bash
+WORKER_COUNT ?= 1
 
 # Default target, no other targets should be before default
 .PHONY: default

--- a/docs/guide-kind.md
+++ b/docs/guide-kind.md
@@ -3,7 +3,7 @@
 [`kind`](kind.sigs.k8s.io) is a tool for running local Kubernetes clusters using Docker container “nodes”.
 Docker is the only prerequisite, it does not require any additional steps, hypervisors etc.
 
-It is worth noting that `kind` as any other Kubernetes deployment tool would expect that the machine that hosts the Docker has at least 4 CPU cores and 4 GB of RAM. That is specifically pointed for OSX users in the official [docs](https://kind.sigs.k8s.io/docs/user/quick-start/).
+It is worth noting that `kind` as any other Kubernetes deplyment tool would expect that the machine that hostst the Docker has at lease 4 CPU cores and 4 GB of RAM. That is specifically pointed for OSX users in the official [docs](https://kind.sigs.k8s.io/docs/user/quick-start/).
 
 
 ## `kind` lifecycle management

--- a/docs/guide-kind.md
+++ b/docs/guide-kind.md
@@ -3,7 +3,7 @@
 [`kind`](kind.sigs.k8s.io) is a tool for running local Kubernetes clusters using Docker container “nodes”.
 Docker is the only prerequisite, it does not require any additional steps, hypervisors etc.
 
-It is worth noting that `kind` as any other Kubernetes deplyment tool would expect that the machine that hostst the Docker has at lease 4 CPU cores and 4 GB of RAM. That is specifically pointed for OSX users in the official [docs](https://kind.sigs.k8s.io/docs/user/quick-start/).
+It is worth noting that `kind` as any other Kubernetes deployment tool would expect that the machine that hosts the Docker has at least 4 CPU cores and 4 GB of RAM. That is specifically pointed for OSX users in the official [docs](https://kind.sigs.k8s.io/docs/user/quick-start/).
 
 
 ## `kind` lifecycle management

--- a/scripts/vagrant/Vagrantfile
+++ b/scripts/vagrant/Vagrantfile
@@ -1,6 +1,7 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
+WORKER_COUNT = ENV['WORKER_COUNT'].nil? ? 1 : ENV['WORKER_COUNT'].to_i
 Vagrant.configure("2") do |config|
 
   config.vm.synced_folder "../..", "/go/src/github.com/networkservicemesh/networkservicemesh",
@@ -47,10 +48,12 @@ Vagrant.configure("2") do |config|
     master.vm.provision "shell", path: "scripts/configureK8smaster.sh"
     master.vm.provision "shell", path: "scripts/coredump.sh"
   end
-  config.vm.define "worker" do |worker|
-    worker.vm.hostname = "kube-worker"
-    worker.vm.provision "shell", path: "scripts/configureK8sworker.sh"
-    worker.vm.provision "shell", path: "scripts/coredump.sh"
+  (1..WORKER_COUNT).each do |i|
+    config.vm.define "worker#{i}" do |worker|
+      worker.vm.hostname = "kube-worker#{i}"
+      worker.vm.provision "shell", path: "scripts/configureK8sworker.sh"
+      worker.vm.provision "shell", path: "scripts/coredump.sh"
+    end
   end
 
 end


### PR DESCRIPTION
Signed-off-by: Mathieu Rohon <mathieu.rohon@orange.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

The WORKER_COUNT can be set to control the number of k8s workers to deploy with vagrant.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

We can then easily set the number of worker to 0 for development.

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [ ] Covered by existing integration testing
- [ ] Added integration testing to cover
- [x] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
