### PR TITLE
Add arp entries to vppagent transaction

### DIFF
--- a/dataplane/pkg/common/egress_interface.go
+++ b/dataplane/pkg/common/egress_interface.go
@@ -25,6 +25,12 @@ import (
 	"strings"
 )
 
+type ARPEntry struct {
+	Interface    	string
+	IpAddress       string
+	PhysAddress     string
+}
+
 type EgressInterface interface {
 	SrcIPNet() *net.IPNet
 	DefaultGateway() *net.IP
@@ -32,6 +38,7 @@ type EgressInterface interface {
 	Name() string
 	HardwareAddr() *net.HardwareAddr
 	OutgoingInterface() string
+	ArpEntries() 		[]* ARPEntry
 }
 
 type egressInterface struct {
@@ -40,6 +47,7 @@ type egressInterface struct {
 	iface             *net.Interface
 	defaultGateway    net.IP
 	outgoingInterface string
+	arpEntries		  []* ARPEntry
 }
 
 func findDefaultGateway4() (string, net.IP, error) {
@@ -94,6 +102,43 @@ func parseGatewayIP(defaultGateway string) net.IP {
 	return ip
 }
 
+func getArpEntries() ([]* ARPEntry, error) {
+	f, err := os.OpenFile("/proc/net/arp", os.O_RDONLY, 0600)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	reader := bufio.NewReader(f)
+
+	arps := []* ARPEntry{}
+	for l := 0; ; l++ {
+		line, err := reader.ReadString('\n')
+
+		if err != nil {
+			if err != io.EOF {
+				break
+			}
+			break
+		}
+
+		if l == 0 {
+			continue //Skip first line with headers and empty line
+		}
+		if line == "" {
+			break //Skip first line with headers and empty line
+		}
+		line = strings.TrimSpace(line)
+		parts := strings.Fields(line)
+		arps = append(arps, &ARPEntry{
+			PhysAddress: strings.TrimSpace(parts[3]),
+			IpAddress:   strings.TrimSpace(parts[0]),
+			Interface:   strings.TrimSpace(parts[5]),
+		})
+	}
+	return arps, nil
+}
+
 func NewEgressInterface(srcIp net.IP) (EgressInterface, error) {
 	ifaces, err := net.Interfaces()
 	if err != nil {
@@ -101,6 +146,11 @@ func NewEgressInterface(srcIp net.IP) (EgressInterface, error) {
 	}
 
 	outgoingInterface, gw, err := findDefaultGateway4()
+	if err != nil {
+		return nil, err
+	}
+
+	arpEntries, err := getArpEntries()
 	if err != nil {
 		return nil, err
 	}
@@ -119,6 +169,7 @@ func NewEgressInterface(srcIp net.IP) (EgressInterface, error) {
 						iface:             &iface,
 						defaultGateway:    gw,
 						outgoingInterface: outgoingInterface,
+						arpEntries:		   arpEntries,
 					}, nil
 				}
 			default:
@@ -169,4 +220,11 @@ func (e *egressInterface) OutgoingInterface() string {
 		return ""
 	}
 	return e.outgoingInterface
+}
+
+func (e *egressInterface) ArpEntries() []*ARPEntry {
+	if e == nil {
+		return nil
+	}
+	return e.arpEntries
 }

--- a/dataplane/pkg/common/egress_interface.go
+++ b/dataplane/pkg/common/egress_interface.go
@@ -152,7 +152,9 @@ func NewEgressInterface(srcIp net.IP) (EgressInterface, error) {
 
 	arpEntries, err := getArpEntries()
 	if err != nil {
-		return nil, err
+		if !os.IsNotExist(err) {
+			return nil, err
+		}
 	}
 
 	for _, iface := range ifaces {

--- a/dataplane/vppagent/pkg/vppagent/vppagent.go
+++ b/dataplane/vppagent/pkg/vppagent/vppagent.go
@@ -210,6 +210,17 @@ func (v *VPPAgent) programMgmtInterface() error {
 	}
 	defer conn.Close()
 	client := configurator.NewConfiguratorClient(conn)
+
+	vppArpEntries := []*vpp.ARPEntry{}
+	for _, arpEntry := range v.egressInterface.ArpEntries() {
+		vppArpEntries = append(vppArpEntries, &vpp.ARPEntry{
+			Interface: ManagementInterface,
+			IpAddress: arpEntry.IpAddress,
+			PhysAddress: arpEntry.PhysAddress,
+
+		})
+	}
+
 	dataRequest := &configurator.UpdateRequest{
 		Update: &configurator.Config{
 			VppConfig: &vpp.ConfigData{
@@ -237,6 +248,9 @@ func (v *VPPAgent) programMgmtInterface() error {
 						NextHopAddr:       v.egressInterface.DefaultGateway().String(),
 					},
 				},
+				// Add system arp entries
+				Arps: vppArpEntries,
+
 			},
 		},
 	}


### PR DESCRIPTION
Configure arp entries for vpp

Signed-off-by: Artem Belov <belov3004@gmail.com>

## Description
Add system arp entries to vppagent transaction

## Motivation and Context
AWS needs configured arp entries to reach gateway

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [x] Covered by existing integration testing
- [ ] Added integration testing to cover
- [x] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
