### PR TITLE
Extend timeout for AWS destroy on failed tests (#1198)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -403,6 +403,7 @@ jobs:
             fi
       - run:
           when: on_fail
+          no_output_timeout: 40m
           command: |
             if [ "x<< parameters.cloud_provider >>" == "xpacket" ]; then
               cp -a /home/circleci/project/terraform/terraform/* ./scripts/terraform/


### PR DESCRIPTION
Extend timeout for AWS destroy on failed tests
Signed-off-by: Artem Belov <artem.belov@xored.com>

## Description
Extend timeout for AWS destroy on failed tests

## Motivation and Context
#1198

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [ ] Covered by existing integration testing
- [ ] Added integration testing to cover
- [ ] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
