### PR TITLE
Waiting for start of nsmdp instead of waiting for ListAndWatch calling

### DIFF
--- a/k8s/cmd/nsmdp/nsmdp.go
+++ b/k8s/cmd/nsmdp/nsmdp.go
@@ -318,5 +318,6 @@ func main() {
 		os.Exit(1)
 	}
 
+	logrus.Info("nsmdp: successfully started")
 	<-c
 }

--- a/test/integration/nsmd_test_utils/test_utils.go
+++ b/test/integration/nsmd_test_utils/test_utils.go
@@ -119,7 +119,7 @@ func deployNSMgrAndDataplane(k8s *kube_testing.K8s, node *v1.Node, corePods []*v
 	failures := InterceptGomegaFailures(func() {
 		k8s.WaitLogsContains(dataplane, "", "Sending MonitorMechanisms update", timeout)
 		k8s.WaitLogsContains(nsmd, "nsmd", "NSM gRPC API Server: [::]:5001 is operational", timeout)
-		k8s.WaitLogsContains(nsmd, "nsmdp", "ListAndWatch was called with", timeout)
+		k8s.WaitLogsContains(nsmd, "nsmdp", "nsmdp: successfully started", timeout)
 		k8s.WaitLogsContains(nsmd, "nsmd-k8s", "nsmd-k8s initialized and waiting for connection", timeout)
 	})
 	if len(failures) > 0 {

--- a/test/integration/recover_remote_nse_nsm_heal_test.go
+++ b/test/integration/recover_remote_nse_nsm_heal_test.go
@@ -75,7 +75,7 @@ func TestNSMHealRemoteDieNSMD_NSE(t *testing.T) {
 	startTime := time.Now()
 	nodes_setup[1].Nsmd = k8s.CreatePod(pods.NSMgrPodWithConfig(nsmdName, nodes_setup[1].Node, &pods.NSMgrPodConfig{Namespace: k8s.GetK8sNamespace()})) // Recovery NSEs
 	k8s.WaitLogsContains(nodes_setup[1].Nsmd, "nsmd", "NSM gRPC API Server: [::]:5001 is operational", defaultTimeout)
-	k8s.WaitLogsContains(nodes_setup[1].Nsmd, "nsmdp", "ListAndWatch was called with", defaultTimeout)
+	k8s.WaitLogsContains(nodes_setup[1].Nsmd, "nsmdp", "nsmdp: successfully started", defaultTimeout)
 	logrus.Printf("Started new NSMD: %v on node %s", time.Since(startTime), nodes_setup[1].Node.Name)
 
 	failures = InterceptGomegaFailures(func() {
@@ -142,7 +142,6 @@ func TestNSMHealRemoteDieNSMD(t *testing.T) {
 	nsmd_test_utils.PrintErrors(failures, k8s, nodes_setup, nscInfo, t)
 }
 
-
 func TestNSMHealRemoteDieNSMDFakeEndpoint(t *testing.T) {
 	RegisterTestingT(t)
 
@@ -201,7 +200,7 @@ func TestNSMHealRemoteDieNSMDFakeEndpoint(t *testing.T) {
 		},
 		NetworkserviceEndpoint: &registry.NetworkServiceEndpoint{
 			NetworkServiceName: "icmp-responder",
-			EndpointName: nseName,
+			EndpointName:       nseName,
 		},
 	})
 	Expect(err).To(BeNil())

--- a/test/integration/usecase_vpn_test.go
+++ b/test/integration/usecase_vpn_test.go
@@ -119,7 +119,7 @@ func testVPN(t *testing.T, ptnum, nodesCount int, affinity map[string]int, verbo
 		k8s.WaitLogsContains(nsmdDataplanePodNode[k], "", "Sending MonitorMechanisms update", defaultTimeout)
 		k8s.WaitLogsContains(nsmdPodNode[k], "nsmd", "Dataplane added", defaultTimeout)
 		k8s.WaitLogsContains(nsmdPodNode[k], "nsmd-k8s", "nsmd-k8s initialized and waiting for connection", defaultTimeout)
-		k8s.WaitLogsContains(nsmdPodNode[k], "nsmdp", "ListAndWatch was called with", defaultTimeout)
+		k8s.WaitLogsContains(nsmdPodNode[k], "nsmdp", "nsmdp: successfully started", defaultTimeout)
 	}
 
 	var nodesConf []*nsmd_test_utils.NodeConf


### PR DESCRIPTION
Signed-off-by: lobkovilya <ilya.lobkov@xored.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Seems like there is no guarantee that kubelet immediately call ListAndWatch. Now wait only registration of nsmdp.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://circleci.com/gh/networkservicemesh/networkservicemesh/52401

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [ ] Covered by existing integration testing
- [ ] Added integration testing to cover
- [ ] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
