### PR TITLE
Make kernel interface converter have a GW

### DIFF
--- a/dataplane/vppagent/pkg/converter/kernel_connection_converter.go
+++ b/dataplane/vppagent/pkg/converter/kernel_connection_converter.go
@@ -151,7 +151,8 @@ func (c *KernelConnectionConverter) ToDataRequest(rv *configurator.Config, conne
 			rv.LinuxConfig.Routes = append(rv.LinuxConfig.Routes, &linux.Route{
 				DstNetwork:        route.Prefix,
 				OutgoingInterface: c.conversionParameters.Name,
-				Scope:             linux_l3.Route_LINK,
+				Scope:             linux_l3.Route_GLOBAL,
+				GwAddr:            extractCleanIPAddress(c.Connection.GetContext().DstIpAddr),
 			})
 		}
 	}


### PR DESCRIPTION
Plus make the supplied routes global and not LINK local

Signed-off-by: Nikolay Nikolaev <nnikolay@vmware.com>


## Description
Make sure that when the vpp-agent injects the interfaces it also sets a GW for the supplied routes. Also, the routes are not really Link Local in the broader sense. The patch is inspired by the memif converter approach to routes.

## Motivation and Context
When a Linux (kernel) client get its routes it does not have a GW for them. Make that GW to be the DST IP in the link, effectively the endpoint.

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [x] Covered by existing integration testing
- [ ] Added integration testing to cover
- [x] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
