### PR TITLE
Fix failing tests after last merges

### DIFF
--- a/k8s/pkg/registryserver/registry_cache.go
+++ b/k8s/pkg/registryserver/registry_cache.go
@@ -150,8 +150,7 @@ func (rc *registryCacheImpl) CreateOrUpdateNetworkServiceManager(nsm *v1.Network
 		}
 		nsm.ObjectMeta = existingNsm.ObjectMeta
 		logrus.Infof("NSM with name %v already exist on server, updating cache: %v", nsm.GetName(), nsm)
-		rc.networkServiceManagerCache.Add(nsm)
-		return nsm, nil
+		return rc.updateNetworkServiceManager(nsm)
 	}
 	return createNsm, err
 }


### PR DESCRIPTION
Signed-off-by: denis-tingajkin <denis.tingajkin@xored.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
After last merges, we have a couple of failing tests.
Root cause: PR #1003 has added regression which has been covered by PR #989
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [X] Covered by existing integration testing
- [X] Added unit testing to cover
- [ ] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
