### PR TITLE
Push latest vppagent-firewall-nse on circleci success build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -350,7 +350,7 @@ jobs:
             export PULL_TAG="${COMMIT}"
             export TAG="latest"
             export REPO="networkservicemesh"
-            export CONTAINERS=(nsmd nsmd-k8s nsmdp crossconnect-monitor test-nse vppagent-icmp-responder-nse vppagent-nsc nsc vppagent-dataplane vppagent-dataplane-dev admission-webhook)
+            export CONTAINERS=(nsmd nsmd-k8s nsmdp crossconnect-monitor test-nse vppagent-icmp-responder-nse vppagent-nsc nsc vppagent-dataplane vppagent-dataplane-dev admission-webhook vppagent-firewall-nse)
             echo "${DOCKER_PASSWORD}" | docker login -u "${DOCKER_USERNAME}" --password-stdin
             for c in ${CONTAINERS[@]}; do
               docker pull ${REPO}/${c}:${PULL_TAG}


### PR DESCRIPTION
Push latest vppagent-firewall-nse on circleci success build
Signed-off-by: Artem Belov <artem.belov@xored.com>

## Description
Add vppagent-firewall-nse to docker-push-latest circleci job

## Motivation and Context
Networkservicemesh docker hub does not contains latest vppagent-firewall-nse image. 

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [x] Covered by existing integration testing
- [ ] Added integration testing to cover
- [ ] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
