### PR TITLE
ci: always install latest kubectl

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -268,7 +268,6 @@ jobs:
             export COMMIT="${CIRCLE_SHA1:8:8}"
             export CONTAINER_TAG="${COMMIT}"
             # export CONTAINER_FORCE_PULL="true"
-            ./scripts/install-kubectl.sh
             cat /home/circleci/project/data/kubeconfig
             ./scripts/prepare-circle-integration-tests.sh
             mkdir -p ~/junit/

--- a/scripts/install-kubectl.sh
+++ b/scripts/install-kubectl.sh
@@ -1,9 +1,7 @@
 #!/usr/bin/env bash
 
-KUBECTL_VERSION=v1.14.1
-
-# Install kubectl
+# Install latest stable kubectl
 if ! command -v kubectl > /dev/null 2>&1; then
-	curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/"${KUBECTL_VERSION}"/bin/linux/amd64/kubectl && \
-		chmod +x "kubectl" && sudo mv "kubectl" /usr/local/bin/
+    curl -LO https://storage.googleapis.com/kubernetes-release/release/"$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)"/bin/linux/amd64/kubectl
+    chmod +x "kubectl" && sudo mv "kubectl" /usr/local/bin/
 fi


### PR DESCRIPTION
Signed-off-by: Nikolay Nikolaev <nnikolay@vmware.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
Do not fix the `kubectl` version in our test scripts, use the latest stable instead.

## Motivation and Context
Just stay up with the current version.

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [x] Covered by existing integration testing
- [ ] Added integration testing to cover
- [x] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
