### PR TITLE
Add timeout for retrying to get logs after failure

### DIFF
--- a/test/kubetest/k8s.go
+++ b/test/kubetest/k8s.go
@@ -683,9 +683,11 @@ func (l *K8s) waitLogsMatch(ctx context.Context, pod *v1.Pod, container string, 
 		case err := <-errChan:
 			if err != nil {
 				logrus.Warnf("Error on get logs: %v retrying", err)
-				linesChan, errChan = l.GetLogsChannel(ctx, pod, options)
-				continue
+			} else {
+				logrus.Warnf("Reached end of logs for %v::%v", pod.GetName(), container)
 			}
+			<-time.After(100 * time.Millisecond)
+			linesChan, errChan = l.GetLogsChannel(ctx, pod, options)
 		case line := <-linesChan:
 			_, _ = builder.WriteString(line)
 			_, _ = builder.WriteString("\n")


### PR DESCRIPTION
## Description
Add timeout for retrying to get logs after failure

## Motivation and Context
Issue #1178 

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [x] Covered by existing integration testing
- [ ] Added integration testing to cover
- [ ] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
