### PR TITLE
Fix empty exclude prefix fault 

### DIFF
--- a/controlplane/pkg/nsm/nsm_prefix_collector.go
+++ b/controlplane/pkg/nsm/nsm_prefix_collector.go
@@ -130,7 +130,15 @@ func (l *subnetStreamListener) listen() {
 			serviceSubnet = extendResponse.Subnet
 		}
 
-		pool, err := prefix_pool.NewPrefixPool(append(l.additionalPrefixes, podSubnet, serviceSubnet)...)
+		var pool prefix_pool.PrefixPool
+		if len(podSubnet) == 0 {
+			pool, err = prefix_pool.NewPrefixPool(append(l.additionalPrefixes, serviceSubnet)...)
+		} else if len(serviceSubnet) == 0 {
+			pool, err = prefix_pool.NewPrefixPool(append(l.additionalPrefixes, podSubnet)...)
+		} else {
+			pool, err = prefix_pool.NewPrefixPool(append(l.additionalPrefixes, podSubnet, serviceSubnet)...)
+		}
+
 		if err != nil {
 			logrus.Error(err)
 			continue

--- a/controlplane/pkg/nsm/nsm_prefix_collector.go
+++ b/controlplane/pkg/nsm/nsm_prefix_collector.go
@@ -130,14 +130,15 @@ func (l *subnetStreamListener) listen() {
 			serviceSubnet = extendResponse.Subnet
 		}
 
-		var pool prefix_pool.PrefixPool
-		if len(podSubnet) == 0 {
-			pool, err = prefix_pool.NewPrefixPool(append(l.additionalPrefixes, serviceSubnet)...)
-		} else if len(serviceSubnet) == 0 {
-			pool, err = prefix_pool.NewPrefixPool(append(l.additionalPrefixes, podSubnet)...)
-		} else {
-			pool, err = prefix_pool.NewPrefixPool(append(l.additionalPrefixes, podSubnet, serviceSubnet)...)
+		prefixes := l.additionalPrefixes
+		if len(podSubnet) > 0 {
+			prefixes = append(prefixes, podSubnet)
 		}
+		if len(serviceSubnet) > 0 {
+			prefixes = append(prefixes, serviceSubnet)
+		}
+
+		pool, err := prefix_pool.NewPrefixPool(prefixes...)
 
 		if err != nil {
 			logrus.Error(err)


### PR DESCRIPTION
Fix empty exclude prefix fault 

Signed-off-by: Artem Belov <artem.belov@xored.com>

## Description
Skip empty subnets on prefix pool formation

## Motivation and Context
icmp-responder returns fault on AWS cluster. Cause of the fault is request from nsmd with empty pod subnet. 

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [x] Covered by existing integration testing
- [ ] Added integration testing to cover
- [x] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
