### PR TITLE
Fix restart of nsmd in case of RestoreConnection and add previous container log retrieval.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -279,7 +279,7 @@ jobs:
           command: |
             export COMMIT="${CIRCLE_SHA1:8:8}"
             export CONTAINER_TAG="${COMMIT}"
-            gotestsum --junitfile ~/junit/integration-tests-basic.xml -f standard-verbose ./test/... -timeout 30m -failfast -tags="<<parameters.test_tags>>"
+            gotestsum --junitfile ~/junit/integration-tests-basic.xml -f standard-verbose ./test/... -timeout 30m -tags="<<parameters.test_tags>>"
           no_output_timeout: 40m
       - run:
           when: always

--- a/controlplane/pkg/nsm/nsm.go
+++ b/controlplane/pkg/nsm/nsm.go
@@ -727,7 +727,7 @@ func (srv *networkServiceManager) RestoreConnections(xcons []*crossconnect.Cross
 						logrus.Errorf("Failed to find NSE to recovery: %v", err)
 					}
 					for _, ep := range endpoints.NetworkServiceEndpoints {
-						if ep.EndpointName == xcon.GetRemoteDestination().GetNetworkServiceEndpointName() {
+						if xcon.GetRemoteDestination() != nil && ep.EndpointName == xcon.GetRemoteDestination().GetNetworkServiceEndpointName() {
 							endpoint = &registry.NSERegistration{
 								NetworkServiceManager:  endpoints.NetworkServiceManagers[ep.NetworkServiceManagerName],
 								NetworkserviceEndpoint: ep,

--- a/controlplane/pkg/tests/restore_state_test.go
+++ b/controlplane/pkg/tests/restore_state_test.go
@@ -1,0 +1,70 @@
+package tests
+
+import (
+	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/crossconnect"
+	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/local/connection"
+	. "github.com/onsi/gomega"
+	"testing"
+	"time"
+)
+
+
+func TestRestoreConnectionState(t *testing.T) {
+	RegisterTestingT(t)
+
+	storage := newSharedStorage()
+	srv := newNSMDFullServer(Master, storage, defaultClusterConfiguration)
+	defer srv.Stop()
+
+	srv.addFakeDataplane("dp1","tcp:some_address")
+
+	Expect(srv.nsmServer.Manager().WaitForDataplane(1*time.Millisecond).Error()).To(Equal("Failed to wait for NSMD stare restore... timeout 1ms happened"))
+
+	xcons := []*crossconnect.CrossConnect{
+
+	}
+	srv.nsmServer.Manager().RestoreConnections(xcons, "dp1")
+	Expect(srv.nsmServer.Manager().WaitForDataplane(1*time.Second)).To(BeNil())
+}
+
+func TestRestoreConnectionStateWrongDst(t *testing.T) {
+	RegisterTestingT(t)
+
+	storage := newSharedStorage()
+	srv := newNSMDFullServer(Master, storage, defaultClusterConfiguration)
+	defer srv.Stop()
+
+	srv.addFakeDataplane("dp1","tcp:some_address")
+	srv.registerFakeEndpointWithName("ns1", "IP", Worker, "ep2")
+
+	requestConnection := &connection.Connection{
+		Id:"1",
+		NetworkService: "ns1",
+	}
+
+	dstConnection := &connection.Connection{
+		Id:"2",
+		Mechanism: &connection.Mechanism{
+			Type: connection.MechanismType_KERNEL_INTERFACE,
+			Parameters: map[string]string {
+				connection.WorkspaceNSEName: "nse1",
+			},
+		},
+		NetworkService: "ns1",
+	}
+	xcons := []*crossconnect.CrossConnect{
+		&crossconnect.CrossConnect{
+			Source: &crossconnect.CrossConnect_LocalSource{
+				LocalSource: requestConnection,
+			},
+			Destination: &crossconnect.CrossConnect_LocalDestination{
+				LocalDestination: dstConnection,
+			},
+			Id:"1",
+		},
+	}
+	srv.nsmServer.Manager().RestoreConnections(xcons, "dp1")
+	Expect(srv.nsmServer.Manager().WaitForDataplane(1*time.Second)).To(BeNil())
+	Expect(len(srv.testModel.GetAllClientConnections())).To(Equal(0))
+}
+

--- a/test/integration/basic_nsmd_deploy_restart_test.go
+++ b/test/integration/basic_nsmd_deploy_restart_test.go
@@ -1,0 +1,86 @@
+// +build basic
+
+package nsmd_integration_tests
+
+import (
+	"k8s.io/api/core/v1"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/networkservicemesh/networkservicemesh/test/integration/nsmd_test_utils"
+	"github.com/networkservicemesh/networkservicemesh/test/kube_testing"
+	. "github.com/onsi/gomega"
+	"github.com/sirupsen/logrus"
+)
+
+func TestNSMgrRestartDeploy(t *testing.T) {
+	RegisterTestingT(t)
+
+	if testing.Short() {
+		t.Skip("Skip, please run without -short")
+		return
+	}
+
+	logrus.Print("Running NSMgr Deploy test")
+
+	k8s, err := kube_testing.NewK8s(true)
+	//defer k8s.Cleanup()
+
+	Expect(err).To(BeNil())
+
+	nodes := k8s.GetNodesWait(2, defaultTimeout)
+
+	if len(nodes) < 2 {
+		logrus.Printf("At least two Kubernetes nodes are required for this test")
+		Expect(len(nodes)).To(Equal(2))
+		return
+	}
+
+	pods := nsmd_test_utils.SetupNodes(k8s, 1, defaultTimeout)
+
+	result, result_err, err := k8s.Exec(pods[0].Nsmd, "nsmd", "kill", "-6", "1")
+	logrus.Infof("Kill status %v %v %v", result, result_err, err)
+
+	st := time.Now()
+	restarts := int32(0)
+	for {
+		pod, err := k8s.GetPod(pods[0].Nsmd)
+		if err != nil {
+			logrus.Printf("error during recieve pod information %v %v", err, pod)
+		}
+		restarts = 0
+		alive := 0
+		for _, cs := range pod.Status.ContainerStatuses {
+			if !cs.Ready {
+				continue
+			}
+			restarts += cs.RestartCount
+			alive += 1
+		}
+		if alive == len(pod.Status.ContainerStatuses) && restarts > 0 {
+			// All are alive and we have restart
+			break
+		}
+		if time.Since(st) > fastTimeout {
+			logrus.Errorf("Failed to have NSmgr restarted")
+			t.Fail()
+		}
+		<- time.After(100 * time.Millisecond)
+	}
+	k8s.WaitLogsContains(pods[0].Nsmd, "nsmd", "NSM gRPC API Server: [::]:5001 is operational", defaultTimeout)
+
+	failures := InterceptGomegaFailures(func() {
+		Expect(restarts).To(Equal(int32(1)))
+		prevLogs, err := k8s.GetLogsWithOptions(pods[0].Nsmd, &v1.PodLogOptions{
+			Container: "nsmd",
+			Previous:  true,
+		})
+		Expect(err).To(BeNil())
+		//logrus.Infof("Previous logs: %v", prevLogs)
+		Expect(strings.Contains(prevLogs, "SIGABRT: abort")).To(Equal(true))
+
+	})
+
+	nsmd_test_utils.PrintErrors(failures, k8s, pods, nil, t)
+}

--- a/test/integration/nsmd_test_utils/test_utils.go
+++ b/test/integration/nsmd_test_utils/test_utils.go
@@ -467,12 +467,23 @@ func printDataplaneLogs(k8s *kube_testing.K8s, dataplane *v1.Pod, k int) {
 }
 
 func printNSMDLogs(k8s *kube_testing.K8s, nsmdPod *v1.Pod, k int) {
-	nsmdLogs, _ := k8s.GetLogs(nsmdPod, "nsmd")
-	logrus.Errorf("===================== NSMD %d output since test is failing %v\n=====================", k, nsmdLogs)
-	nsmdk8sLogs, _ := k8s.GetLogs(nsmdPod, "nsmd-k8s")
-	logrus.Errorf("===================== NSMD K8S %d output since test is failing %v\n=====================", k, nsmdk8sLogs)
-	nsmdpLogs, _ := k8s.GetLogs(nsmdPod, "nsmdp")
-	logrus.Errorf("===================== NSMD K8P %d output since test is failing %v\n=====================", k, nsmdpLogs)
+	nsmdUpdatedPod,err  := k8s.GetPod(nsmdPod)
+	if err != nil {
+		logrus.Errorf("Failed to update POD details %v", err)
+		return
+	}
+	for _, cs := range nsmdUpdatedPod.Status.ContainerStatuses {
+		containerLogs, _ := k8s.GetLogs(nsmdPod, cs.Name)
+		if cs.RestartCount > 0 {
+			prevLogs, _ := k8s.GetLogsWithOptions(nsmdPod, &v1.PodLogOptions{
+				Container: cs.Name,
+				Previous:  true,
+			})
+			logrus.Errorf("===================== %s %d previous output since test is failing %v\n=====================", strings.ToUpper(cs.Name), k, prevLogs)
+		}
+		logrus.Errorf("===================== %s %d output since test is failing %v\n=====================", strings.ToUpper(cs.Name), k, containerLogs)
+	}
+
 }
 
 type NSCCheckInfo struct {
@@ -483,6 +494,9 @@ type NSCCheckInfo struct {
 }
 
 func (info *NSCCheckInfo) PrintLogs() {
+	if info == nil {
+		return
+	}
 	logrus.Errorf("===================== NSC IP Addr %v\n=====================", info.ipResponse)
 	logrus.Errorf("===================== NSC IP Route %v\n=====================", info.routeResponse)
 	logrus.Errorf("===================== NSC IP PING %v\n=====================", info.pingResponse)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

1. Fixes one part of issue #919.
2. Enable execution of all tests.
3. Collect previous logs if container restarts on CI tests.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [ ] Covered by existing integration testing
- [x] Added integration testing to cover
- [x] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
