### PR TITLE
AWS cluster destroy optimization

### DIFF
--- a/.circleci/cleanup-aws.sh
+++ b/.circleci/cleanup-aws.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
 ./scripts/aws/aws-init.sh
+kubectl delete svc --all --all-namespaces
 export NSM_AWS_SERVICE_SUFFIX="-${CLUSTER_ID}-${CIRCLE_WORKFLOW_ID}"
 make aws-destroy
-

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -193,7 +193,6 @@ jobs:
             export NSM_AWS_SERVICE_SUFFIX="-<< parameters.cluster_id >>-${CIRCLE_WORKFLOW_ID}"
             ./scripts/install-kubectl.sh
             make aws-start
-            cp ~/.kube/config data/kubeconfig
           no_output_timeout: 40m
       - save_cache:
           key: cncf-data-aws-<< parameters.cluster_id >>-{{.Environment.CIRCLE_WORKFLOW_ID}}
@@ -207,6 +206,10 @@ jobs:
           command: |
             export NSM_AWS_SERVICE_SUFFIX="-<< parameters.cluster_id >>-${CIRCLE_WORKFLOW_ID}"
             make aws-destroy
+    environment:
+      CLUSTER_ID: "<< parameters.cluster_id >>"
+      KUBECONFIG: /home/circleci/project/data/kubeconfig
+      GO111MODULE: "on"
 
   aws-destroy:
     parameters:
@@ -222,6 +225,10 @@ jobs:
           command: |
             ./scripts/install-kubectl.sh
             .circleci/cleanup-aws.sh
+    environment:
+      CLUSTER_ID: "<< parameters.cluster_id >>"
+      KUBECONFIG: /home/circleci/project/data/kubeconfig
+      GO111MODULE: "on"
 
 # gke
   gke-create-cluster:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -217,16 +217,11 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Install AWS Prerequisites
-          command: |
-            ./scripts/aws/aws-init.sh
-            sudo cp "$HOME/bin/aws-iam-authenticator" /usr/local/bin
-      - run:
           name: Destroy AWS Cluster
           no_output_timeout: 40m
           command: |
-            export NSM_AWS_SERVICE_SUFFIX="-<< parameters.cluster_id >>-${CIRCLE_WORKFLOW_ID}"
-            make aws-destroy
+            ./scripts/install-kubectl.sh
+            .circleci/cleanup-aws.sh
 
 # gke
   gke-create-cluster:
@@ -366,8 +361,8 @@ jobs:
               cp -a /home/circleci/project/terraform/terraform/* ./scripts/terraform/
               .circleci/cleanup-packet.sh
             elif [ "x<< parameters.cloud_provider >>" == "xaws" ]; then
-              export NSM_AWS_SERVICE_SUFFIX="-<< parameters.cluster_id >>-${CIRCLE_WORKFLOW_ID}"
-              make aws-destroy
+              ./scripts/install-kubectl.sh
+              .circleci/cleanup-aws.sh
             elif [ "x<< parameters.cloud_provider >>" == "xgke" ]; then
               .circleci/gke/cleanup-gke.sh "$GCLOUD_SERVICE_KEY" "${CIRCLE_SHA1:8:8}" "<< parameters.gke_project_id >>" "${CIRCLE_PR_NUMBER}" "dev-testing-${CIRCLE_SHA1:8:8}-<< parameters.cluster_id >>"
             elif [ "x<< parameters.cloud_provider >>" == "xazure" ]; then


### PR DESCRIPTION
AWS cluster destroy optimization

## Description
- Delete Kubernetes services before deleting cluster to allow resources to be properly released
- Remove AWS network interfaces first on EKS nodes deletion fail

## Motivation and Context
AWS cluster returns DELETE_FAILED status if resources are not properly released #1101

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [ ] Covered by existing integration testing
- [ ] Added integration testing to cover
- [x] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
