### PR TITLE
Fix skydive issues with latest nsm libs and deployments

### DIFF
--- a/deployments/helm/nsm-monitoring/templates/skydive.tpl
+++ b/deployments/helm/nsm-monitoring/templates/skydive.tpl
@@ -109,6 +109,26 @@ spec:
           configMap:
             name: skydive-analyzer-config-file
 ---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: skydive-agent-config-file
+  namespace: nsm-system
+data:
+  skydive.yml: |
+    logging:
+      level: INFO
+
+    agent:
+      topology:
+        probes:
+          - docker
+
+      docker:
+        netns:
+          run_path: /var/run/netns
+
+---
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -129,7 +149,7 @@ spec:
       hostPID: true
       containers:
         - name: skydive-agent
-          image: skydive/skydive:0.23.0
+          image: skydive/skydive:0.24.0
           imagePullPolicy: {{ .Values.pullPolicy }}
           args:
             - agent
@@ -144,11 +164,17 @@ spec:
             - name: docker
               mountPath: /var/run/docker.sock
             - name: run
-              mountPath: /host/run
+              mountPath: /var/run/netns
+            - name: skydive-agent-config-file
+              mountPath: /etc/skydive.yml
+              subPath: skydive.yml
       volumes:
         - name: docker
           hostPath:
             path: /var/run/docker.sock
         - name: run
           hostPath:
-            path: /var/run/netns
+            path: /var/run/docker/netns
+        - name: skydive-agent-config-file
+          configMap:
+            name: skydive-agent-config-file

--- a/k8s/conf/skydive.yaml
+++ b/k8s/conf/skydive.yaml
@@ -116,7 +116,7 @@ metadata:
 data:
   skydive.yml: |
     logging:
-      level: DEBUG
+      level: INFO
 
     agent:
       topology:

--- a/k8s/conf/skydive.yaml
+++ b/k8s/conf/skydive.yaml
@@ -82,7 +82,7 @@ spec:
     spec:
       containers:
         - name: skydive-analyzer
-          image: matrohon/skydive:latest
+          image: skydive/skydive:0.24.0
           imagePullPolicy: IfNotPresent
           args:
             - analyzer
@@ -148,7 +148,7 @@ spec:
       hostPID: true
       containers:
         - name: skydive-agent
-          image: matrohon/skydive:latest
+          image: skydive/skydive:0.24.0
           imagePullPolicy: IfNotPresent
           args:
             - agent

--- a/k8s/conf/skydive.yaml
+++ b/k8s/conf/skydive.yaml
@@ -82,7 +82,7 @@ spec:
     spec:
       containers:
         - name: skydive-analyzer
-          image: skydive/skydive:0.23.0
+          image: matrohon/skydive:latest
           imagePullPolicy: IfNotPresent
           args:
             - analyzer
@@ -108,6 +108,26 @@ spec:
           configMap:
             name: skydive-analyzer-config-file
 ---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: skydive-agent-config-file
+  namespace: nsm-system
+data:
+  skydive.yml: |
+    logging:
+      level: DEBUG
+
+    agent:
+      topology:
+        probes:
+          - docker
+
+      docker:
+        netns:
+          run_path: /var/run/netns
+
+---
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -128,7 +148,7 @@ spec:
       hostPID: true
       containers:
         - name: skydive-agent
-          image: skydive/skydive:0.23.0
+          image: matrohon/skydive:latest
           imagePullPolicy: IfNotPresent
           args:
             - agent
@@ -143,11 +163,17 @@ spec:
             - name: docker
               mountPath: /var/run/docker.sock
             - name: run
-              mountPath: /host/run
+              mountPath: /var/run/netns
+            - name: skydive-agent-config-file
+              mountPath: /etc/skydive.yml
+              subPath: skydive.yml
       volumes:
         - name: docker
           hostPath:
             path: /var/run/docker.sock
         - name: run
           hostPath:
-            path: /var/run/netns
+            path: /var/run/docker/netns
+        - name: skydive-agent-config-file
+          configMap:
+            name: skydive-agent-config-file


### PR DESCRIPTION
Signed-off-by: Mathieu Rohon <mathieu.rohon@orange.com>

Since the move of nsm API to v1alpha1, skydive is not able to fetch data from nsmgr.
A PR is trying to fix the issue upstream: https://github.com/skydive-project/skydive/pull/1875
Until this PR merges, I propose to fetch the skydive image from an alternative hub.docker repository.

Nsm is also using containerd+docker for vagrant deployment. The skydive configuration file need to be adapted to find netns.

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [ ] Covered by existing integration testing
- [ ] Added integration testing to cover
- [x] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
