### PR TITLE
helm: Add option for enabling jaeger tracing in NSM components

### DIFF
--- a/deployments/helm/nsm-monitoring/templates/jaeger.tpl
+++ b/deployments/helm/nsm-monitoring/templates/jaeger.tpl
@@ -28,12 +28,16 @@ apiVersion: v1
 kind: Service
 metadata:
   name: jaeger
+  namespace: {{ .Release.Namespace }}
   labels:
     run: jaeger
   namespace: {{ .Release.Namespace }}
 spec:
   ports:
     - name: http
+{{- if eq .Values.monSvcType "NodePort" }}
+      nodePort: 31922
+{{- end }}
       port: 16686
       protocol: TCP
     - name: jaeger
@@ -41,3 +45,4 @@ spec:
       protocol: UDP
   selector:
     run: jaeger
+  type: {{ .Values.monSvcType }}

--- a/deployments/helm/nsm-monitoring/templates/skydive.tpl
+++ b/deployments/helm/nsm-monitoring/templates/skydive.tpl
@@ -2,11 +2,12 @@ apiVersion: v1
 kind: Service
 metadata:
   name: skydive-analyzer
+  namespace: {{ .Release.Namespace }}
   labels:
     app: skydive-analyzer
   namespace: {{ .Release.Namespace }}
 spec:
-  type: NodePort
+  type: {{ .Values.monSvcType }}
   ports:
     - port: 8082
       name: api

--- a/deployments/helm/nsm-monitoring/values.yaml
+++ b/deployments/helm/nsm-monitoring/values.yaml
@@ -6,3 +6,7 @@ registry: docker.io
 org: networkservicemesh
 tag: master
 pullPolicy: IfNotPresent
+
+# The type for monitoring services, i.e. Jaeger
+# value is one of ClusterIp, NodePort, LoadBalancer
+monSvcType: ClusterIP

--- a/deployments/helm/nsm-monitoring/values.yaml
+++ b/deployments/helm/nsm-monitoring/values.yaml
@@ -8,5 +8,5 @@ tag: master
 pullPolicy: IfNotPresent
 
 # The type for monitoring services, i.e. Jaeger
-# value is one of ClusterIp, NodePort, LoadBalancer
+# May be set to valid Kubernetes ServiceTypes values--ClusterIP, NodePort, LoadBalancer, ExternalName
 monSvcType: ClusterIP

--- a/deployments/helm/nsm/charts/admission-webhook/templates/admission-webhook-secret.tpl
+++ b/deployments/helm/nsm/charts/admission-webhook/templates/admission-webhook-secret.tpl
@@ -40,6 +40,13 @@ spec:
               value: "{{ .Values.org }}"
             - name: TAG
               value: "{{ .Values.tag }}"
+{{- if .Values.global.JaegerTracing }}
+          env:
+            - name: JAEGER_SERVICE_HOST
+              value: jaeger.nsm-system
+            - name: JAEGER_SERVICE_PORT_JAEGER
+              value: "6831"
+{{- end }}
           volumeMounts:
             - name: webhook-certs
               mountPath: /etc/webhook/certs

--- a/deployments/helm/nsm/charts/admission-webhook/templates/admission-webhook-secret.tpl
+++ b/deployments/helm/nsm/charts/admission-webhook/templates/admission-webhook-secret.tpl
@@ -42,9 +42,9 @@ spec:
               value: "{{ .Values.tag }}"
 {{- if .Values.global.JaegerTracing }}
           env:
-            - name: JAEGER_SERVICE_HOST
+            - name: JAEGER_AGENT_HOST
               value: jaeger.nsm-system
-            - name: JAEGER_SERVICE_PORT_JAEGER
+            - name: JAEGER_AGENT_PORT
               value: "6831"
 {{- end }}
           volumeMounts:

--- a/deployments/helm/nsm/templates/nsmgr.tpl
+++ b/deployments/helm/nsm/templates/nsmgr.tpl
@@ -18,9 +18,9 @@ spec:
           imagePullPolicy: {{ .Values.pullPolicy }}
 {{- if .Values.global.JaegerTracing }}
           env:
-            - name: JAEGER_SERVICE_HOST
+            - name: JAEGER_AGENT_HOST
               value: jaeger.nsm-system
-            - name: JAEGER_SERVICE_PORT_JAEGER
+            - name: JAEGER_AGENT_PORT
               value: "6831"
 {{- end }}
           volumeMounts:
@@ -33,9 +33,9 @@ spec:
           imagePullPolicy: {{ .Values.pullPolicy }}
 {{- if .Values.global.JaegerTracing }}
           env:
-            - name: JAEGER_SERVICE_HOST
+            - name: JAEGER_AGENT_HOST
               value: jaeger.nsm-system
-            - name: JAEGER_SERVICE_PORT_JAEGER
+            - name: JAEGER_AGENT_PORT
               value: "6831"
 {{- end }}
           volumeMounts:
@@ -66,9 +66,9 @@ spec:
                 fieldRef:
                   fieldPath: spec.nodeName
 {{- if .Values.global.JaegerTracing }}
-            - name: JAEGER_SERVICE_HOST
+            - name: JAEGER_AGENT_HOST
               value: jaeger.nsm-system
-            - name: JAEGER_SERVICE_PORT_JAEGER
+            - name: JAEGER_AGENT_PORT
               value: "6831"
 {{- end }}
       volumes:

--- a/deployments/helm/nsm/templates/nsmgr.tpl
+++ b/deployments/helm/nsm/templates/nsmgr.tpl
@@ -16,6 +16,13 @@ spec:
         - name: nsmdp
           image: {{ .Values.registry }}/{{ .Values.org }}/nsmdp:{{ .Values.tag }}
           imagePullPolicy: {{ .Values.pullPolicy }}
+{{- if .Values.global.JaegerTracing }}
+          env:
+            - name: JAEGER_SERVICE_HOST
+              value: jaeger.nsm-system
+            - name: JAEGER_SERVICE_PORT_JAEGER
+              value: "6831"
+{{- end }}
           volumeMounts:
             - name: kubelet-socket
               mountPath: /var/lib/kubelet/device-plugins
@@ -24,6 +31,13 @@ spec:
         - name: nsmd
           image: {{ .Values.registry }}/{{ .Values.org }}/nsmd:{{ .Values.tag }}
           imagePullPolicy: {{ .Values.pullPolicy }}
+{{- if .Values.global.JaegerTracing }}
+          env:
+            - name: JAEGER_SERVICE_HOST
+              value: jaeger.nsm-system
+            - name: JAEGER_SERVICE_PORT_JAEGER
+              value: "6831"
+{{- end }}
           volumeMounts:
             - name: nsm-socket
               mountPath: /var/lib/networkservicemesh
@@ -51,6 +65,12 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+{{- if .Values.global.JaegerTracing }}
+            - name: JAEGER_SERVICE_HOST
+              value: jaeger.nsm-system
+            - name: JAEGER_SERVICE_PORT_JAEGER
+              value: "6831"
+{{- end }}
       volumes:
         - hostPath:
             path: /var/lib/kubelet/device-plugins

--- a/deployments/helm/nsm/templates/vppagent-dataplane.tpl
+++ b/deployments/helm/nsm/templates/vppagent-dataplane.tpl
@@ -23,6 +23,12 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIP
+{{- if .Values.JaegerTracing }}
+            - name: JAEGER_SERVICE_HOST
+              value: jaeger.nsm-system
+            - name: JAEGER_SERVICE_PORT_JAEGER
+              value: "6831"
+{{- end }}
           volumeMounts:
             - name: workspace
               mountPath: /var/lib/networkservicemesh/

--- a/deployments/helm/nsm/templates/vppagent-dataplane.tpl
+++ b/deployments/helm/nsm/templates/vppagent-dataplane.tpl
@@ -23,12 +23,6 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIP
-{{- if .Values.JaegerTracing }}
-            - name: JAEGER_SERVICE_HOST
-              value: jaeger.nsm-system
-            - name: JAEGER_SERVICE_PORT_JAEGER
-              value: "6831"
-{{- end }}
           volumeMounts:
             - name: workspace
               mountPath: /var/lib/networkservicemesh/

--- a/deployments/helm/nsm/values.yaml
+++ b/deployments/helm/nsm/values.yaml
@@ -6,3 +6,7 @@ registry: docker.io
 org: networkservicemesh
 tag: master
 pullPolicy: IfNotPresent
+
+global:
+  # set to true to enable Jaeger tracing for NSM components
+  JaegerTracing: false


### PR DESCRIPTION
- include var for setting monitoring k8s service types
- fix missing namespace settings for templates in nsm-monitoring chart

Signed-off-by: Tim Swanson <tiswanso@cisco.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add the ability to enable Jaegar tracing on components in the NSM helm charts.  Additionally, add a setting that maps to the monitoring services k8s service types--e.g. NodePort. 

| Chart | New setting | Possible Values | Description |
|---|---|---|--|
| deployments/helm/nsm |  global.JaegerTracing | `true`, `false` |  Enables the env vars for Jaeger tracing in each NSM component |
|  deployments/helm/nsm-monitoring | monSvcType | `ClusterIP`, `NodePort`, `LoadBalancer` | The service type for the monitoring UIs--currently Jaeger and Skydive |

Example usage of the settings:
```
helm template deployments/helm/nsm --namespace nsm-system --set global.JaegerTracing=true > ~/tmp/nsm_k8s_mfst
helm template deployments/helm/nsm-monitoring --namespace nsm-system --set monSvcType=NodePort > ~/tmp/nsm_k8s_nsm_monitoring.yaml
```

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When using NSM with monitoring, it's very useful to enable Jaeger and have it be available via a service type that allows external access to the webUI.


## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [ ] Covered by existing integration testing
- [ ] Added integration testing to cover
- [x] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->
I'm not sure if anything in the test suites renders installation manifests from helm.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
