### PR TITLE
Add tests to verify NetworkService and NSE deployment order

### DIFF
--- a/test/integration/usecase_deployment_order_test.go
+++ b/test/integration/usecase_deployment_order_test.go
@@ -102,12 +102,33 @@ func TestDeploymentOrderServiceClientEndpoint(t *testing.T) {
 		DeployEndpoint})
 }
 
+func TestDeploymentOrderService2ClientEndpoint(t *testing.T) {
+	testDeploymentOrder(t, []Deployment{
+		DeployService,
+		DeployClient, DeployClient,
+		DeployEndpoint})
+}
+
 func TestDeploymentOrderServiceClientEndpointClient(t *testing.T) {
 	testDeploymentOrder(t, []Deployment{
 		DeployService,
 		DeployClient,
 		DeployEndpoint,
 		DeployClient})
+}
+
+func TestDeploymentOrderServiceClientWebhookEndpoint(t *testing.T) {
+	testDeploymentOrder(t, []Deployment{
+		DeployService,
+		DeployClientWebhook,
+		DeployEndpoint})
+}
+
+func TestDeploymentOrderService4ClientWebhook2Endpoint(t *testing.T) {
+	testDeploymentOrder(t, []Deployment{
+		DeployService,
+		DeployClientWebhook, DeployClientWebhook, DeployClientWebhook, DeployClientWebhook,
+		DeployEndpoint, DeployEndpoint})
 }
 
 func testDeploymentOrder(t *testing.T, order []Deployment) {

--- a/test/integration/usecase_deployment_order_test.go
+++ b/test/integration/usecase_deployment_order_test.go
@@ -1,0 +1,180 @@
+// +build usecase
+
+package nsmd_integration_tests
+
+import (
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	nsapiv1 "github.com/networkservicemesh/networkservicemesh/k8s/pkg/apis/networkservice/v1alpha1"
+	"github.com/networkservicemesh/networkservicemesh/test/kubetest"
+	"github.com/networkservicemesh/networkservicemesh/test/kubetest/crds"
+	. "github.com/onsi/gomega"
+	"github.com/sirupsen/logrus"
+	v1 "k8s.io/api/core/v1"
+)
+
+type Deployment int
+
+const (
+	DeployService Deployment = iota
+	DeployEndpoint
+	DeployClient
+	DeployClientWebhook
+)
+
+func TestDeploymentOrder2EndpointClient(t *testing.T) {
+	testDeploymentOrder(t, []Deployment{
+		DeployEndpoint, DeployEndpoint,
+		DeployClient})
+}
+
+func TestDeploymentOrder2EndpointClientWebhook(t *testing.T) {
+	testDeploymentOrder(t, []Deployment{
+		DeployEndpoint, DeployEndpoint,
+		DeployClientWebhook})
+}
+
+func TestDeploymentOrder2EndpointClientAndWebhook(t *testing.T) {
+	testDeploymentOrder(t, []Deployment{
+		DeployEndpoint, DeployEndpoint,
+		DeployClient,
+		DeployClientWebhook})
+}
+
+func TestDeploymentOrder4EndpointClientAndWebhook(t *testing.T) {
+	testDeploymentOrder(t, []Deployment{
+		DeployEndpoint, DeployEndpoint, DeployEndpoint, DeployEndpoint,
+		DeployClient,
+		DeployClientWebhook})
+}
+
+func TestDeploymentOrderClientEndpoint(t *testing.T) {
+	testDeploymentOrder(t, []Deployment{
+		DeployClient,
+		DeployEndpoint})
+}
+
+func TestDeploymentOrder2ClientEndpoint(t *testing.T) {
+	testDeploymentOrder(t, []Deployment{
+		DeployClient, DeployClient,
+		DeployEndpoint})
+}
+
+func TestDeploymentOrder2Client2Endpoint(t *testing.T) {
+	testDeploymentOrder(t, []Deployment{
+		DeployClient, DeployClient,
+		DeployEndpoint, DeployEndpoint})
+}
+
+func TestDeploymentOrder4ClientEndpoint(t *testing.T) {
+	testDeploymentOrder(t, []Deployment{
+		DeployClient, DeployClient, DeployClient, DeployClient,
+		DeployEndpoint})
+}
+
+func TestDeploymentOrder4Client2Endpoint(t *testing.T) {
+	testDeploymentOrder(t, []Deployment{
+		DeployClient, DeployClient, DeployClient, DeployClient,
+		DeployEndpoint, DeployEndpoint})
+}
+
+func TestDeploymentOrderServiceEndpointClient(t *testing.T) {
+	testDeploymentOrder(t, []Deployment{
+		DeployService,
+		DeployEndpoint,
+		DeployClient})
+}
+
+func TestDeploymentOrderService2Endpoint4Client(t *testing.T) {
+	testDeploymentOrder(t, []Deployment{
+		DeployService,
+		DeployEndpoint, DeployEndpoint,
+		DeployClient, DeployClient, DeployClient, DeployClient})
+}
+
+func TestDeploymentOrderServiceClientEndpoint(t *testing.T) {
+	testDeploymentOrder(t, []Deployment{
+		DeployService,
+		DeployClient,
+		DeployEndpoint})
+}
+
+func TestDeploymentOrderServiceClientEndpointClient(t *testing.T) {
+	testDeploymentOrder(t, []Deployment{
+		DeployService,
+		DeployClient,
+		DeployEndpoint,
+		DeployClient})
+}
+
+func testDeploymentOrder(t *testing.T, order []Deployment) {
+	RegisterTestingT(t)
+
+	if testing.Short() {
+		t.Skip("Skip, please run without -short")
+		return
+	}
+
+	k8s, err := kubetest.NewK8s(true)
+	defer k8s.Cleanup()
+
+	Expect(err).To(BeNil())
+
+	for _, deploy := range order {
+		if deploy == DeployClientWebhook {
+			awc, awDeployment, awService := kubetest.DeployAdmissionWebhook(k8s, "nsm-admission-webhook", "networkservicemesh/admission-webhook", k8s.GetK8sNamespace())
+			defer kubetest.DeleteAdmissionWebhook(k8s, "nsm-admission-webhook-certs", awc, awDeployment, awService, k8s.GetK8sNamespace())
+			break
+		}
+	}
+
+	_, err = kubetest.SetupNodes(k8s, 1, defaultTimeout)
+	Expect(err).To(BeNil())
+
+	var nseCount uint64
+	var nscPods []*v1.Pod
+	var nscCount uint64
+	var waitgroup sync.WaitGroup
+	var scheduled = make(chan interface{})
+
+	for _, deploy := range order {
+		waitgroup.Add(1)
+
+		go func() {
+			scheduled <- true
+			defer func() { waitgroup.Done() }()
+			switch deploy {
+			case DeployService:
+				nscrd, err := crds.NewNSCRD(k8s.GetK8sNamespace())
+				Expect(err).To(BeNil())
+				nsIcmpResponder := crds.IcmpResponder(map[string]string{}, map[string]string{"app": "icmp"})
+				logrus.Printf("About to insert: %v", nsIcmpResponder)
+				var result *nsapiv1.NetworkService
+				result, err = nscrd.Create(nsIcmpResponder)
+				Expect(err).To(BeNil())
+				logrus.Printf("CRD applied with result: %v", result)
+				result, err = nscrd.Get(nsIcmpResponder.ObjectMeta.Name)
+				Expect(err).To(BeNil())
+				logrus.Printf("Registered CRD is: %v", result)
+			case DeployEndpoint:
+				kubetest.DeployICMP(k8s, nil, "nse-"+strconv.FormatUint(atomic.AddUint64(&nseCount, 1), 10), defaultTimeout)
+			case DeployClient:
+				nscPods = append(nscPods, kubetest.DeployNSC(k8s, nil, "nsc-"+strconv.FormatUint(atomic.AddUint64(&nscCount, 1), 10), defaultTimeout))
+			case DeployClientWebhook:
+				nscPods = append(nscPods, kubetest.DeployNSCWebhook(k8s, nil, "nsc-webhook-"+strconv.FormatUint(atomic.AddUint64(&nscCount, 1), 10), defaultTimeout))
+			}
+		}()
+		// ensure the deplyment routine is scheduled
+		<-scheduled
+	}
+
+	// wait for all deployment routines to end
+	waitgroup.Wait()
+
+	for _, p := range nscPods {
+		kubetest.CheckNSC(k8s, p)
+	}
+}

--- a/test/kubetest/crds/icmpresponder.go
+++ b/test/kubetest/crds/icmpresponder.go
@@ -1,0 +1,49 @@
+// Copyright 2019 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package crds
+
+import (
+	v12 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	nsapiv1 "github.com/networkservicemesh/networkservicemesh/k8s/pkg/apis/networkservice/v1alpha1"
+)
+
+// IcmpResponder creates a NetworkService
+func IcmpResponder(sourceSelector, destinationSelector map[string]string) *nsapiv1.NetworkService {
+	ns := &nsapiv1.NetworkService{
+		TypeMeta: v12.TypeMeta{
+			APIVersion: "networkservicemesh.io/v1alpha1",
+			Kind:       "NetworkService",
+		},
+		ObjectMeta: v12.ObjectMeta{
+			Name: "icmp-responder",
+		},
+		Spec: nsapiv1.NetworkServiceSpec{
+			Payload: "IP",
+			Matches: []*nsapiv1.Match{
+				&nsapiv1.Match{
+					SourceSelector: sourceSelector,
+					Routes: []*nsapiv1.Destination{
+						&nsapiv1.Destination{
+							DestinationSelector: destinationSelector,
+						},
+					},
+				},
+			},
+		},
+	}
+	return ns
+}

--- a/test/kubetest/crds/secureintranetconnectivity.go
+++ b/test/kubetest/crds/secureintranetconnectivity.go
@@ -1,0 +1,87 @@
+// Copyright 2019 VMware, Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package crds
+
+import (
+	"strconv"
+
+	v12 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	nsapiv1 "github.com/networkservicemesh/networkservicemesh/k8s/pkg/apis/networkservice/v1alpha1"
+)
+
+// SecureIntranetConnectivity creates a NetworkService
+func SecureIntranetConnectivity(ptnum int) *nsapiv1.NetworkService {
+	ns := &nsapiv1.NetworkService{
+		TypeMeta: v12.TypeMeta{
+			APIVersion: "networkservicemesh.io/v1alpha1",
+			Kind:       "NetworkService",
+		},
+		ObjectMeta: v12.ObjectMeta{
+			Name: "secure-intranet-connectivity",
+		},
+		Spec: nsapiv1.NetworkServiceSpec{
+			Payload: "IP",
+			Matches: []*nsapiv1.Match{
+				&nsapiv1.Match{
+					SourceSelector: map[string]string{
+						"app": "firewall",
+					},
+					Routes: []*nsapiv1.Destination{
+						&nsapiv1.Destination{
+							DestinationSelector: map[string]string{
+								"app": "vpn-gateway",
+							},
+						},
+					},
+				},
+				&nsapiv1.Match{
+					Routes: []*nsapiv1.Destination{
+						&nsapiv1.Destination{
+							DestinationSelector: map[string]string{
+								"app": "firewall",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	matches := ns.Spec.Matches
+	for i := 0; i < ptnum; i++ {
+		id := strconv.Itoa(i + 1)
+		dest := matches[i].Routes[0].DestinationSelector["app"]
+		matches[i].Routes[0].DestinationSelector["app"] = "passthrough-" + id
+
+		m := &nsapiv1.Match{
+			SourceSelector: map[string]string{
+				"app": "passthrough-" + id,
+			},
+			Routes: []*nsapiv1.Destination{
+				&nsapiv1.Destination{
+					DestinationSelector: map[string]string{
+						"app": dest,
+					},
+				},
+			},
+		}
+
+		t := append([]*nsapiv1.Match{m}, matches[i+1:]...)
+		matches = append(matches[:i+1], t...)
+	}
+	ns.Spec.Matches = matches
+	return ns
+}

--- a/test/kubetest/utils.go
+++ b/test/kubetest/utils.go
@@ -268,6 +268,19 @@ func deployICMP(k8s *K8s, nodeName, name string, timeout time.Duration, template
 	return icmp
 }
 
+func deployDirtyNSE(k8s *K8s, nodeName, name string, timeout time.Duration, template *v1.Pod) *v1.Pod {
+	startTime := time.Now()
+
+	logrus.Infof("Starting dirty NSE on node: %s", nodeName)
+	dirty := k8s.CreatePod(template)
+	Expect(dirty.Name).To(Equal(name))
+
+	k8s.WaitLogsContains(dirty, "", "NSE: channel has been successfully advertised, waiting for connection from NSM...", timeout)
+
+	logrus.Printf("Dirty NSE %v started done: %v", name, time.Since(startTime))
+	return dirty
+}
+
 func deployNSC(k8s *K8s, nodeName, name, container string, timeout time.Duration, template *v1.Pod) *v1.Pod {
 	startTime := time.Now()
 	Expect(template).ShouldNot(BeNil())

--- a/test/kubetest/utils.go
+++ b/test/kubetest/utils.go
@@ -268,19 +268,6 @@ func deployICMP(k8s *K8s, nodeName, name string, timeout time.Duration, template
 	return icmp
 }
 
-func deployDirtyNSE(k8s *K8s, nodeName, name string, timeout time.Duration, template *v1.Pod) *v1.Pod {
-	startTime := time.Now()
-
-	logrus.Infof("Starting dirty NSE on node: %s", nodeName)
-	dirty := k8s.CreatePod(template)
-	Expect(dirty.Name).To(Equal(name))
-
-	k8s.WaitLogsContains(dirty, "", "NSE: channel has been successfully advertised, waiting for connection from NSM...", timeout)
-
-	logrus.Printf("Dirty NSE %v started done: %v", name, time.Since(startTime))
-	return dirty
-}
-
 func deployNSC(k8s *K8s, nodeName, name, container string, timeout time.Duration, template *v1.Pod) *v1.Pod {
 	startTime := time.Now()
 	Expect(template).ShouldNot(BeNil())


### PR DESCRIPTION

## Description
This PR adds tests to verify how NetworkService, NSE and NSC deployment order changes NSM behaviour.

## Motivation and Context
We need to ensure that NSM can operate no matter the deployment order.

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [ ] Covered by existing integration testing
- [x] Added integration testing to cover
- [x] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
