### PR TITLE
Checking availability of k8s api server in case of error

### DIFF
--- a/test/integration/nsmd_test_utils/test_utils.go
+++ b/test/integration/nsmd_test_utils/test_utils.go
@@ -63,7 +63,7 @@ func SetupNodesConfig(k8s *kube_testing.K8s, nodesCount int, timeout time.Durati
 			debug := false
 			if i >= len(conf) {
 				corePod = pods.NSMgrPod(nsmdName, node, k8s.GetK8sNamespace())
-				dataplanePod = pods.VPPDataplanePodConfig(dataplaneName, node, defaultDataplaneVariables())
+				dataplanePod = pods.VPPDataplanePodConfig(dataplaneName, node, DefaultDataplaneVariables())
 			} else {
 				conf[i].Namespace = namespace
 				if conf[i].Nsmd == pods.NSMgrContainerDebug || conf[i].NsmdK8s == pods.NSMgrContainerDebug || conf[i].NsmdP == pods.NSMgrContainerDebug {
@@ -172,7 +172,7 @@ func defaultICMPEnv() map[string]string {
 }
 
 func defaultICMPCommand() []string {
-	return []string{ "/bin/icmp-responder-nse" }
+	return []string{"/bin/icmp-responder-nse"}
 }
 
 func defaultDirtyNSEEnv() map[string]string {
@@ -184,7 +184,7 @@ func defaultDirtyNSEEnv() map[string]string {
 }
 
 func defaultDirtyNSECommand() []string {
-	return []string{ "/bin/icmp-responder-nse", "--dirty" }
+	return []string{"/bin/icmp-responder-nse", "--dirty"}
 }
 
 func defaultNSCEnv() map[string]string {
@@ -468,7 +468,7 @@ func printDataplaneLogs(k8s *kube_testing.K8s, dataplane *v1.Pod, k int) {
 }
 
 func printNSMDLogs(k8s *kube_testing.K8s, nsmdPod *v1.Pod, k int) {
-	nsmdUpdatedPod,err  := k8s.GetPod(nsmdPod)
+	nsmdUpdatedPod, err := k8s.GetPod(nsmdPod)
 	if err != nil {
 		logrus.Errorf("Failed to update POD details %v", err)
 		return
@@ -557,11 +557,12 @@ func IsBrokeTestsEnabled() bool {
 	_, ok := os.LookupEnv("BROKEN_TESTS_ENABLED")
 	return ok
 }
-func defaultDataplaneVariables() map[string]string {
+func DefaultDataplaneVariables() map[string]string {
 	return map[string]string{
 		vppagent.DataplaneMetricsCollectorEnabledKey: "false",
 	}
 }
+
 func GetVppAgentNSEAddr(k8s *kube_testing.K8s, nsc *v1.Pod) (net.IP, error) {
 	return getNSEAddr(k8s, nsc, parseVppAgentAddr, "vppctl", "show int addr")
 }

--- a/test/integration/recover_death_handling_test.go
+++ b/test/integration/recover_death_handling_test.go
@@ -68,6 +68,7 @@ var NSENoHeal = &pods.NSMgrPodConfig{
 		nsm.NsmdHealDSTWaitTimeout:   "1",    // 1 second
 		nsm.NsmdHealEnabled:          "true",
 	},
+	DataplaneVariables: nsmd_test_utils.DefaultDataplaneVariables(),
 }
 
 func testDie(t *testing.T, killSrc bool, nodesCount int) {


### PR DESCRIPTION
Signed-off-by: lobkovilya <ilya.lobkov@xored.com>

<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Issue https://github.com/networkservicemesh/networkservicemesh/issues/1081 needs additional check to figure out whether the whole node is unavailable or api server only 
## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [ ] Covered by existing integration testing
- [ ] Added integration testing to cover
- [ ] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
