### PR TITLE
Fix the name of init container by setting the proper env

### DIFF
--- a/.mk/k8s.mk
+++ b/.mk/k8s.mk
@@ -80,6 +80,9 @@ endif
 ifeq ($(CONTAINER_REPO),)
 CONTAINER_REPO=networkservicemesh
 endif
+ifeq ($(CONTAINER_TAG),)
+CONTAINER_TAG=latest
+endif
 
 kubectl = kubectl -n ${NSM_NAMESPACE}
 
@@ -113,7 +116,8 @@ k8s-admission-webhook-deploy:  k8s-start k8s-config k8s-admission-webhook-delete
 	@until ! $$($(kubectl) get pods | grep -q ^admission-webhook ); do echo "Wait for admission-webhook to terminate"; sleep 1; done
 	@sed "s;\(image:[ \t]*\)\(networkservicemesh\)\(/[^:]*\).*;\1${CONTAINER_REPO}\3$${COMMIT/$${COMMIT}/:$${COMMIT}};" ${K8S_CONF_DIR}/admission-webhook.yaml \
 		| sed "N; s/\(name:[ \t]*TAG\n[ \t]*value:[ \t]*\).*/\1\"${COMMIT}\"/" \
-		| sed 's;value: "networkservicemesh";value: "networkservicemeshci";' \
+		| sed 's;value: "networkservicemesh";value: "${CONTAINER_REPO}";' \
+		| sed 's;value: "latest";value: "${CONTAINER_TAG}";' \
 		| $(kubectl) apply -f -
 	@echo "Installing webhook..."
 	@cat ./k8s/conf/admission-webhook-cfg.yaml | ./scripts/webhook-patch-ca-bundle.sh | $(kubectl) apply -f -

--- a/k8s/cmd/admission-webhook/utils.go
+++ b/k8s/cmd/admission-webhook/utils.go
@@ -3,17 +3,18 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
+	"net/http"
+
 	"github.com/go-errors/errors"
 	"github.com/networkservicemesh/networkservicemesh/pkg/tools"
 	"github.com/networkservicemesh/networkservicemesh/sdk/client"
 	"github.com/sirupsen/logrus"
-	"io/ioutil"
 	"k8s.io/api/admission/v1beta1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"net/http"
 )
 
 type podSpecAndMeta struct {
@@ -70,8 +71,9 @@ func createInitContainerPatch(annotationValue, path string) []patchOperation {
 	var patch []patchOperation
 
 	value := []corev1.Container{{
-		Name:  initContainerName,
-		Image: fmt.Sprintf("%s/%s:%s", getRepo(), getInitContainer(), getTag()),
+		Name:            initContainerName,
+		Image:           fmt.Sprintf("%s/%s:%s", getRepo(), getInitContainer(), getTag()),
+		ImagePullPolicy: corev1.PullIfNotPresent,
 		Env: []corev1.EnvVar{{
 			Name:  client.AnnotationEnv,
 			Value: annotationValue,

--- a/k8s/conf/admission-webhook.yaml
+++ b/k8s/conf/admission-webhook.yaml
@@ -20,10 +20,10 @@ spec:
           image: networkservicemesh/admission-webhook
           imagePullPolicy: IfNotPresent
           env:
-            - name: TAG
-              value: "latest"
             - name: REPO
               value: "networkservicemesh"
+            - name: TAG
+              value: "latest"
           volumeMounts:
             - name: webhook-certs
               mountPath: /etc/webhook/certs


### PR DESCRIPTION
Also, set the ImagePullPolicy to PullIfNotPresent

Signed-off-by: Nikolay Nikolaev <nnikolay@vmware.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixes #1342 

## Motivation and Context
After the introduction of the new repo networkservicemeshci and the new methodology where we do not have "latest" the admission webhook is having issues deploying the right images for the init container.

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [x] Covered by existing integration testing
- [ ] Added integration testing to cover
- [x] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
