### PR TITLE
Fix deleting testing clusters

### DIFF
--- a/test/cloudtest/pkg/commands/main.go
+++ b/test/cloudtest/pkg/commands/main.go
@@ -119,6 +119,7 @@ type executionContext struct {
 	clusterReadyTime time.Time
 	factory          k8s.ValidationFactory
 	arguments        *Arguments
+	clusterWaitGroup sync.WaitGroup // Wait group for clusters destroying
 }
 
 // CloudTestRun - CloudTestRun
@@ -223,7 +224,6 @@ func parseConfig(cloudTestConfig *config.CloudTestConfig, configFileContent []by
 func (ctx *executionContext) performShutdown() {
 	// We need to stop all clusters we started
 	if !ctx.arguments.instanceOptions.NoStop {
-		var wg sync.WaitGroup
 		for _, clG := range ctx.clusters {
 			group := clG
 			for _, cInst := range group.instances {
@@ -233,16 +233,16 @@ func (ctx *executionContext) performShutdown() {
 					curInst.taskCancel()
 				}
 				logrus.Infof("Schedule Closing cluster %v %v", group.config.Name, curInst.id)
-				wg.Add(1)
+				ctx.clusterWaitGroup.Add(1)
 
 				go func() {
-					defer wg.Done()
+					defer ctx.clusterWaitGroup.Done()
 					logrus.Infof("Closing cluster %v %v", group.config.Name, curInst.id)
 					ctx.destroyCluster(curInst, false, false)
 				}()
 			}
 		}
-		wg.Wait()
+		ctx.clusterWaitGroup.Wait()
 	}
 	logrus.Infof("All clusters destroyed")
 }
@@ -784,7 +784,9 @@ func (ctx *executionContext) destroyCluster(ci *clusterInstance, sendUpdate, for
 	}
 	timeout := ctx.getClusterTimeout(ci.group)
 	if fork {
+		ctx.clusterWaitGroup.Add(1)
 		go func() {
+			defer ctx.clusterWaitGroup.Done()
 			err := ci.instance.Destroy(timeout)
 			if err != nil {
 				logrus.Errorf("Failed to destroy cluster")


### PR DESCRIPTION
Signed-off-by: Artem Belov <artem.belov@xored.com>

## Description
Wait for deleting cluster goroutine is finished before finish testing

## Motivation and Context
AWS leaking resources #1306

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [ ] Covered by existing integration testing
- [ ] Added integration testing to cover
- [x] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
