### PR TITLE
Fix command value in k8s deployments

### DIFF
--- a/k8s/conf/icmp-responder-nse.yaml
+++ b/k8s/conf/icmp-responder-nse.yaml
@@ -43,7 +43,7 @@ spec:
           resources:
             limits:
               networkservicemesh.io/socket: 1
-          command: "/bin/icmp-responder-nse"
+          command: ["/bin/icmp-responder-nse"]
 metadata:
   name: icmp-responder-nse
   namespace: nsm-system

--- a/k8s/conf/vpn-gateway-nse.yaml
+++ b/k8s/conf/vpn-gateway-nse.yaml
@@ -41,7 +41,7 @@ spec:
           resources:
             limits:
               networkservicemesh.io/socket: 1
-          command: "/bin/icmp-responder-nse"
+          command: ["/bin/icmp-responder-nse"]
         - name: nginx
           image: networkservicemesh/nginx
 metadata:


### PR DESCRIPTION
Signed-off-by: Mathieu Rohon <mathieu.rohon@orange.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description

The command used in k8s deployments need to be in an array, not a single string

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [ ] Covered by existing integration testing
- [ ] Added integration testing to cover
- [x] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
