### PR TITLE
Clear leftover copies of docker images in Vagrant

### DIFF
--- a/.mk/vagrant.mk
+++ b/.mk/vagrant.mk
@@ -53,10 +53,10 @@ vagrant-%-load-images:
 	@if [ -e "scripts/vagrant/images/$*.tar" ]; then \
 		cd scripts/vagrant; \
 		echo "Loading image $*.tar to master"; \
-		vagrant ssh master -c "sudo docker load -i /vagrant/images/$*.tar" > /dev/null 2>&1; \
+		vagrant ssh master -c "sudo docker rmi networkservicemesh/$* -f && docker load -i /vagrant/images/$*.tar" > /dev/null 2>&1; \
 		number=1 ; while [[ $$number -le ${WORKER_COUNT} ]] ; do \
 			echo "Loading image $*.tar to worker$$number"; \
-			vagrant ssh worker$$number -c "sudo docker load -i /vagrant/images/$*.tar" ; \
+			vagrant ssh worker$$number -c "sudo docker rmi networkservicemesh/$* -f && docker load -i /vagrant/images/$*.tar" > /dev/null 2>&1; \
 			((number++)) ; \
 		done; \
 	else \


### PR DESCRIPTION
Signed-off-by: Radoslav Dimitrov <dimitrovr@vmware.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Clean the old, unnecessary images before loading the new ones.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When loading new images to a node, the old ones are renamed and left there consuming space.

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [ ] Covered by existing integration testing
- [ ] Added integration testing to cover
- [x] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.