### PR TITLE
Use k8s cache informer for xconn monitoring

### DIFF
--- a/k8s/pkg/registryserver/resource_cache/nsm_cache.go
+++ b/k8s/pkg/registryserver/resource_cache/nsm_cache.go
@@ -1,7 +1,7 @@
 package resource_cache
 
 import (
-	"github.com/networkservicemesh/networkservicemesh/k8s/pkg/apis/networkservice/v1"
+	v1 "github.com/networkservicemesh/networkservicemesh/k8s/pkg/apis/networkservice/v1"
 	"github.com/networkservicemesh/networkservicemesh/k8s/pkg/networkservice/informers/externalversions"
 	"github.com/sirupsen/logrus"
 )
@@ -9,6 +9,7 @@ import (
 type NetworkServiceManagerCache struct {
 	cache                  abstractResourceCache
 	networkServiceManagers map[string]*v1.NetworkServiceManager
+	AddedHandler           func(nsm *v1.NetworkServiceManager)
 }
 
 func NewNetworkServiceManagerCache() *NetworkServiceManagerCache {
@@ -58,6 +59,9 @@ func (c *NetworkServiceManagerCache) resourceAdded(obj interface{}) {
 	nsm := obj.(*v1.NetworkServiceManager)
 	logrus.Infof("NetworkServiceManagerCache.Added(%v)", nsm)
 	c.networkServiceManagers[getNsmKey(nsm)] = nsm
+	if c.AddedHandler != nil {
+		c.AddedHandler(nsm)
+	}
 }
 
 func (c *NetworkServiceManagerCache) resourceUpdated(obj interface{}) {

--- a/k8s/pkg/registryserver/resource_cache/resource_cache.go
+++ b/k8s/pkg/registryserver/resource_cache/resource_cache.go
@@ -1,11 +1,12 @@
 package resource_cache
 
 import (
-	"github.com/networkservicemesh/networkservicemesh/k8s/pkg/apis/networkservice/v1"
+	"reflect"
+
+	v1 "github.com/networkservicemesh/networkservicemesh/k8s/pkg/apis/networkservice/v1"
 	"github.com/networkservicemesh/networkservicemesh/k8s/pkg/networkservice/informers/externalversions"
 	"github.com/sirupsen/logrus"
 	"k8s.io/client-go/tools/cache"
-	"reflect"
 )
 
 const (


### PR DESCRIPTION
Signed-off-by: Mathieu Rohon <mathieu.rohon@orange.com>

Instead of polling the Registry every second, the crossconnect monitor component should use the cache informer be informed of any new NSManager.

## Motivation and Context

It will allow the crossconnect monitor to scale better and remve stress on the registry.

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [ ] Covered by existing integration testing
- [ ] Added integration testing to cover
- [x] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
