### PR TITLE
Add infinity number of attempts for create/update NSM

### DIFF
--- a/k8s/pkg/registryserver/discovery.go
+++ b/k8s/pkg/registryserver/discovery.go
@@ -37,9 +37,11 @@ func (d *discoveryService) FindNetworkService(ctx context.Context, request *regi
 	for i, endpoint := range endpointList {
 		NSEs[i] = mapNseFromCustomResource(endpoint, payload)
 		endpointIds = append(endpointIds, NSEs[i].EndpointName)
-		if nsm := d.cache.GetNetworkServiceManager(endpoint.Spec.NsmName); nsm != nil {
-			NSMs[endpoint.Spec.NsmName] = mapNsmFromCustomResource(nsm)
+		nsm, err := d.cache.GetNetworkServiceManager(endpoint.Spec.NsmName)
+		if err != nil {
+			return nil, err
 		}
+		NSMs[endpoint.Spec.NsmName] = mapNsmFromCustomResource(nsm)
 	}
 
 	var matches []*registry.Match

--- a/k8s/pkg/registryserver/nse.go
+++ b/k8s/pkg/registryserver/nse.go
@@ -71,9 +71,11 @@ func (rs *nseRegistryService) RegisterNSE(ctx context.Context, request *registry
 		}
 
 		request.NetworkserviceEndpoint = mapNseFromCustomResource(nseResponse, networkService.Spec.Payload)
-		if nsm := rs.cache.GetNetworkServiceManager(rs.nsmName); nsm != nil {
-			request.NetworkServiceManager = mapNsmFromCustomResource(nsm)
+		nsm, err := rs.cache.GetNetworkServiceManager(rs.nsmName)
+		if err != nil {
+			return nil, err
 		}
+		request.NetworkServiceManager = mapNsmFromCustomResource(nsm)
 	}
 	logrus.Infof("Returned from RegisterNSE: time: %v request: %v", time.Since(st), request)
 	return request, nil

--- a/k8s/pkg/registryserver/registry_cache.go
+++ b/k8s/pkg/registryserver/registry_cache.go
@@ -146,7 +146,7 @@ func (rc *registryCacheImpl) CreateOrUpdateNetworkServiceManager(nsm *v1.Network
 		if existingNsm == nil {
 			logrus.Infof("Creating NSM: %v", nsm)
 			newNsm, err := rc.addNetworkServiceManager(nsm)
-			if err == nil || (err != nil && !apierrors.IsAlreadyExists(err)) {
+			if err == nil || !apierrors.IsAlreadyExists(err) {
 				return newNsm, err
 			}
 
@@ -160,7 +160,7 @@ func (rc *registryCacheImpl) CreateOrUpdateNetworkServiceManager(nsm *v1.Network
 			updNsm := nsm.DeepCopy()
 			updNsm.ObjectMeta = existingNsm.ObjectMeta
 			updNsm, err := rc.updateNetworkServiceManager(updNsm)
-			if err == nil || (err != nil && !apierrors.IsConflict(err)) {
+			if err == nil || !apierrors.IsConflict(err) {
 				return updNsm, err
 			}
 

--- a/k8s/pkg/registryserver/registry_cache.go
+++ b/k8s/pkg/registryserver/registry_cache.go
@@ -134,11 +134,13 @@ func (rc *registryCacheImpl) GetEndpointsByNsm(nsmName string) []*v1.NetworkServ
 	return rc.networkServiceEndpointCache.GetByNetworkServiceManager(nsmName)
 }
 
+const maxAllowedAttempts = 10
+
 func (rc *registryCacheImpl) CreateOrUpdateNetworkServiceManager(nsm *v1.NetworkServiceManager) (*v1.NetworkServiceManager, error) {
 	existingNsm := rc.networkServiceManagerCache.Get(nsm.GetName())
 
 	attempt := 0
-	for {
+	for attempt < maxAllowedAttempts {
 		logrus.Infof("CreateOrUpdateNSM attempt %d: ", attempt)
 
 		if existingNsm == nil {
@@ -167,6 +169,8 @@ func (rc *registryCacheImpl) CreateOrUpdateNetworkServiceManager(nsm *v1.Network
 		}
 		attempt++
 	}
+
+	return nil, fmt.Errorf("exceeded the amount of attempts %d", maxAllowedAttempts)
 }
 
 func (rc *registryCacheImpl) addNetworkServiceManager(nsm *v1.NetworkServiceManager) (*v1.NetworkServiceManager, error) {

--- a/test/integration/basic_nsmd_k8s_test.go
+++ b/test/integration/basic_nsmd_k8s_test.go
@@ -74,9 +74,6 @@ func TestNSMDDRegistryNSE(t *testing.T) {
 	registryClient, err := serviceRegistry.NseRegistryClient()
 	Expect(err).To(BeNil())
 
-	// Cleanup all registered stuff
-	k8s.CleanupCRDs()
-
 	nses := []string{}
 	nme := "my-network-service"
 
@@ -442,4 +439,56 @@ func TestLostUpdate(t *testing.T) {
 	Expect(err).To(BeNil())
 	logrus.Info(nseResp)
 	Expect(getNsmUrl(discovery2)).ToNot(Equal(url1))
+}
+
+func TestRegistryConcurrentModification(t *testing.T) {
+	RegisterTestingT(t)
+
+	if testing.Short() {
+		t.Skip("Skip, please run without -short")
+		return
+	}
+
+	k8s, err := kube_testing.NewK8s(true)
+	defer k8s.Cleanup()
+	Expect(err).To(BeNil())
+
+	nsmgr1 := createSingleNsmgr(k8s, "nsmgr-1")
+
+	sr1, closeFunc := serviceRegistryAt(k8s, nsmgr1)
+	defer closeFunc()
+
+	nsmRegistryClient, err := sr1.NsmRegistryClient()
+	Expect(err).To(BeNil())
+
+	n := 100
+	errorCh := make(chan error)
+
+	// concurrent modification of k8s registry
+	go func() {
+		for i := 0; i < n; i++ {
+			url := fmt.Sprintf("1.1.1.%d:1", i)
+			_, err := nsmRegistryClient.RegisterNSM(context.Background(), &registry.NetworkServiceManager{
+				Url: url,
+			})
+			if err != nil {
+				errorCh <- err
+				break
+			}
+			logrus.Infof("RegisterNSM(%v)", url)
+			<-time.After(100 * time.Millisecond)
+		}
+		close(errorCh)
+	}()
+
+	for {
+		select {
+		case <-time.Tick(10 * time.Millisecond):
+			k8s.CleanupCRDs()
+			logrus.Info("CleanupCRDs")
+		case err := <-errorCh:
+			Expect(err).To(BeNil())
+			return
+		}
+	}
 }

--- a/test/integration/basic_nsmd_k8s_test.go
+++ b/test/integration/basic_nsmd_k8s_test.go
@@ -461,7 +461,7 @@ func TestRegistryConcurrentModification(t *testing.T) {
 	nsmRegistryClient, err := sr1.NsmRegistryClient()
 	Expect(err).To(BeNil())
 
-	n := 100
+	n := 30
 	errorCh := make(chan error)
 
 	// concurrent modification of k8s registry


### PR DESCRIPTION
Signed-off-by: lobkovilya <ilya.lobkov@xored.com>

<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Since k8s-registry doesn't support transactions and doesn't have kind of *createOrUpdate* method we can't atomically figure out resource existence and call appropriate (create/update) method. That's why we always can get error. I provided additional attempts during error handling

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [ ] Covered by existing integration testing
- [X] Added integration testing to cover
- [X] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
