### PR TITLE
Remove aws cluster ssh private key printing

### DIFF
--- a/scripts/aws/create-kubernetes-cluster.go
+++ b/scripts/aws/create-kubernetes-cluster.go
@@ -217,7 +217,6 @@ func CreateEksEc2KeyPair(ec2Client *ec2.EC2, keyPairName *string) {
 	err = ioutil.WriteFile(keyFile, []byte(*resp.KeyMaterial), 0400)
 
 	checkError(err)
-	log.Print(resp)
 	log.Printf("Amazon EC2 key pair \"%s\" successfully created!\n", *keyPairName)
 }
 


### PR DESCRIPTION
Signed-off-by: Artem Belov <artem.belov@xored.com>

## Description
AWS cluster starting script is printing nodes ssh private key for debug purposes. This log entry is not needed now so it has to be removed.

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [ ] Covered by existing integration testing
- [ ] Added integration testing to cover
- [x] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
