### PR TITLE
Cleanup icmp-responder networkservice on k8s-icmp-responder-nse-delete

### DIFF
--- a/.mk/k8s.mk
+++ b/.mk/k8s.mk
@@ -154,6 +154,13 @@ k8s-%-delete:
 	@echo "Deleting ${K8S_CONF_DIR}/$*.yaml"
 	@$(kubectl) delete -f ${K8S_CONF_DIR}/$*.yaml > /dev/null 2>&1 || echo "$* does not exist and thus cannot be deleted"
 
+.PHONY: k8s-icmp-responder-nse-delete
+k8s-icmp-responder-nse-delete:
+	@echo "Deleting ${K8S_CONF_DIR}/icmp-responder-nse.yaml"
+	@$(kubectl) delete -f ${K8S_CONF_DIR}/icmp-responder-nse.yaml > /dev/null 2>&1 || echo "icmp-responder-nse does not exist and thus cannot be deleted"
+	@echo "Deleting networkservice icmp-responder"
+	@$(kubectl) delete networkservice icmp-responder > /dev/null 2>&1 || echo "icmp-responder does not exist and thus cannot be deleted"
+
 .PHONY: k8s-load-images
 k8s-load-images: $(addsuffix -load-images,$(addprefix k8s-,$(DEPLOYS)))
 


### PR DESCRIPTION
## Description
Cleanup `icmp-responder` networkservice on `make k8s-icmp-responder-nse-delete`

## Motivation and Context
Issue #1123 

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [ ] Covered by existing integration testing
- [ ] Added integration testing to cover
- [x] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
