### PR TITLE
CloudTest should fail if test find are failed

### DIFF
--- a/test/cloudtest/pkg/commands/main.go
+++ b/test/cloudtest/pkg/commands/main.go
@@ -923,7 +923,7 @@ func (ctx *executionContext) findShellTest(exec *config.ExecutionConfig) []*mode
 	}
 }
 
-func (ctx *executionContext) findGoTest(executionConfig *config.ExecutionConfig) ([]*model.TestEntry,error) {
+func (ctx *executionContext) findGoTest(executionConfig *config.ExecutionConfig) ([]*model.TestEntry, error) {
 	st := time.Now()
 	logrus.Infof("Starting finding tests by tags %v", executionConfig.Tags)
 	execTests, err := model.GetTestConfiguration(ctx.manager, executionConfig.PackageRoot, executionConfig.Tags)

--- a/test/cloudtest/pkg/model/tests.go
+++ b/test/cloudtest/pkg/model/tests.go
@@ -85,7 +85,7 @@ func GetTestConfiguration(manager execmanager.ExecutionManager, root string, tag
 func getTests(manager execmanager.ExecutionManager, gotestCmd []string, tag string) (map[string]*TestEntry, error) {
 	result, err := utils.ExecRead(context.Background(), gotestCmd)
 	if err != nil {
-		logrus.Errorf("Error getting list of tests %v", err)
+		logrus.Errorf("Error getting list of tests: %v\nOutput: %v\nCmdLine: %v", err, result, gotestCmd)
 		return nil, err
 	}
 

--- a/test/cloudtest/pkg/utils/process.go
+++ b/test/cloudtest/pkg/utils/process.go
@@ -44,7 +44,10 @@ func ExecRead(ctx context.Context, args []string) ([]string, error) {
 		}
 		output = append(output, strings.TrimSpace(s))
 	}
-	_ = proc.Cmd.Wait()
+	err := proc.Cmd.Wait()
+	if err != nil {
+		return output, err
+	}
 	return output, nil
 }
 


### PR DESCRIPTION
Signed-off-by: Andrey Sobolev <haiodo@xored.com>

CloudTest should fail if finding go tests are failed.

## Description
Right now if some of tests was not able to be compiled, we are not able to find tests, so only logging to console about this was happened, and build was green, but this is not right,

## Motivation and Context

CloudTest should fail build in case product are broken.

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [x] Covered by existing integration testing
- [ ] Added integration testing to cover
- [x] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
