### PR TITLE
Fix dadfailure when configured with IPv6

### DIFF
--- a/dataplane/vppagent/pkg/converter/kernel_connection_converter.go
+++ b/dataplane/vppagent/pkg/converter/kernel_connection_converter.go
@@ -109,7 +109,6 @@ func (c *KernelConnectionConverter) ToDataRequest(rv *configurator.Config, conne
 			Name:        c.conversionParameters.Name + "-veth",
 			Type:        linux_interfaces.Interface_VETH,
 			Enabled:     true,
-			IpAddresses: ipAddresses,
 			HostIfName:  c.conversionParameters.Name + "-veth",
 			Link: &linux_interfaces.Interface_Veth{
 				Veth: &linux_interfaces.VethLink{


### PR DESCRIPTION
Both ends of the VETH pair were assigned with the same IP address

Signed-off-by: Radoslav Dimitrov <dimitrovr@vmware.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Some of the IPv6 tests were failing sporadically due to a strange race condition caused by the fact that we assign the same IP address on both ends of the VETH pair. 
This was causing the IPv6 interface to stay in a `tentative` and `dadfailed` state.

The solution is to assign an address only to the VETH end that will be used in the container.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Related to https://github.com/networkservicemesh/networkservicemesh/issues/1191

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [x] Covered by existing integration testing
- [ ] Added integration testing to cover
- [x] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.