### PR TITLE
Admission webhook: propagate jaeger host and port env vars to NSCs init containers

### DIFF
--- a/.mk/docker.mk
+++ b/.mk/docker.mk
@@ -46,7 +46,7 @@ docker-save: $(addsuffix -save,$(addprefix docker-,$(BUILD_CONTAINERS)))
 
 .PHONY: docker-%-save
 docker-%-save: docker-%-build
-	@echo "Saving $*"
+	@echo "Saving $* to scripts/vagrant/images/$*.tar"
 	@mkdir -p scripts/vagrant/images/
 	@docker save -o scripts/vagrant/images/$*.tar ${ORG}/$*
 

--- a/k8s/cmd/admission-webhook/const.go
+++ b/k8s/cmd/admission-webhook/const.go
@@ -12,6 +12,8 @@ const (
 	repoEnv                      = "REPO"
 	initContainerEnv             = "INITCONTAINER"
 	tagEnv                       = "TAG"
+	jaegerHostEnv                = "JAEGER_SERVICE_HOST"
+	jaegerPortEnv                = "JAEGER_SERVICE_PORT_JAEGER"
 	repoDefault                  = "networkservicemesh"
 	initContainerDefault         = "nsm-init"
 	tagDefault                   = "latest"

--- a/k8s/cmd/admission-webhook/main.go
+++ b/k8s/cmd/admission-webhook/main.go
@@ -69,3 +69,11 @@ func getInitContainer() string {
 	}
 	return initContainer
 }
+
+func getJaegerHost() string {
+	return os.Getenv(jaegerHostEnv)
+}
+
+func getJaegerPort() string {
+	return os.Getenv(jaegerPortEnv)
+}

--- a/k8s/cmd/admission-webhook/utils.go
+++ b/k8s/cmd/admission-webhook/utils.go
@@ -70,15 +70,33 @@ func validateAnnotationValue(value string) error {
 func createInitContainerPatch(annotationValue, path string) []patchOperation {
 	var patch []patchOperation
 
+	envVals := []corev1.EnvVar{{
+		Name:  client.AnnotationEnv,
+		Value: annotationValue,
+	},
+	}
+	jaegerHost := getJaegerHost()
+	if jaegerHost != "" {
+		envVals = append(envVals,
+			corev1.EnvVar{
+				Name:  jaegerHostEnv,
+				Value: jaegerHost,
+			})
+	}
+	jaegerPort := getJaegerPort()
+	if jaegerPort != "" {
+		envVals = append(envVals,
+			corev1.EnvVar{
+				Name:  jaegerPortEnv,
+				Value: jaegerPort,
+			})
+	}
+
 	value := []corev1.Container{{
 		Name:            initContainerName,
 		Image:           fmt.Sprintf("%s/%s:%s", getRepo(), getInitContainer(), getTag()),
 		ImagePullPolicy: corev1.PullIfNotPresent,
-		Env: []corev1.EnvVar{{
-			Name:  client.AnnotationEnv,
-			Value: annotationValue,
-		},
-		},
+		Env:             envVals,
 		Resources: corev1.ResourceRequirements{
 			Limits: corev1.ResourceList{
 				"networkservicemesh.io/socket": resource.MustParse("1"),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Since the mutating webhook admission controller adds the nsm-init container for NSCs, this change optionally adds the env vars for Jaeger tracing to the injected NSC initContainer if they are defined in the admission-webhook.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
To be able to configure NSCs to send tracing info to Jaeger for troubleshooting and GRPC sequence information.

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [ ] Covered by existing integration testing
- [ ] Added integration testing to cover
- [ x ] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->
Testing without the env vars set is covered by the existing CI/integration tests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
