### PR TITLE
Fixed nil pointer dereference problem when installing with helm

### DIFF
--- a/controlplane/pkg/nsm/nsm.go
+++ b/controlplane/pkg/nsm/nsm.go
@@ -56,12 +56,15 @@ func (srv *networkServiceManager) GetHealProperties() *nsm.NsmProperties {
 }
 
 func NewNetworkServiceManager(model model.Model, serviceRegistry serviceregistry.ServiceRegistry) nsm.NetworkServiceManager {
+	emptyPrefixPool, _ := prefix_pool.NewPrefixPool()
+
 	srv := &networkServiceManager{
-		serviceRegistry: serviceRegistry,
-		model:           model,
-		properties:      nsm.NewNsmProperties(),
-		stateRestored:   make(chan bool, 1),
-		errCh:           make(chan error, 1),
+		serviceRegistry:  serviceRegistry,
+		model:            model,
+		excludedPrefixes: emptyPrefixPool,
+		properties:       nsm.NewNsmProperties(),
+		stateRestored:    make(chan bool, 1),
+		errCh:            make(chan error, 1),
 	}
 
 	go srv.monitorExcludePrefixes()


### PR DESCRIPTION
Fixes: https://github.com/networkservicemesh/networkservicemesh/issues/1007

Signed-off-by: Bart Smykla <bsmykla@vmware.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description

If you tried to install nsm using helm chart and then install
some example (ie. icmp-responder) also with helm,
nsmd was panicking because of nil pointer of resolution
related to networkServiceManager.excludedPrefixes.
It was probably related with some synchronisation issues
(some things should be deployed first, before other,
which was not forced by helm).

I fixed it by initializing new NetworkServiceManager
with empty excludedPrefixes immediately.
<!--- Describe your changes in detail -->

## Motivation and Context
Installing `icmp-responder` or other examples via helm was crashing. It should fix the issues related to that.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [ ] Covered by existing integration testing
- [ ] Added integration testing to cover
- [x] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
