### PR TITLE
TestLostUpdate stabilization

### DIFF
--- a/controlplane/pkg/nsmd/serviceregistry.go
+++ b/controlplane/pkg/nsmd/serviceregistry.go
@@ -199,8 +199,6 @@ func (impl *nsmdServiceRegistry) initRegistryClient() {
 			continue
 		}
 		impl.registryClientConnection = conn
-		for ; conn.GetState() != connectivity.Ready; <-time.Tick(300 * time.Millisecond) {
-		}
 		logrus.Infof("Successfully connected to %s", impl.registryAddress)
 		return
 	}

--- a/controlplane/pkg/nsmd/serviceregistry.go
+++ b/controlplane/pkg/nsmd/serviceregistry.go
@@ -19,7 +19,7 @@ import (
 	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/vni"
 	dataplaneapi "github.com/networkservicemesh/networkservicemesh/dataplane/pkg/apis/dataplane"
 	"github.com/networkservicemesh/networkservicemesh/pkg/tools"
-	opentracing "github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go"
 	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/connectivity"
@@ -199,6 +199,8 @@ func (impl *nsmdServiceRegistry) initRegistryClient() {
 			continue
 		}
 		impl.registryClientConnection = conn
+		for ; conn.GetState() != connectivity.Ready; <-time.Tick(300 * time.Millisecond) {
+		}
 		logrus.Infof("Successfully connected to %s", impl.registryAddress)
 		return
 	}

--- a/k8s/cmd/nsmd-k8s/main.go
+++ b/k8s/cmd/nsmd-k8s/main.go
@@ -54,12 +54,6 @@ func main() {
 	}
 
 	nsmClientSet, err := versioned.NewForConfig(config)
-
-	listener, err := net.Listen("tcp", address)
-	if err != nil {
-		logrus.Fatalln(err)
-	}
-
 	server := registryserver.New(nsmClientSet, nsmName)
 
 	clusterInfoService, err := registryserver.NewK8sClusterInfoService(config)
@@ -68,6 +62,11 @@ func main() {
 	}
 
 	registry.RegisterClusterInfoServer(server, clusterInfoService)
+
+	listener, err := net.Listen("tcp", address)
+	if err != nil {
+		logrus.Fatalln(err)
+	}
 
 	logrus.Print("nsmd-k8s initialized and waiting for connection")
 	go func() {

--- a/k8s/pkg/registryserver/registry_cache.go
+++ b/k8s/pkg/registryserver/registry_cache.go
@@ -37,12 +37,12 @@ type registryCacheImpl struct {
 	nsmNamespace                string
 }
 
-func NewRegistryCache(clientset *nsmClientset.Clientset) RegistryCache {
+func NewRegistryCache(cs *nsmClientset.Clientset) RegistryCache {
 	return &registryCacheImpl{
 		networkServiceCache:         resource_cache.NewNetworkServiceCache(),
 		networkServiceEndpointCache: resource_cache.NewNetworkServiceEndpointCache(),
 		networkServiceManagerCache:  resource_cache.NewNetworkServiceManagerCache(),
-		clientset:                   clientset,
+		clientset:                   cs,
 		stopFuncs:                   make([]func(), 0, 3),
 		nsmNamespace:                namespace.GetNamespace(),
 	}
@@ -51,21 +51,21 @@ func NewRegistryCache(clientset *nsmClientset.Clientset) RegistryCache {
 func (rc *registryCacheImpl) Start() error {
 	factory := externalversions.NewSharedInformerFactory(rc.clientset, 0)
 
-	if stopFunc, err := rc.networkServiceCache.Start(factory); err != nil {
+	if stopFunc, err := rc.networkServiceCache.StartWithResync(factory, rc.clientset); err != nil {
 		rc.Stop()
 		return err
 	} else {
 		rc.stopFuncs = append(rc.stopFuncs, stopFunc)
 	}
 
-	if stopFunc, err := rc.networkServiceEndpointCache.Start(factory); err != nil {
+	if stopFunc, err := rc.networkServiceEndpointCache.StartWithResync(factory, rc.clientset); err != nil {
 		rc.Stop()
 		return err
 	} else {
 		rc.stopFuncs = append(rc.stopFuncs, stopFunc)
 	}
 
-	if stopFunc, err := rc.networkServiceManagerCache.Start(factory); err != nil {
+	if stopFunc, err := rc.networkServiceManagerCache.StartWithResync(factory, rc.clientset); err != nil {
 		rc.Stop()
 		return err
 	} else {

--- a/k8s/pkg/registryserver/resource_cache/ns_cache.go
+++ b/k8s/pkg/registryserver/resource_cache/ns_cache.go
@@ -6,6 +6,7 @@ import (
 	"github.com/networkservicemesh/networkservicemesh/k8s/pkg/networkservice/clientset/versioned"
 	. "github.com/networkservicemesh/networkservicemesh/k8s/pkg/networkservice/informers/externalversions"
 	"github.com/networkservicemesh/networkservicemesh/k8s/pkg/networkservice/namespace"
+	"github.com/sirupsen/logrus"
 	v12 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -61,9 +62,10 @@ func (c *NetworkServiceCache) StartWithResync(f SharedInformerFactory, cs *versi
 
 func (c *NetworkServiceCache) replace(resources []v1.NetworkService) {
 	newMap := map[string]*v1.NetworkService{}
-
+	logrus.Info("Replacing Network services with: ")
 	for _, r := range resources {
-		newMap[getNsKey(&r)] = &r
+		logrus.Infof("new ns: %v", r)
+		c.resourceAdded(&r)
 	}
 
 	c.networkServices = newMap

--- a/k8s/pkg/registryserver/resource_cache/ns_cache.go
+++ b/k8s/pkg/registryserver/resource_cache/ns_cache.go
@@ -1,8 +1,12 @@
 package resource_cache
 
 import (
+	"fmt"
 	"github.com/networkservicemesh/networkservicemesh/k8s/pkg/apis/networkservice/v1"
-	"github.com/networkservicemesh/networkservicemesh/k8s/pkg/networkservice/informers/externalversions"
+	"github.com/networkservicemesh/networkservicemesh/k8s/pkg/networkservice/clientset/versioned"
+	. "github.com/networkservicemesh/networkservicemesh/k8s/pkg/networkservice/informers/externalversions"
+	"github.com/networkservicemesh/networkservicemesh/k8s/pkg/networkservice/namespace"
+	v12 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 type NetworkServiceCache struct {
@@ -42,8 +46,27 @@ func (c *NetworkServiceCache) Delete(key string) {
 	c.cache.delete(key)
 }
 
-func (c *NetworkServiceCache) Start(informerFactory externalversions.SharedInformerFactory) (func(), error) {
-	return c.cache.start(informerFactory)
+func (c *NetworkServiceCache) Start(f SharedInformerFactory, init ...v1.NetworkService) (func(), error) {
+	c.replace(init)
+	return c.cache.start(f)
+}
+
+func (c *NetworkServiceCache) StartWithResync(f SharedInformerFactory, cs *versioned.Clientset) (func(), error) {
+	l, err := cs.NetworkservicemeshV1().NetworkServices(namespace.GetNamespace()).List(v12.ListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("unable to list NSs for cache initialization: %v", err)
+	}
+	return c.Start(f, l.Items...)
+}
+
+func (c *NetworkServiceCache) replace(resources []v1.NetworkService) {
+	newMap := map[string]*v1.NetworkService{}
+
+	for _, r := range resources {
+		newMap[getNsKey(&r)] = &r
+	}
+
+	c.networkServices = newMap
 }
 
 func (c *NetworkServiceCache) resourceAdded(obj interface{}) {

--- a/k8s/pkg/registryserver/resource_cache/ns_cache.go
+++ b/k8s/pkg/registryserver/resource_cache/ns_cache.go
@@ -61,14 +61,12 @@ func (c *NetworkServiceCache) StartWithResync(f SharedInformerFactory, cs *versi
 }
 
 func (c *NetworkServiceCache) replace(resources []v1.NetworkService) {
-	newMap := map[string]*v1.NetworkService{}
-	logrus.Info("Replacing Network services with: ")
+	c.networkServices = map[string]*v1.NetworkService{}
+	logrus.Infof("Replacing Network services with: %v", resources)
+
 	for _, r := range resources {
-		logrus.Infof("new ns: %v", r)
 		c.resourceAdded(&r)
 	}
-
-	c.networkServices = newMap
 }
 
 func (c *NetworkServiceCache) resourceAdded(obj interface{}) {

--- a/k8s/pkg/registryserver/resource_cache/nse_cache.go
+++ b/k8s/pkg/registryserver/resource_cache/nse_cache.go
@@ -1,9 +1,13 @@
 package resource_cache
 
 import (
+	"fmt"
 	"github.com/networkservicemesh/networkservicemesh/k8s/pkg/apis/networkservice/v1"
-	"github.com/networkservicemesh/networkservicemesh/k8s/pkg/networkservice/informers/externalversions"
+	"github.com/networkservicemesh/networkservicemesh/k8s/pkg/networkservice/clientset/versioned"
+	. "github.com/networkservicemesh/networkservicemesh/k8s/pkg/networkservice/informers/externalversions"
+	"github.com/networkservicemesh/networkservicemesh/k8s/pkg/networkservice/namespace"
 	"github.com/sirupsen/logrus"
+	v12 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 type NetworkServiceEndpointCache struct {
@@ -65,8 +69,27 @@ func (c *NetworkServiceEndpointCache) Delete(key string) {
 	c.cache.delete(key)
 }
 
-func (c *NetworkServiceEndpointCache) Start(informerFactory externalversions.SharedInformerFactory) (func(), error) {
-	return c.cache.start(informerFactory)
+func (c *NetworkServiceEndpointCache) Start(f SharedInformerFactory, init ...v1.NetworkServiceEndpoint) (func(), error) {
+	c.replace(init)
+	return c.cache.start(f)
+}
+
+func (c *NetworkServiceEndpointCache) StartWithResync(f SharedInformerFactory, cs *versioned.Clientset) (func(), error) {
+	l, err := cs.NetworkservicemeshV1().NetworkServiceEndpoints(namespace.GetNamespace()).List(v12.ListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("unable to list NSEs for cache initialization: %v", err)
+	}
+	return c.Start(f, l.Items...)
+}
+
+func (c *NetworkServiceEndpointCache) replace(resources []v1.NetworkServiceEndpoint) {
+	newMap := map[string]*v1.NetworkServiceEndpoint{}
+
+	for _, r := range resources {
+		newMap[getNseKey(&r)] = &r
+	}
+
+	c.networkServiceEndpoints = newMap
 }
 
 func (c *NetworkServiceEndpointCache) resourceAdded(obj interface{}) {

--- a/k8s/pkg/registryserver/resource_cache/nse_cache.go
+++ b/k8s/pkg/registryserver/resource_cache/nse_cache.go
@@ -85,10 +85,9 @@ func (c *NetworkServiceEndpointCache) StartWithResync(f SharedInformerFactory, c
 func (c *NetworkServiceEndpointCache) replace(resources []v1.NetworkServiceEndpoint) {
 	c.networkServiceEndpoints = map[string]*v1.NetworkServiceEndpoint{}
 	c.nseByNs = map[string][]*v1.NetworkServiceEndpoint{}
-	logrus.Info("Replacing Network service endpoints with: ")
+	logrus.Infof("Replacing Network service endpoints with: %v", resources)
 
 	for _, r := range resources {
-		logrus.Infof("new nse: %v", r)
 		c.resourceAdded(&r)
 	}
 }

--- a/k8s/pkg/registryserver/resource_cache/nse_cache.go
+++ b/k8s/pkg/registryserver/resource_cache/nse_cache.go
@@ -83,13 +83,14 @@ func (c *NetworkServiceEndpointCache) StartWithResync(f SharedInformerFactory, c
 }
 
 func (c *NetworkServiceEndpointCache) replace(resources []v1.NetworkServiceEndpoint) {
-	newMap := map[string]*v1.NetworkServiceEndpoint{}
+	c.networkServiceEndpoints = map[string]*v1.NetworkServiceEndpoint{}
+	c.nseByNs = map[string][]*v1.NetworkServiceEndpoint{}
+	logrus.Info("Replacing Network service endpoints with: ")
 
 	for _, r := range resources {
-		newMap[getNseKey(&r)] = &r
+		logrus.Infof("new nse: %v", r)
+		c.resourceAdded(&r)
 	}
-
-	c.networkServiceEndpoints = newMap
 }
 
 func (c *NetworkServiceEndpointCache) resourceAdded(obj interface{}) {

--- a/k8s/pkg/registryserver/resource_cache/nsm_cache.go
+++ b/k8s/pkg/registryserver/resource_cache/nsm_cache.go
@@ -1,9 +1,13 @@
 package resource_cache
 
 import (
+	"fmt"
 	"github.com/networkservicemesh/networkservicemesh/k8s/pkg/apis/networkservice/v1"
-	"github.com/networkservicemesh/networkservicemesh/k8s/pkg/networkservice/informers/externalversions"
+	"github.com/networkservicemesh/networkservicemesh/k8s/pkg/networkservice/clientset/versioned"
+	. "github.com/networkservicemesh/networkservicemesh/k8s/pkg/networkservice/informers/externalversions"
+	"github.com/networkservicemesh/networkservicemesh/k8s/pkg/networkservice/namespace"
 	"github.com/sirupsen/logrus"
+	v12 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 type NetworkServiceManagerCache struct {
@@ -50,8 +54,27 @@ func (c *NetworkServiceManagerCache) Delete(key string) {
 	c.cache.delete(key)
 }
 
-func (c *NetworkServiceManagerCache) Start(informerFactory externalversions.SharedInformerFactory) (func(), error) {
-	return c.cache.start(informerFactory)
+func (c *NetworkServiceManagerCache) Start(f SharedInformerFactory, init ...v1.NetworkServiceManager) (func(), error) {
+	c.replace(init)
+	return c.cache.start(f)
+}
+
+func (c *NetworkServiceManagerCache) StartWithResync(f SharedInformerFactory, cs *versioned.Clientset) (func(), error) {
+	l, err := cs.NetworkservicemeshV1().NetworkServiceManagers(namespace.GetNamespace()).List(v12.ListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("unable to list NSMs for cache initialization: %v", err)
+	}
+	return c.Start(f, l.Items...)
+}
+
+func (c *NetworkServiceManagerCache) replace(resources []v1.NetworkServiceManager) {
+	newMap := map[string]*v1.NetworkServiceManager{}
+
+	for _, r := range resources {
+		newMap[getNsmKey(&r)] = &r
+	}
+
+	c.networkServiceManagers = newMap
 }
 
 func (c *NetworkServiceManagerCache) resourceAdded(obj interface{}) {

--- a/k8s/pkg/registryserver/resource_cache/nsm_cache.go
+++ b/k8s/pkg/registryserver/resource_cache/nsm_cache.go
@@ -68,16 +68,12 @@ func (c *NetworkServiceManagerCache) StartWithResync(f SharedInformerFactory, cs
 }
 
 func (c *NetworkServiceManagerCache) replace(resources []v1.NetworkServiceManager) {
-	newMap := map[string]*v1.NetworkServiceManager{}
-
-	logrus.Info("Replacing Network service endpoints with: ")
+	c.networkServiceManagers = map[string]*v1.NetworkServiceManager{}
+	logrus.Infof("Replacing Network service endpoints with: %v", resources)
 
 	for _, r := range resources {
-		logrus.Infof("new nsm: %v", r)
 		c.resourceAdded(&r)
 	}
-
-	c.networkServiceManagers = newMap
 }
 
 func (c *NetworkServiceManagerCache) resourceAdded(obj interface{}) {

--- a/k8s/pkg/registryserver/resource_cache/nsm_cache.go
+++ b/k8s/pkg/registryserver/resource_cache/nsm_cache.go
@@ -70,8 +70,11 @@ func (c *NetworkServiceManagerCache) StartWithResync(f SharedInformerFactory, cs
 func (c *NetworkServiceManagerCache) replace(resources []v1.NetworkServiceManager) {
 	newMap := map[string]*v1.NetworkServiceManager{}
 
+	logrus.Info("Replacing Network service endpoints with: ")
+
 	for _, r := range resources {
-		newMap[getNsmKey(&r)] = &r
+		logrus.Infof("new nsm: %v", r)
+		c.resourceAdded(&r)
 	}
 
 	c.networkServiceManagers = newMap

--- a/k8s/pkg/registryserver/server.go
+++ b/k8s/pkg/registryserver/server.go
@@ -18,7 +18,6 @@ func New(clientset *nsmClientset.Clientset, nsmName string) *grpc.Server {
 			otgrpc.OpenTracingStreamServerInterceptor(tracer)))
 
 	cache := NewRegistryCache(clientset)
-	logrus.Info("RegistryCache started")
 
 	nseRegistry := newNseRegistryService(nsmName, cache)
 	nsmRegistry := newNsmRegistryService(nsmName, cache)
@@ -31,6 +30,7 @@ func New(clientset *nsmClientset.Clientset, nsmName string) *grpc.Server {
 	if err := cache.Start(); err != nil {
 		logrus.Error(err)
 	}
+	logrus.Info("RegistryCache started")
 
 	return server
 }

--- a/k8s/pkg/tests/registry_cache_test.go
+++ b/k8s/pkg/tests/registry_cache_test.go
@@ -30,14 +30,20 @@ func fakeNsmRest(serverData *sync.Map) *FakeRest {
 	result.MockGet("/networkserviceendpoints", func(r *http.Request, resource string) (response *http.Response, e error) {
 		return Ok([]v1.NetworkServiceEndpoint{}), nil
 	})
+	result.MockGet("/namespaces/default/networkserviceendpoints", func(r *http.Request, resource string) (response *http.Response, e error) {
+		return Ok(v1.NetworkServiceEndpointList{}), nil
+	})
 	result.MockGet("/namespaces/default/networkservicemanagers", func(r *http.Request, resource string) (response *http.Response, e error) {
 		if val, ok := serverData.Load(resource); ok {
 			return Ok(val), nil
 		}
-		return NotFound(v1.NetworkServiceManager{}), nil
+		return Ok(v1.NetworkServiceManagerList{}), nil
 	})
 	result.MockGet("/networkservices", func(r *http.Request, resource string) (response *http.Response, e error) {
 		return Ok([]v1.NetworkService{}), nil
+	})
+	result.MockGet("/namespaces/default/networkservices", func(r *http.Request, resource string) (response *http.Response, e error) {
+		return Ok(v1.NetworkServiceList{}), nil
 	})
 	result.MockGet("/networkservicemanagers", func(r *http.Request, resource string) (response *http.Response, e error) {
 		return Ok([]v1.NetworkService{}), nil

--- a/test/integration/basic_nsmd_k8s_test.go
+++ b/test/integration/basic_nsmd_k8s_test.go
@@ -5,6 +5,8 @@ package nsmd_integration_tests
 import (
 	"context"
 	"fmt"
+	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/serviceregistry"
+	"k8s.io/api/core/v1"
 	"net"
 	"testing"
 	"time"
@@ -291,7 +293,7 @@ func getNsmUrl(discovery registry.NetworkServiceDiscoveryClient) string {
 		NetworkServiceName: "icmp-responder",
 	})
 	Expect(err).To(BeNil())
-	Expect(len(response.GetNetworkServiceEndpoints())).To(Equal(1))
+	Expect(len(response.GetNetworkServiceEndpoints()) >= 1).To(Equal(true))
 
 	endpoint := response.GetNetworkServiceEndpoints()[0]
 	logrus.Infof("Endpoint: %v", endpoint)
@@ -352,6 +354,28 @@ func TestClusterInfo(t *testing.T) {
 	Expect(err).To(BeNil())
 }
 
+func serviceRegistryAt(k8s *kube_testing.K8s, nsmgr *v1.Pod) (serviceregistry.ServiceRegistry, func()) {
+	fwd, err := k8s.NewPortForwarder(nsmgr, 5000)
+	Expect(err).To(BeNil())
+
+	err = fwd.Start()
+	Expect(err).To(BeNil())
+
+	sr := nsmd2.NewServiceRegistryAt(fmt.Sprintf("localhost:%d", fwd.ListenPort))
+	return sr, fwd.Stop
+}
+
+func createSingleNsmgr(k8s *kube_testing.K8s, name string) *v1.Pod {
+	nsmgr := k8s.CreatePod(pods.NSMgrPod(name, nil, k8s.GetK8sNamespace()))
+
+	// We need to wait until it is started
+	k8s.WaitLogsContains(nsmgr, "nsmd-k8s", "nsmd-k8s initialized and waiting for connection", fastTimeout)
+	// To be sure NSMD is already called for register.
+	k8s.WaitLogsContains(nsmgr, "nsmd", "Waiting for dataplane available...", defaultTimeout)
+
+	return nsmgr
+}
+
 func TestLostUpdate(t *testing.T) {
 	RegisterTestingT(t)
 
@@ -364,29 +388,17 @@ func TestLostUpdate(t *testing.T) {
 	defer k8s.Cleanup()
 	Expect(err).To(BeNil())
 
-	nsmd := k8s.CreatePod(pods.NSMgrPod("nsmgr-1", nil, k8s.GetK8sNamespace()))
+	nsmgr1 := createSingleNsmgr(k8s, "nsmgr-1")
 
-	// We need to wait until it is started
-	k8s.WaitLogsContains(nsmd, "nsmd-k8s", "nsmd-k8s initialized and waiting for connection", fastTimeout)
-	// To be sure NSMD is already called for register.
-	k8s.WaitLogsContains(nsmd, "nsmd", "Waiting for dataplane available...", defaultTimeout)
+	sr1, closeFunc := serviceRegistryAt(k8s, nsmgr1)
 
-	fwd, err := k8s.NewPortForwarder(nsmd, 5000)
+	nsmRegistryClient, err := sr1.NsmRegistryClient()
 	Expect(err).To(BeNil())
 
-	e := fwd.Start()
-	if e != nil {
-		logrus.Printf("Error on forward: %v retrying", e)
-	}
-
-	serviceRegistry := nsmd2.NewServiceRegistryAt(fmt.Sprintf("localhost:%d", fwd.ListenPort))
-	nsmRegistryClient, err := serviceRegistry.NsmRegistryClient()
+	discovery, err := sr1.DiscoveryClient()
 	Expect(err).To(BeNil())
 
-	discovery, err := serviceRegistry.DiscoveryClient()
-	Expect(err).To(BeNil())
-
-	nseRegistryClient, err := serviceRegistry.NseRegistryClient()
+	nseRegistryClient, err := sr1.NseRegistryClient()
 	Expect(err).To(BeNil())
 
 	networkService := "icmp-responder"
@@ -411,38 +423,21 @@ func TestLostUpdate(t *testing.T) {
 	Expect(err).To(BeNil())
 	logrus.Info(nseResp)
 	Expect(getNsmUrl(discovery)).To(Equal(url1))
+	closeFunc()
+	k8s.DeletePods(nsmgr1)
 
-	fwd.Stop()
-	k8s.DeletePods(nsmd)
+	nsmgr2 := createSingleNsmgr(k8s, "nsmgr-2")
 
-	nsmgr2 := k8s.CreatePod(pods.NSMgrPod("nsmgr-2", nil, k8s.GetK8sNamespace()))
+	sr2, closeFunc2 := serviceRegistryAt(k8s, nsmgr2)
+	defer closeFunc2()
 
-	fwd, err = k8s.NewPortForwarder(nsmgr2, 5000)
-	Expect(err).To(BeNil())
-	defer fwd.Stop()
-
-	e = fwd.Start()
-	if e != nil {
-		logrus.Printf("Error on forward: %v retrying", e)
-	}
-
-	serviceRegistry = nsmd2.NewServiceRegistryAt(fmt.Sprintf("localhost:%d", fwd.ListenPort))
-	nsmRegistryClient, err = serviceRegistry.NsmRegistryClient()
+	discovery2, err := sr2.DiscoveryClient()
 	Expect(err).To(BeNil())
 
-	discovery, err = serviceRegistry.DiscoveryClient()
+	nseRegistryClient2, err := sr2.NseRegistryClient()
 	Expect(err).To(BeNil())
 
-	nseRegistryClient, err = serviceRegistry.NseRegistryClient()
-	Expect(err).To(BeNil())
-
-	// We need to wait until it is started
-	k8s.WaitLogsContains(nsmgr2, "nsmd-k8s", "nsmd-k8s initialized and waiting for connection", fastTimeout)
-	// To be sure NSMD is already called for register.
-	k8s.WaitLogsContains(nsmgr2, "nsmd", "Waiting for dataplane available...", defaultTimeout)
-	Expect(err).To(BeNil())
-
-	nseResp, err = nseRegistryClient.RegisterNSE(context.Background(), &registry.NSERegistration{
+	nseResp, err = nseRegistryClient2.RegisterNSE(context.Background(), &registry.NSERegistration{
 		NetworkService: &registry.NetworkService{
 			Name:    networkService,
 			Payload: "tcp",
@@ -453,5 +448,5 @@ func TestLostUpdate(t *testing.T) {
 	})
 	Expect(err).To(BeNil())
 	logrus.Info(nseResp)
-	Expect(getNsmUrl(discovery)).ToNot(Equal(url1))
+	Expect(getNsmUrl(discovery2)).ToNot(Equal(url1))
 }


### PR DESCRIPTION
Signed-off-by: lobkovilya <ilya.lobkov@xored.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add fetching real k8s-registry state before starting cache
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
TestLostUpdate is not stable

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [X] Covered by existing integration testing
- [ ] Added integration testing to cover
- [X] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
