### PR TITLE
vppagent-icmp-responder-nse: Initialize the allocation pool correctly

### DIFF
--- a/k8s/conf/vppagent-icmp-responder-nse.yaml
+++ b/k8s/conf/vppagent-icmp-responder-nse.yaml
@@ -41,7 +41,7 @@ spec:
             - name: TRACER_ENABLED
               value: "true"
             - name: IP_ADDRESS
-              value: "10.30.1.1"
+              value: "10.30.1.0/24"
           resources:
             limits:
               networkservicemesh.io/socket: 1


### PR DESCRIPTION
closes #1301

Signed-off-by: Mathieu Rohon <mathieu.rohon@orange.com>

The IPAddress in the vppagent-icmp-responder-nse yaml file must be a prefix

## Motivation and Context

Fix the crash described in 1301

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [ ] Covered by existing integration testing
- [ ] Added integration testing to cover
- [x] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
