### PR TITLE
Fix to be able to load images to vagrant workers

### DIFF
--- a/.mk/vagrant.mk
+++ b/.mk/vagrant.mk
@@ -56,7 +56,7 @@ vagrant-%-load-images:
 		vagrant ssh master -c "sudo docker load -i /vagrant/images/$*.tar" > /dev/null 2>&1; \
 		number=1 ; while [[ $$number -le ${WORKER_COUNT} ]] ; do \
 			echo "Loading image $*.tar to worker$$number"; \
-			vagrant ssh worker$$number	"sudo docker load -i /vagrant/images/$*.tar" > /dev/null 2>&1; \
+			vagrant ssh worker$$number -c "sudo docker load -i /vagrant/images/$*.tar" ; \
 			((number++)) ; \
 		done; \
 	else \


### PR DESCRIPTION
Signed-off-by: Mathieu Rohon <mathieu.rohon@orange.com>

## Description

The forgotten "-c" was preventing new docker images to be uploaded to vagrant workers

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [ ] Covered by existing integration testing
- [ ] Added integration testing to cover
- [x] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
