### PR TITLE
Fix vagrant-%-load-images for mac users

### DIFF
--- a/.mk/vagrant.mk
+++ b/.mk/vagrant.mk
@@ -58,7 +58,7 @@ vagrant-%-load-images:
 			echo "Loading image $*.tar to worker$$number"; \
 			vagrant ssh worker$$number	"sudo docker load -i /vagrant/images/$*.tar" > /dev/null 2>&1; \
 			((number++)) ; \
-		done
+		done; \
 	else \
 		echo "Cannot load $*.tar: scripts/vagrant/images/$*.tar does not exist.  Try running 'make k8s-$*-save'"; \
 		exit 1; \


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
https://github.com/networkservicemesh/networkservicemesh/pull/1001 improved bash script for deploying images for nodes worker 1...n. 
But this script doesn't run on mac. For example
```
users-iMac:networkservicemesh user$ make vagrant-admission-webhook-load-images
/bin/bash: -c: line 1: syntax error: unexpected end of file
make: *** [vagrant-admission-webhook-load-images] Error 2
```

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [ ] Covered by existing integration testing
- [ ] Added integration testing to cover
- [X] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
