### PR TITLE
remove node selection going to master

### DIFF
--- a/deployments/helm/vpn/templates/vpn-gateway-nsc.tpl
+++ b/deployments/helm/vpn/templates/vpn-gateway-nsc.tpl
@@ -13,8 +13,6 @@ spec:
         networkservicemesh.io/app: "vpn-gateway-nsc"
         networkservicemesh.io/impl: "secure-intranet-connectivity"
     spec:
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
       containers:
         - name: alpine-img
           image: alpine:latest


### PR DESCRIPTION
hardcoded nodeselection to master might fail in all kubernetes services

<!--- Provide a general summary of your changes in the Title above -->

## Description
removed the node selection spec.

## Motivation and Context
Deployment of a helm chart on managed k8s platforms will fail.