### PR TITLE
Fix little concurrent issue in TestExcludePrefixesMonitorFails

### DIFF
--- a/controlplane/pkg/tests/nsmd_test_utils.go
+++ b/controlplane/pkg/tests/nsmd_test_utils.go
@@ -157,7 +157,7 @@ type dummySubnetStream struct {
 func newDummySubnetStream() *dummySubnetStream {
 	return &dummySubnetStream{
 		isKilled:  false,
-		responses: make(chan *registry.SubnetExtendingResponse, 10),
+		responses: make(chan *registry.SubnetExtendingResponse),
 	}
 }
 


### PR DESCRIPTION
Signed-off-by: lobkovilya <ilya.lobkov@xored.com>

<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Tiny concurrent issue in TestExcludePrefixesMonitorFails, could be easily reproduced by adding 1s delay before receiving msg from SubnetMonitor. Leads to unstable behavior of mentioned test
## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [ ] Covered by existing integration testing
- [ ] Added integration testing to cover
- [X] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
