### PR TITLE
Add nil check for received event

### DIFF
--- a/controlplane/pkg/monitor/monitor_client.go
+++ b/controlplane/pkg/monitor/monitor_client.go
@@ -17,16 +17,16 @@ type EventStreamConstructor func(ctx context.Context, cc *grpc.ClientConn) (Even
 
 // Client is an unified interface for GRPC monitoring API client
 type Client interface {
-	ErrorChannel() chan error
-	EventChannel() chan Event
+	ErrorChannel() <-chan error
+	EventChannel() <-chan Event
 
 	Context() context.Context
 	Close()
 }
 
 type client struct {
-	eventCh chan Event
-	errorCh chan error
+	eventCh <-chan Event
+	errorCh <-chan error
 
 	ctx    context.Context
 	cancel context.CancelFunc
@@ -72,12 +72,12 @@ func NewClient(cc *grpc.ClientConn, eventFactory EventFactory, streamConstructor
 }
 
 // ErrorChannel returns client errorChannel
-func (c *client) ErrorChannel() chan error {
+func (c *client) ErrorChannel() <-chan error {
 	return c.errorCh
 }
 
 // EventChannel returns client eventChannel
-func (c *client) EventChannel() chan Event {
+func (c *client) EventChannel() <-chan Event {
 	return c.eventCh
 }
 

--- a/controlplane/pkg/nsmd/nsmd_crossconnect_client.go
+++ b/controlplane/pkg/nsmd/nsmd_crossconnect_client.go
@@ -232,16 +232,18 @@ func (client *NsmMonitorCrossConnectClient) monitor(
 			logrus.Errorf(logWithParamFormat, name, "Connection closed", err)
 			return err
 		case event := <-monitorClient.EventChannel():
-			logrus.Infof(logWithParamFormat, name, "Received event", event)
-			for _, entity := range event.Entities() {
-				if err = entityHandler(entity, event.EventType()); err != nil {
-					logrus.Errorf(logWithParamFormat, name, "Error handling entity", err)
+			if event != nil {
+				logrus.Infof(logWithParamFormat, name, "Received event", event)
+				for _, entity := range event.Entities() {
+					if err = entityHandler(entity, event.EventType()); err != nil {
+						logrus.Errorf(logWithParamFormat, name, "Error handling entity", err)
+					}
 				}
-			}
 
-			if eventHandler != nil {
-				if err = eventHandler(event); err != nil {
-					logrus.Errorf(logWithParamFormat, name, "Error handling event", err)
+				if eventHandler != nil {
+					if err = eventHandler(event); err != nil {
+						logrus.Errorf(logWithParamFormat, name, "Error handling event", err)
+					}
 				}
 			}
 		}


### PR DESCRIPTION
## Description
Add `nil` check for event receiving in `nsmd_crossconnect_client`.

## Motivation and Context
Sometimes `monitorClient.EventChannel()` is getting closed at the same time with last error sent in `monitorClient.ErrorChannel()` and `select` breaks on event channel.
```
select {
		case <-ctx.Done():
			logrus.Infof(logFormat, name, "Removed")
			return nil
		case err = <-monitorClient.ErrorChannel():
			...
		case event := <-monitorClient.EventChannel():
			...
		}
```
https://circleci.com/gh/networkservicemesh/networkservicemesh/65816

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [ ] Covered by existing integration testing
- [ ] Added integration testing to cover
- [x] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
