### PR TITLE
Security #1: Proxy monitor for crossconnects

### DIFF
--- a/test/applications/build/Dockerfile.test-common
+++ b/test/applications/build/Dockerfile.test-common
@@ -24,3 +24,10 @@ ARG VERSION=unspecified
 RUN CGO_ENABLED=0 GOOS=linux go build -ldflags "-extldflags "-static" -X  main.version=${VERSION}"  -o /go/bin/monitoring-nsc ./test/applications/cmd/monitoring-nsc
 FROM runtime-1 as runtime-2
 COPY --from=build-2 /go/bin/monitoring-nsc /bin/monitoring-nsc
+
+# 3. xcon-monitor
+FROM build-2 as build-3
+ARG VERSION=unspecified
+RUN CGO_ENABLED=0 GOOS=linux go build -ldflags "-extldflags "-static" -X  main.version=${VERSION}"  -o /go/bin/proxy-xcon-monitor ./test/applications/cmd/proxy-xcon-monitor
+FROM runtime-2 as runtime-3
+COPY --from=build-3 /go/bin/proxy-xcon-monitor /bin/proxy-xcon-monitor

--- a/test/applications/cmd/proxy-xcon-monitor/main.go
+++ b/test/applications/cmd/proxy-xcon-monitor/main.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"github.com/golang/protobuf/ptypes/empty"
+	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/crossconnect"
+	"github.com/sirupsen/logrus"
+	"google.golang.org/grpc"
+	"net"
+)
+
+func parseFlags() string {
+	address := flag.String("address", "", "address of crossconnect monitor server")
+	flag.Parse()
+
+	return *address
+}
+
+type proxyMonitor struct {
+	address string
+}
+
+func (p *proxyMonitor) MonitorCrossConnects(empty *empty.Empty, src crossconnect.MonitorCrossConnect_MonitorCrossConnectsServer) error {
+	logrus.Infof("MonitorCrossConnects called, address - %v", p.address)
+
+	conn, err := grpc.Dial(p.address)
+	if err != nil {
+		logrus.Error(err)
+		return err
+	}
+	defer conn.Close()
+
+	monitorClient := crossconnect.NewMonitorCrossConnectClient(conn)
+
+	dstCtx, dstCancel := context.WithCancel(src.Context())
+	dst, err := monitorClient.MonitorCrossConnects(dstCtx, empty)
+	if err != nil {
+		logrus.Error(err)
+		return err
+	}
+
+	for {
+		event, err := dst.Recv()
+		if err != nil {
+			logrus.Error(err)
+			return err
+		}
+
+		logrus.Info("Receive event: %v", event)
+		if err := src.Send(event); err != nil {
+			logrus.Error(err)
+			return err
+		}
+
+		logrus.Info("Send event: %v", event)
+
+		select {
+		case <-src.Context().Done():
+			logrus.Info("src context is done")
+			dstCancel()
+			return nil
+		case <-dst.Context().Done():
+			logrus.Info("dst context is done")
+			return nil
+		default:
+		}
+	}
+}
+
+func main() {
+	logrus.Info("Starting Xcon Monitor Proxy")
+	address := parseFlags()
+
+	logrus.Infof("address=%v", address)
+
+	ln, err := net.Listen("tcp", ":6001")
+	if err != nil {
+		logrus.Error(err)
+		return
+	}
+	defer ln.Close()
+
+	srv := grpc.NewServer()
+	crossconnect.RegisterMonitorCrossConnectServer(srv, &proxyMonitor{
+		address: address,
+	})
+
+	if err := srv.Serve(ln); err != nil {
+		logrus.Error(err)
+		return
+	}
+}

--- a/test/integration/basic_monitor_crossconnect_metrics_test.go
+++ b/test/integration/basic_monitor_crossconnect_metrics_test.go
@@ -46,7 +46,7 @@ func TestSimpleMetrics(t *testing.T) {
 	kubetest.DeployICMP(k8s, nodes[nodesCount-1].Node, "icmp-responder-nse-1", defaultTimeout)
 	defer kubetest.ShowLogs(k8s, t)
 
-	eventCh, closeFunc := kubetest.XconProxyMonitor(k8s, nodes[0])
+	eventCh, closeFunc := kubetest.XconProxyMonitor(k8s, nodes[0], "0")
 	defer closeFunc()
 
 	metricsCh := metricsFromEventCh(eventCh)

--- a/test/integration/basic_monitor_crossconnect_metrics_test.go
+++ b/test/integration/basic_monitor_crossconnect_metrics_test.go
@@ -4,8 +4,6 @@ package nsmd_integration_tests
 
 import (
 	"context"
-	"fmt"
-
 	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/crossconnect"
 
@@ -47,18 +45,11 @@ func TestSimpleMetrics(t *testing.T) {
 	Expect(err).To(BeNil())
 	kubetest.DeployICMP(k8s, nodes[nodesCount-1].Node, "icmp-responder-nse-1", defaultTimeout)
 	defer kubetest.ShowLogs(k8s, t)
-	fwd, err := k8s.NewPortForwarder(nodes[0].Nsmd, 5001)
-	Expect(err).To(BeNil())
 
-	defer fwd.Stop()
+	eventCh, closeFunc := kubetest.XconProxyMonitor(k8s, nodes[0])
+	defer closeFunc()
 
-	err = fwd.Start()
-	Expect(err).To(BeNil())
-
-	nsmdMonitor, close := crossConnectClient(fmt.Sprintf("localhost:%d", fwd.ListenPort))
-	defer close()
-	metricsCh := make(chan map[string]string)
-	monitorCrossConnectsMetrics(nsmdMonitor, metricsCh)
+	metricsCh := metricsFromEventCh(eventCh)
 	nsc := kubetest.DeployNSC(k8s, nodes[0].Node, "nsc1", defaultTimeout)
 
 	response, _, err := k8s.Exec(nsc, nsc.Spec.Containers[0].Name, "ping", "172.16.1.2", "-A", "-c", "4")
@@ -100,33 +91,30 @@ func crossConnectClient(address string) (crossconnect.MonitorCrossConnect_Monito
 	return stream, closeFunc
 }
 
-func monitorCrossConnectsMetrics(stream crossconnect.MonitorCrossConnect_MonitorCrossConnectsClient, metricsCh chan<- map[string]string) {
+func metricsFromEventCh(eventCh <-chan *crossconnect.CrossConnectEvent) chan map[string]string {
+	metricsCh := make(chan map[string]string)
 	go func() {
+		defer close(metricsCh)
 		for {
-			select {
-			case <-stream.Context().Done():
+			event, ok := <-eventCh
+			if !ok {
 				return
-			default:
-				event, err := stream.Recv()
-				if err != nil {
-					logrus.Infof("An error during receive event %v", err)
+			}
+			logrus.Infof("Received event %v", event)
+			if event.Metrics == nil {
+				continue
+			}
+			for k, v := range event.Metrics {
+				logrus.Infof("New statistics: %v %v", k, v)
+				if isMetricsEmpty(v.Metrics) {
+					logrus.Infof("Statistics: %v %v is empty", k, v)
 					continue
 				}
-				logrus.Infof("Received event %v", event)
-				if event.Metrics == nil {
-					continue
-				}
-				for k, v := range event.Metrics {
-					logrus.Infof("New statistics: %v %v", k, v)
-					if isMetricsEmpty(v.Metrics) {
-						logrus.Infof("Statistics: %v %v is empty", k, v)
-						continue
-					}
-					metricsCh <- v.Metrics
-				}
+				metricsCh <- v.Metrics
 			}
 		}
 	}()
+	return metricsCh
 }
 
 func isMetricsEmpty(metrics map[string]string) bool {

--- a/test/integration/basic_monitor_crossconnect_test.go
+++ b/test/integration/basic_monitor_crossconnect_test.go
@@ -3,7 +3,7 @@
 package nsmd_integration_tests
 
 import (
-	"fmt"
+	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/crossconnect"
 	"github.com/networkservicemesh/networkservicemesh/test/kubetest"
 	. "github.com/onsi/gomega"
 	"github.com/sirupsen/logrus"
@@ -30,29 +30,36 @@ func TestSingleCrossConnect(t *testing.T) {
 	kubetest.DeployICMP(k8s, nodes[nodesCount-1].Node, "icmp-responder-nse-1", defaultTimeout)
 	kubetest.DeployNSC(k8s, nodes[0].Node, "nsc-1", defaultTimeout)
 
-	fwd, err := k8s.NewPortForwarder(nodes[0].Nsmd, 5001)
-	Expect(err).To(BeNil())
-	defer fwd.Stop()
+	// monitor client for node0
+	eventCh0, closeFunc0 := kubetest.XconProxyMonitor(k8s, nodes[0])
+	defer closeFunc0()
 
-	err = fwd.Start()
-	Expect(err).To(BeNil())
+	// monitor client for node1
+	eventCh1, closeFunc1 := kubetest.XconProxyMonitor(k8s, nodes[1])
+	defer closeFunc1()
 
-	fwd2, err := k8s.NewPortForwarder(nodes[1].Nsmd, 5001)
-	Expect(err).To(BeNil())
-	defer fwd2.Stop()
+	// checking goroutine for node0
+	expectedFunc0, waitFunc0 := kubetest.NewEventChecker(t, eventCh0)
 
-	err = fwd2.Start()
-	Expect(err).To(BeNil())
+	// checking goroutine for node1
+	expectedFunc1, waitFunc1 := kubetest.NewEventChecker(t, eventCh1)
 
-	nsmdMonitor1, close1, cancel1 := kubetest.CreateCrossConnectClient(fmt.Sprintf("localhost:%d", fwd.ListenPort))
-	defer close1()
-	nsmdMonitor2, close2, cancel2 := kubetest.CreateCrossConnectClient(fmt.Sprintf("localhost:%d", fwd2.ListenPort))
-	defer close2()
+	expectedFunc0(kubetest.EventDescription{
+		EventType: crossconnect.CrossConnectEventType_INITIAL_STATE_TRANSFER,
+		SrcUp:     true,
+		DstUp:     true,
+		LastEvent: true,
+	})
 
-	_, err = kubetest.GetCrossConnectsFromMonitor(nsmdMonitor1, cancel1, 1, fastTimeout)
-	Expect(err).To(BeNil())
-	_, err = kubetest.GetCrossConnectsFromMonitor(nsmdMonitor2, cancel2, 1, fastTimeout)
-	Expect(err).To(BeNil())
+	expectedFunc1(kubetest.EventDescription{
+		EventType: crossconnect.CrossConnectEventType_INITIAL_STATE_TRANSFER,
+		SrcUp:     true,
+		DstUp:     true,
+		LastEvent: true,
+	})
+
+	waitFunc0()
+	waitFunc1()
 }
 
 func TestSingleCrossConnectMonitorBeforeXcons(t *testing.T) {
@@ -73,32 +80,19 @@ func TestSingleCrossConnectMonitorBeforeXcons(t *testing.T) {
 	Expect(err).To(BeNil())
 	defer kubetest.ShowLogs(k8s, t)
 
-	fwd, err := k8s.NewPortForwarder(nodes[0].Nsmd, 5001)
-	Expect(err).To(BeNil())
-	defer fwd.Stop()
+	// monitor client for node0
+	eventCh0, closeFunc0 := kubetest.XconProxyMonitor(k8s, nodes[0])
+	defer closeFunc0()
 
-	err = fwd.Start()
-	Expect(err).To(BeNil())
-
-	fwd2, err := k8s.NewPortForwarder(nodes[1].Nsmd, 5001)
-	Expect(err).To(BeNil())
-	defer fwd2.Stop()
-
-	err = fwd2.Start()
-	Expect(err).To(BeNil())
-
-	nsmdMonitor1, close1, cancel1 := kubetest.CreateCrossConnectClient(fmt.Sprintf("localhost:%d", fwd.ListenPort))
-	defer close1()
-	nsmdMonitor2, close2, cancel2 := kubetest.CreateCrossConnectClient(fmt.Sprintf("localhost:%d", fwd2.ListenPort))
-	defer close2()
+	// monitor client for node1
+	eventCh1, closeFunc1 := kubetest.XconProxyMonitor(k8s, nodes[1])
+	defer closeFunc1()
 
 	kubetest.DeployICMP(k8s, nodes[nodesCount-1].Node, "icmp-responder-nse-1", defaultTimeout)
 	kubetest.DeployNSC(k8s, nodes[0].Node, "nsc-1", defaultTimeout)
 
-	_, err = kubetest.GetCrossConnectsFromMonitor(nsmdMonitor1, cancel1, 1, fastTimeout)
-	Expect(err).To(BeNil())
-	_, err = kubetest.GetCrossConnectsFromMonitor(nsmdMonitor2, cancel2, 1, fastTimeout)
-	Expect(err).To(BeNil())
+	Expect(kubetest.CollectXcons(eventCh0, 2, fastTimeout)).To(BeNil())
+	Expect(kubetest.CollectXcons(eventCh1, 2, fastTimeout)).To(BeNil())
 }
 
 func TestSeveralCrossConnects(t *testing.T) {
@@ -122,30 +116,16 @@ func TestSeveralCrossConnects(t *testing.T) {
 	kubetest.DeployNSC(k8s, nodes[0].Node, "nsc-1", defaultTimeout)
 	kubetest.DeployNSC(k8s, nodes[0].Node, "nsc-2", defaultTimeout)
 
-	fwd, err := k8s.NewPortForwarder(nodes[0].Nsmd, 5001)
-	Expect(err).To(BeNil())
-	defer fwd.Stop()
+	// monitor client for node0
+	eventCh0, closeFunc0 := kubetest.XconProxyMonitor(k8s, nodes[0])
+	defer closeFunc0()
 
-	err = fwd.Start()
-	Expect(err).To(BeNil())
+	// monitor client for node1
+	eventCh1, closeFunc1 := kubetest.XconProxyMonitor(k8s, nodes[1])
+	defer closeFunc1()
 
-	fwd2, err := k8s.NewPortForwarder(nodes[1].Nsmd, 5001)
-	Expect(err).To(BeNil())
-	defer fwd2.Stop()
-
-	err = fwd2.Start()
-	Expect(err).To(BeNil())
-
-	nsmdMonitor1, close1, cancel1 := kubetest.CreateCrossConnectClient(fmt.Sprintf("localhost:%d", fwd.ListenPort))
-	defer close1()
-
-	nsmdMonitor2, close2, cancel2 := kubetest.CreateCrossConnectClient(fmt.Sprintf("localhost:%d", fwd2.ListenPort))
-	defer close2()
-
-	_, err = kubetest.GetCrossConnectsFromMonitor(nsmdMonitor1, cancel1, 2, fastTimeout)
-	Expect(err).To(BeNil())
-	_, err = kubetest.GetCrossConnectsFromMonitor(nsmdMonitor2, cancel2, 2, fastTimeout)
-	Expect(err).To(BeNil())
+	Expect(kubetest.CollectXcons(eventCh0, 2, fastTimeout)).To(BeNil())
+	Expect(kubetest.CollectXcons(eventCh1, 2, fastTimeout)).To(BeNil())
 }
 
 func TestCrossConnectMonitorRestart(t *testing.T) {
@@ -168,21 +148,15 @@ func TestCrossConnectMonitorRestart(t *testing.T) {
 	kubetest.DeployNSC(k8s, nodes[0].Node, "nsc-1", defaultTimeout)
 	kubetest.DeployNSC(k8s, nodes[0].Node, "nsc-2", defaultTimeout)
 
-	fwd, err := k8s.NewPortForwarder(nodes[0].Nsmd, 5001)
-	Expect(err).To(BeNil())
-	defer fwd.Stop()
+	// monitor client for node0
+	eventCh0, closeFunc0 := kubetest.XconProxyMonitor(k8s, nodes[0])
 
-	err = fwd.Start()
-	Expect(err).To(BeNil())
-
-	nsmdMonitor, closeFunc, cancel := kubetest.CreateCrossConnectClient(fmt.Sprintf("localhost:%d", fwd.ListenPort))
-	_, err = kubetest.GetCrossConnectsFromMonitor(nsmdMonitor, cancel, 2, fastTimeout)
-	Expect(err).To(BeNil())
-	closeFunc()
+	Expect(kubetest.CollectXcons(eventCh0, 2, fastTimeout)).To(BeNil())
+	closeFunc0()
 
 	logrus.Info("Restarting monitor")
-	nsmdMonitor, closeFunc, cancel = kubetest.CreateCrossConnectClient(fmt.Sprintf("localhost:%d", fwd.ListenPort))
-	defer closeFunc()
-	_, err = kubetest.GetCrossConnectsFromMonitor(nsmdMonitor, cancel, 2, fastTimeout)
-	Expect(err).To(BeNil())
+
+	eventCh1, closeFunc1 := kubetest.XconProxyMonitor(k8s, nodes[0])
+	defer closeFunc1()
+	Expect(kubetest.CollectXcons(eventCh1, 2, fastTimeout)).To(BeNil())
 }

--- a/test/integration/basic_monitor_crossconnect_test.go
+++ b/test/integration/basic_monitor_crossconnect_test.go
@@ -31,11 +31,11 @@ func TestSingleCrossConnect(t *testing.T) {
 	kubetest.DeployNSC(k8s, nodes[0].Node, "nsc-1", defaultTimeout)
 
 	// monitor client for node0
-	eventCh0, closeFunc0 := kubetest.XconProxyMonitor(k8s, nodes[0])
+	eventCh0, closeFunc0 := kubetest.XconProxyMonitor(k8s, nodes[0], "0")
 	defer closeFunc0()
 
 	// monitor client for node1
-	eventCh1, closeFunc1 := kubetest.XconProxyMonitor(k8s, nodes[1])
+	eventCh1, closeFunc1 := kubetest.XconProxyMonitor(k8s, nodes[1], "1")
 	defer closeFunc1()
 
 	// checking goroutine for node0
@@ -81,11 +81,11 @@ func TestSingleCrossConnectMonitorBeforeXcons(t *testing.T) {
 	defer kubetest.ShowLogs(k8s, t)
 
 	// monitor client for node0
-	eventCh0, closeFunc0 := kubetest.XconProxyMonitor(k8s, nodes[0])
+	eventCh0, closeFunc0 := kubetest.XconProxyMonitor(k8s, nodes[0], "0")
 	defer closeFunc0()
 
 	// monitor client for node1
-	eventCh1, closeFunc1 := kubetest.XconProxyMonitor(k8s, nodes[1])
+	eventCh1, closeFunc1 := kubetest.XconProxyMonitor(k8s, nodes[1], "1")
 	defer closeFunc1()
 
 	kubetest.DeployICMP(k8s, nodes[nodesCount-1].Node, "icmp-responder-nse-1", defaultTimeout)
@@ -117,11 +117,11 @@ func TestSeveralCrossConnects(t *testing.T) {
 	kubetest.DeployNSC(k8s, nodes[0].Node, "nsc-2", defaultTimeout)
 
 	// monitor client for node0
-	eventCh0, closeFunc0 := kubetest.XconProxyMonitor(k8s, nodes[0])
+	eventCh0, closeFunc0 := kubetest.XconProxyMonitor(k8s, nodes[0], "0")
 	defer closeFunc0()
 
 	// monitor client for node1
-	eventCh1, closeFunc1 := kubetest.XconProxyMonitor(k8s, nodes[1])
+	eventCh1, closeFunc1 := kubetest.XconProxyMonitor(k8s, nodes[1], "1")
 	defer closeFunc1()
 
 	Expect(kubetest.CollectXcons(eventCh0, 2, fastTimeout)).To(BeNil())
@@ -149,14 +149,14 @@ func TestCrossConnectMonitorRestart(t *testing.T) {
 	kubetest.DeployNSC(k8s, nodes[0].Node, "nsc-2", defaultTimeout)
 
 	// monitor client for node0
-	eventCh0, closeFunc0 := kubetest.XconProxyMonitor(k8s, nodes[0])
+	eventCh0, closeFunc0 := kubetest.XconProxyMonitor(k8s, nodes[0], "0")
 
 	Expect(kubetest.CollectXcons(eventCh0, 2, fastTimeout)).To(BeNil())
 	closeFunc0()
 
 	logrus.Info("Restarting monitor")
 
-	eventCh1, closeFunc1 := kubetest.XconProxyMonitor(k8s, nodes[0])
+	eventCh1, closeFunc1 := kubetest.XconProxyMonitor(k8s, nodes[0], "0")
 	defer closeFunc1()
 	Expect(kubetest.CollectXcons(eventCh1, 2, fastTimeout)).To(BeNil())
 }

--- a/test/integration/recover_xcon_monitor_test.go
+++ b/test/integration/recover_xcon_monitor_test.go
@@ -28,7 +28,7 @@ func TestXconMonitorSingleNodeHealFailed(t *testing.T) {
 	nscPodNode := kubetest.DeployNSC(k8s, nodesConf[0].Node, "nsc-0", defaultTimeout)
 	Expect(nscPodNode).ToNot(BeNil())
 
-	eventCh, closeFunc := kubetest.XconProxyMonitor(k8s, nodesConf[0])
+	eventCh, closeFunc := kubetest.XconProxyMonitor(k8s, nodesConf[0], "0")
 	defer closeFunc()
 
 	expectedFunc, waitFunc := kubetest.NewEventChecker(t, eventCh)
@@ -75,7 +75,7 @@ func TestXconMonitorSingleNodeHealSuccess(t *testing.T) {
 	nsc := kubetest.DeployNSC(k8s, nodesConf[0].Node, "nsc-0", defaultTimeout)
 	Expect(nsc).ToNot(BeNil())
 
-	eventCh, closeFunc := kubetest.XconProxyMonitor(k8s, nodesConf[0])
+	eventCh, closeFunc := kubetest.XconProxyMonitor(k8s, nodesConf[0], "0")
 	defer closeFunc()
 
 	expectedFunc, waitFunc := kubetest.NewEventChecker(t, eventCh)
@@ -127,11 +127,11 @@ func TestXconMonitorMultiNodeHealFail(t *testing.T) {
 	Expect(nsc).ToNot(BeNil())
 
 	// monitor client for node0
-	eventCh0, closeFunc0 := kubetest.XconProxyMonitor(k8s, nodesConf[0])
+	eventCh0, closeFunc0 := kubetest.XconProxyMonitor(k8s, nodesConf[0], "0")
 	defer closeFunc0()
 
 	// monitor client for node1
-	eventCh1, closeFunc1 := kubetest.XconProxyMonitor(k8s, nodesConf[1])
+	eventCh1, closeFunc1 := kubetest.XconProxyMonitor(k8s, nodesConf[1], "1")
 	defer closeFunc1()
 
 	// checking goroutine for node0
@@ -207,11 +207,11 @@ func TestXconMonitorMultiNodeHealSuccess(t *testing.T) {
 	Expect(nsc).ToNot(BeNil())
 
 	// monitor client for node0
-	eventCh0, closeFunc0 := kubetest.XconProxyMonitor(k8s, nodesConf[0])
+	eventCh0, closeFunc0 := kubetest.XconProxyMonitor(k8s, nodesConf[0], "0")
 	defer closeFunc0()
 
 	// monitor client for node1
-	eventCh1, closeFunc1 := kubetest.XconProxyMonitor(k8s, nodesConf[1])
+	eventCh1, closeFunc1 := kubetest.XconProxyMonitor(k8s, nodesConf[1], "1")
 	defer closeFunc1()
 
 	// checking goroutine for node0
@@ -288,7 +288,7 @@ func TestXconMonitorNsmgrRestart(t *testing.T) {
 	nsc := kubetest.DeployNSC(k8s, nodesConf[0].Node, "nsc-0", defaultTimeout)
 	Expect(nsc).ToNot(BeNil())
 
-	eventCh, closeFunc := kubetest.XconProxyMonitor(k8s, nodesConf[0])
+	eventCh, closeFunc := kubetest.XconProxyMonitor(k8s, nodesConf[0], "0")
 	expectFunc, waitFunc := kubetest.NewEventChecker(t, eventCh)
 
 	expectFunc(kubetest.EventDescription{
@@ -306,7 +306,7 @@ func TestXconMonitorNsmgrRestart(t *testing.T) {
 		&pods.NSMgrPodConfig{Namespace: k8s.GetK8sNamespace()})) // Recovery NSEs
 	k8s.WaitLogsContains(nodesConf[0].Nsmd, "nsmd", "All connections are recovered...", defaultTimeout)
 
-	eventChR, closeFuncR := kubetest.XconProxyMonitor(k8s, nodesConf[0])
+	eventChR, closeFuncR := kubetest.XconProxyMonitor(k8s, nodesConf[0], "0")
 	defer closeFuncR()
 	expectFuncR, waitFuncR := kubetest.NewEventChecker(t, eventChR)
 

--- a/test/integration/recover_xcon_monitor_test.go
+++ b/test/integration/recover_xcon_monitor_test.go
@@ -28,7 +28,7 @@ func TestXconMonitorSingleNodeHealFailed(t *testing.T) {
 	nscPodNode := kubetest.DeployNSC(k8s, nodesConf[0].Node, "nsc-0", defaultTimeout)
 	Expect(nscPodNode).ToNot(BeNil())
 
-	eventCh, closeFunc := kubetest.CrossConnectClientAt(k8s, nodesConf[0].Nsmd)
+	eventCh, closeFunc := kubetest.XconProxyMonitor(k8s, nodesConf[0])
 	defer closeFunc()
 
 	expectedFunc, waitFunc := kubetest.NewEventChecker(t, eventCh)
@@ -75,7 +75,7 @@ func TestXconMonitorSingleNodeHealSuccess(t *testing.T) {
 	nsc := kubetest.DeployNSC(k8s, nodesConf[0].Node, "nsc-0", defaultTimeout)
 	Expect(nsc).ToNot(BeNil())
 
-	eventCh, closeFunc := kubetest.CrossConnectClientAt(k8s, nodesConf[0].Nsmd)
+	eventCh, closeFunc := kubetest.XconProxyMonitor(k8s, nodesConf[0])
 	defer closeFunc()
 
 	expectedFunc, waitFunc := kubetest.NewEventChecker(t, eventCh)
@@ -127,11 +127,11 @@ func TestXconMonitorMultiNodeHealFail(t *testing.T) {
 	Expect(nsc).ToNot(BeNil())
 
 	// monitor client for node0
-	eventCh0, closeFunc0 := kubetest.CrossConnectClientAt(k8s, nodesConf[0].Nsmd)
+	eventCh0, closeFunc0 := kubetest.XconProxyMonitor(k8s, nodesConf[0])
 	defer closeFunc0()
 
 	// monitor client for node1
-	eventCh1, closeFunc1 := kubetest.CrossConnectClientAt(k8s, nodesConf[1].Nsmd)
+	eventCh1, closeFunc1 := kubetest.XconProxyMonitor(k8s, nodesConf[1])
 	defer closeFunc1()
 
 	// checking goroutine for node0
@@ -207,11 +207,11 @@ func TestXconMonitorMultiNodeHealSuccess(t *testing.T) {
 	Expect(nsc).ToNot(BeNil())
 
 	// monitor client for node0
-	eventCh0, closeFunc0 := kubetest.CrossConnectClientAt(k8s, nodesConf[0].Nsmd)
+	eventCh0, closeFunc0 := kubetest.XconProxyMonitor(k8s, nodesConf[0])
 	defer closeFunc0()
 
 	// monitor client for node1
-	eventCh1, closeFunc1 := kubetest.CrossConnectClientAt(k8s, nodesConf[1].Nsmd)
+	eventCh1, closeFunc1 := kubetest.XconProxyMonitor(k8s, nodesConf[1])
 	defer closeFunc1()
 
 	// checking goroutine for node0
@@ -288,7 +288,7 @@ func TestXconMonitorNsmgrRestart(t *testing.T) {
 	nsc := kubetest.DeployNSC(k8s, nodesConf[0].Node, "nsc-0", defaultTimeout)
 	Expect(nsc).ToNot(BeNil())
 
-	eventCh, closeFunc := kubetest.CrossConnectClientAt(k8s, nodesConf[0].Nsmd)
+	eventCh, closeFunc := kubetest.XconProxyMonitor(k8s, nodesConf[0])
 	expectFunc, waitFunc := kubetest.NewEventChecker(t, eventCh)
 
 	expectFunc(kubetest.EventDescription{
@@ -306,7 +306,7 @@ func TestXconMonitorNsmgrRestart(t *testing.T) {
 		&pods.NSMgrPodConfig{Namespace: k8s.GetK8sNamespace()})) // Recovery NSEs
 	k8s.WaitLogsContains(nodesConf[0].Nsmd, "nsmd", "All connections are recovered...", defaultTimeout)
 
-	eventChR, closeFuncR := kubetest.CrossConnectClientAt(k8s, nodesConf[0].Nsmd)
+	eventChR, closeFuncR := kubetest.XconProxyMonitor(k8s, nodesConf[0])
 	defer closeFuncR()
 	expectFuncR, waitFuncR := kubetest.NewEventChecker(t, eventChR)
 

--- a/test/kubetest/monitor_utils.go
+++ b/test/kubetest/monitor_utils.go
@@ -51,6 +51,7 @@ func CrossConnectClientAt(k8s *K8s, pod *v1.Pod) (<-chan *crossconnect.CrossConn
 	return getEventCh(client, cancel, stopCh), closeFunc
 }
 
+// XconProxyMonitor deploys proxy monitor to node and returns channel of events from it
 func XconProxyMonitor(k8s *K8s, conf *NodeConf) (<-chan *crossconnect.CrossConnectEvent, func()) {
 	address := fmt.Sprintf("%s:5001", conf.Nsmd.Status.PodIP)
 
@@ -271,6 +272,7 @@ func dstConnToString(xcon *crossconnect.CrossConnect) string {
 	return fmt.Sprintf("[DST:%s:%s:%s:%s]", endpoint, distance, ip, state)
 }
 
+// CollectXcons takes n crossconencts from event channel
 func CollectXcons(ch <-chan *crossconnect.CrossConnectEvent,
 	n int, timeout time.Duration) (map[string]*crossconnect.CrossConnect, error) {
 	rv := map[string]*crossconnect.CrossConnect{}

--- a/test/kubetest/monitor_utils.go
+++ b/test/kubetest/monitor_utils.go
@@ -2,7 +2,9 @@ package kubetest
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"github.com/networkservicemesh/networkservicemesh/test/kubetest/pods"
 	"testing"
 	"time"
 
@@ -12,7 +14,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
-	v1 "k8s.io/api/core/v1"
+	"k8s.io/api/core/v1"
 )
 
 // MonitorClient is shorter name for crossconnect.MonitorCrossConnect_MonitorCrossConnectsClient
@@ -29,7 +31,7 @@ type EventDescription struct {
 
 // CrossConnectClientAt returns channel of CrossConnectEvents from passed nsmgr pod
 func CrossConnectClientAt(k8s *K8s, pod *v1.Pod) (<-chan *crossconnect.CrossConnectEvent, func()) {
-	fwd, err := k8s.NewPortForwarder(pod, 5001)
+	fwd, err := k8s.NewPortForwarder(pod, 6001)
 	Expect(err).To(BeNil())
 
 	err = fwd.Start()
@@ -47,6 +49,22 @@ func CrossConnectClientAt(k8s *K8s, pod *v1.Pod) (<-chan *crossconnect.CrossConn
 	}
 
 	return getEventCh(client, cancel, stopCh), closeFunc
+}
+
+func XconProxyMonitor(k8s *K8s, conf *NodeConf) (<-chan *crossconnect.CrossConnectEvent, func()) {
+	address := fmt.Sprintf("%s:5001", conf.Nsmd.Status.PodIP)
+
+	xconProxy := k8s.CreatePod(pods.TestCommonPod(
+		fmt.Sprintf("xcon-proxy-monitor-%s", conf.Node.GetName()),
+		[]string{"/bin/proxy-xcon-monitor", fmt.Sprintf("-address=%s", address)},
+		conf.Node,
+		map[string]string{}))
+
+	eventCh, closeFunc := CrossConnectClientAt(k8s, xconProxy)
+	return eventCh, func() {
+		k8s.DeletePods(xconProxy)
+		closeFunc()
+	}
 }
 
 const defaultNextTimeout = 10 * time.Second
@@ -253,43 +271,23 @@ func dstConnToString(xcon *crossconnect.CrossConnect) string {
 	return fmt.Sprintf("[DST:%s:%s:%s:%s]", endpoint, distance, ip, state)
 }
 
-// GetCrossConnectsFromMonitor returns xconAmount events from stream
-func GetCrossConnectsFromMonitor(stream MonitorClient, cancel context.CancelFunc,
-	xconAmount int, timeout time.Duration) (map[string]*crossconnect.CrossConnect, error) {
-
-	xcons := map[string]*crossconnect.CrossConnect{}
-	events := make(chan *crossconnect.CrossConnectEvent)
-
-	go func() {
-		for {
-			select {
-			case <-stream.Context().Done():
-				return
-			default:
-				event, _ := stream.Recv()
-				if event != nil {
-					events <- event
-				}
-			}
-		}
-	}()
-
+func CollectXcons(ch <-chan *crossconnect.CrossConnectEvent,
+	n int, timeout time.Duration) (map[string]*crossconnect.CrossConnect, error) {
+	rv := map[string]*crossconnect.CrossConnect{}
 	for {
 		select {
-		case event := <-events:
-			logrus.Infof("Receive event type: %v", event.GetType())
-
-			for _, xcon := range event.CrossConnects {
-				logrus.Infof("xcon: %v", xcon)
-				xcons[xcon.GetId()] = xcon
+		case event, ok := <-ch:
+			if !ok && len(rv) < n {
+				return nil, errors.New("reached end of CrossConnectEvent channel")
 			}
-			if len(xcons) == xconAmount {
-				cancel()
-				return xcons, nil
+			for id, xcon := range event.GetCrossConnects() {
+				rv[id] = xcon
+			}
+			if len(rv) == n {
+				return rv, nil
 			}
 		case <-time.After(timeout):
-			cancel()
-			return nil, fmt.Errorf("timeout exceeded")
+			return nil, fmt.Errorf("no events during %v", timeout)
 		}
 	}
 }

--- a/test/kubetest/monitor_utils.go
+++ b/test/kubetest/monitor_utils.go
@@ -52,11 +52,11 @@ func CrossConnectClientAt(k8s *K8s, pod *v1.Pod) (<-chan *crossconnect.CrossConn
 }
 
 // XconProxyMonitor deploys proxy monitor to node and returns channel of events from it
-func XconProxyMonitor(k8s *K8s, conf *NodeConf) (<-chan *crossconnect.CrossConnectEvent, func()) {
+func XconProxyMonitor(k8s *K8s, conf *NodeConf, suffix string) (<-chan *crossconnect.CrossConnectEvent, func()) {
 	address := fmt.Sprintf("%s:5001", conf.Nsmd.Status.PodIP)
 
 	xconProxy := k8s.CreatePod(pods.TestCommonPod(
-		fmt.Sprintf("xcon-proxy-monitor-%s", conf.Node.GetName()),
+		fmt.Sprintf("xcon-proxy-monitor-%s", suffix),
 		[]string{"/bin/proxy-xcon-monitor", fmt.Sprintf("-address=%s", address)},
 		conf.Node,
 		map[string]string{}))


### PR DESCRIPTION
Signed-off-by: lobkovilya <ilya.lobkov@xored.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Create proxy monitor for crossconnects

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
There are several tests that somehow check `CrossConnectMonitor`. They forward 5001 port from nsmd and receive `CrossConnectEvent` directly from the monitor. 

But #737 introduces TLS securing of grpc connections. Certificates are issued by spire-agent based on pod's service account. That's why for simplifying events reading outside the cluster this PR introduces proxy-xcon-monitor. Proxy-xcon-monitor will establish secure connection with nsmd:5001 and forward CrossConnectEvents to insecure 6001 port.

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [ ] Covered by existing integration testing
- [ ] Added integration testing to cover
- [X] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
