### PR TITLE
Skydive: switch to the official docker image

### DIFF
--- a/k8s/conf/skydive.yaml
+++ b/k8s/conf/skydive.yaml
@@ -33,7 +33,7 @@ data:
         driver: memory
 
     logging:
-      level: DEBUG
+      level: INFO
 
     agent:
       topology:
@@ -82,7 +82,7 @@ spec:
     spec:
       containers:
         - name: skydive-analyzer
-          image: matrohon/skydive
+          image: skydive/skydive:0.23.0
           imagePullPolicy: IfNotPresent
           args:
             - analyzer
@@ -128,7 +128,7 @@ spec:
       hostPID: true
       containers:
         - name: skydive-agent
-          image: matrohon/skydive
+          image: skydive/skydive:0.23.0
           imagePullPolicy: IfNotPresent
           args:
             - agent


### PR DESCRIPTION
Signed-off-by: Mathieu Rohon <mathieu.rohon@orange.com>

Switch to the official skydive docker image with the NSM probe
<!--- Provide a general summary of your changes in the Title above -->

## Description
The NSM probe is now included in skydive

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [ ] Covered by existing integration testing
- [ ] Added integration testing to cover
- [x] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
