### PR TITLE
Security #2: Refactor Dial methods

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -113,6 +113,10 @@ issues:
       linters:
         - gochecknoglobals
         - gochecknoinits
+    - path: pkg/tools/socket.go
+      linters:
+        - gochecknoglobals
+        - gochecknoinits
     - path: controlplane/pkg/monitor/
       linters:
         - dupl

--- a/controlplane/pkg/monitor/tests/monitor_server_test.go
+++ b/controlplane/pkg/monitor/tests/monitor_server_test.go
@@ -3,6 +3,7 @@ package tests
 import (
 	"context"
 	"fmt"
+	"github.com/networkservicemesh/networkservicemesh/pkg/tools"
 	"net"
 	"sync"
 	"testing"
@@ -17,7 +18,7 @@ import (
 )
 
 func startClient(target string) {
-	conn, err := grpc.Dial(target, grpc.WithInsecure())
+	conn, err := tools.DialTCP(target)
 	defer conn.Close()
 
 	Expect(err).To(BeNil())

--- a/controlplane/pkg/nsmd/client.go
+++ b/controlplane/pkg/nsmd/client.go
@@ -35,5 +35,5 @@ func newNetworkServiceClientSocket() (*grpc.ClientConn, error) {
 		return nil, err
 	}
 
-	return tools.SocketOperationCheck(tools.SocketPath(nsmServerSocket))
+	return tools.DialUnix(nsmServerSocket)
 }

--- a/controlplane/pkg/nsmd/dataplanes.go
+++ b/controlplane/pkg/nsmd/dataplanes.go
@@ -63,7 +63,7 @@ func dataplaneMonitor(model model.Model, dataplaneName string) {
 		logrus.Errorf("Dataplane object store does not have registered plugin %s", dataplaneName)
 		return
 	}
-	conn, err := tools.SocketOperationCheck(tools.SocketPath(dataplane.SocketLocation))
+	conn, err := tools.DialUnix(dataplane.SocketLocation)
 	if err != nil {
 		logrus.Errorf("failure to communicate with the socket %s with error: %+v", dataplane.SocketLocation, err)
 		model.DeleteDataplane(dataplaneName)
@@ -170,7 +170,7 @@ func (dataplaneRegistrarServer *dataplaneRegistrarServer) startDataplaneRegistra
 		}
 	}()
 
-	conn, err := tools.SocketOperationCheck(tools.SocketPath(dataplaneRegistrar))
+	conn, err := tools.DialUnix(dataplaneRegistrar)
 	if err != nil {
 		logrus.Errorf("failure to communicate with the socket %s with error: %+v", dataplaneRegistrar, err)
 		return err

--- a/controlplane/pkg/nsmd/workspace.go
+++ b/controlplane/pkg/nsmd/workspace.go
@@ -15,7 +15,6 @@
 package nsmd
 
 import (
-	"context"
 	"net"
 	"os"
 	"sync"
@@ -115,7 +114,8 @@ func NewWorkSpace(nsm *nsmServer, name string, restore bool) (*Workspace, error)
 			return
 		}
 	}()
-	conn, err := tools.SocketOperationCheck(tools.SocketPath(socket))
+
+	conn, err := tools.DialUnix(socket)
 	if err != nil {
 		logrus.Errorf("failure to communicate with the socket %s with error: %+v", socket, err)
 		return nil, err
@@ -167,10 +167,7 @@ func (w *Workspace) Close() {
 }
 
 func (w *Workspace) isConnectionAlive(timeout time.Duration) bool {
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
-	defer cancel()
-
-	nseConn, err := tools.SocketOperationCheckContext(ctx, tools.SocketPath(w.NsmClientSocket()))
+	nseConn, err := tools.DialTimeoutUnix(w.NsmClientSocket(), timeout)
 	if err != nil {
 		return false
 	}

--- a/controlplane/pkg/tests/nsmd_crossconnect_client_test.go
+++ b/controlplane/pkg/tests/nsmd_crossconnect_client_test.go
@@ -2,6 +2,7 @@ package tests
 
 import (
 	"context"
+	"github.com/networkservicemesh/networkservicemesh/pkg/tools"
 	"net"
 	"testing"
 
@@ -107,7 +108,7 @@ func TestCCServerEmpty(t *testing.T) {
 
 func readNMSDCrossConnectEvents(address string, count int) []*crossconnect.CrossConnectEvent {
 	var err error
-	conn, err := grpc.Dial(address, grpc.WithInsecure())
+	conn, err := tools.DialTCP(address)
 	if err != nil {
 		logrus.Errorf("failure to communicate with the socket %s with error: %+v", address, err)
 		return nil

--- a/controlplane/pkg/tests/nsmd_test_utils.go
+++ b/controlplane/pkg/tests/nsmd_test_utils.go
@@ -227,7 +227,7 @@ func (impl *nsmdTestServiceRegistry) RemoteNetworkServiceClient(ctx context.Cont
 	}
 
 	logrus.Println("Remote Network Service is available, attempting to connect...")
-	conn, err := grpc.Dial(nsm.Url, grpc.WithInsecure())
+	conn, err := tools.DialTCP(nsm.GetUrl())
 	if err != nil {
 		logrus.Errorf("Failed to dial Network Service Registry at %s: %s", nsm.Url, err)
 		return nil, nil, err
@@ -332,7 +332,7 @@ func (impl *nsmdTestServiceRegistry) NSMDApiClient() (nsmdapi.NSMDClient, *grpc.
 	if err != nil {
 		return nil, nil, err
 	}
-	conn, err := grpc.Dial(addr, grpc.WithInsecure())
+	conn, err := tools.DialTCP(addr)
 	if err != nil {
 		logrus.Errorf("Failed to dial Network Service Registry at %s: %s", addr, err)
 		return nil, nil, err
@@ -400,8 +400,7 @@ func newNetworkServiceClient(nsmServerSocket string) (local_networkservice.Netwo
 		return nil, nil, err
 	}
 
-	conn, err := tools.SocketOperationCheck(tools.SocketPath(nsmServerSocket))
-
+	conn, err := tools.DialUnix(nsmServerSocket)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/controlplane/pkg/tests/test-listener.go
+++ b/controlplane/pkg/tests/test-listener.go
@@ -86,9 +86,13 @@ func (impl *testConnectionModelListener) WaitUpdate(count int, duration time.Dur
 	st := time.Now()
 	for {
 		<-time.After(stepTimeout)
+		impl.RLock()
 		if impl.updates == count {
+			impl.RUnlock()
 			break
 		}
+		impl.RUnlock()
+
 		if time.Since(st) > duration {
 			t.Fatalf("Failed to wait for add events.. %d timeout happened...", count)
 			break

--- a/dataplane/pkg/common/dataplaneregistrarclient.go
+++ b/dataplane/pkg/common/dataplaneregistrarclient.go
@@ -80,7 +80,7 @@ func (dr *DataplaneRegistration) tryRegistration(ctx context.Context) error {
 			return err
 		}
 	}
-	conn, err := tools.SocketOperationCheck(dr.registrar.registrarSocket)
+	conn, err := tools.DialTimeout(dr.registrar.registrarSocket, 5*time.Second)
 	if err != nil {
 		logrus.Errorf("%s: failure to communicate with the socket \"%v\" with error: %+v", dr.dataplaneName, dr.registrar.registrarSocket, err)
 		return err
@@ -145,9 +145,7 @@ func (dr *DataplaneRegistration) Close() {
 	dr.cancelFunc()
 
 	if dr.wasRegistered {
-		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
-		defer cancel()
-		conn, err := tools.SocketOperationCheckContext(ctx, dr.registrar.registrarSocket)
+		conn, err := tools.DialTimeout(dr.registrar.registrarSocket, 1*time.Second)
 		if err != nil {
 			logrus.Errorf("%s: failure to communicate with the socket %v with error: %+v", dr.dataplaneName, dr.registrar.registrarSocket, err)
 			return

--- a/dataplane/vppagent/pkg/vppagent/metrics_collector.go
+++ b/dataplane/vppagent/pkg/vppagent/metrics_collector.go
@@ -3,18 +3,16 @@ package vppagent
 import (
 	"context"
 	"fmt"
+	"github.com/networkservicemesh/networkservicemesh/pkg/tools"
 	"io"
 	"time"
 
 	"github.com/gogo/protobuf/proto"
-	"github.com/grpc-ecosystem/grpc-opentracing/go/otgrpc"
 	rpc "github.com/ligato/vpp-agent/api/configurator"
 	interfaces "github.com/ligato/vpp-agent/api/models/vpp/interfaces"
 	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/crossconnect"
 	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/metrics"
-	"github.com/opentracing/opentracing-go"
 	"github.com/sirupsen/logrus"
-	"google.golang.org/grpc"
 )
 
 type MetricsCollector struct {
@@ -34,12 +32,7 @@ func (m *MetricsCollector) CollectAsync(monitor metrics.MetricsMonitor, endpoint
 }
 
 func (m *MetricsCollector) collect(monitor metrics.MetricsMonitor, endpoint string) {
-	tracer := opentracing.GlobalTracer()
-	conn, err := grpc.Dial(endpoint, grpc.WithInsecure(),
-		grpc.WithUnaryInterceptor(
-			otgrpc.OpenTracingClientInterceptor(tracer, otgrpc.LogPayloads())),
-		grpc.WithStreamInterceptor(
-			otgrpc.OpenTracingStreamClientInterceptor(tracer)))
+	conn, err := tools.DialTCP(endpoint)
 	if err != nil {
 		logrus.Errorf("Metrics collector: can't dial %v", err)
 		return

--- a/dataplane/vppagent/pkg/vppagent/vppagent.go
+++ b/dataplane/vppagent/pkg/vppagent/vppagent.go
@@ -23,17 +23,15 @@ import (
 	"github.com/gogo/protobuf/proto"
 	"github.com/ligato/vpp-agent/api/configurator"
 	"github.com/ligato/vpp-agent/api/models/vpp"
-	vpp_acl "github.com/ligato/vpp-agent/api/models/vpp/acl"
-	vpp_interfaces "github.com/ligato/vpp-agent/api/models/vpp/interfaces"
-	vpp_l3 "github.com/ligato/vpp-agent/api/models/vpp/l3"
+	"github.com/ligato/vpp-agent/api/models/vpp/acl"
+	"github.com/ligato/vpp-agent/api/models/vpp/interfaces"
+	"github.com/ligato/vpp-agent/api/models/vpp/l3"
 
 	"github.com/networkservicemesh/networkservicemesh/dataplane/pkg/common"
 
 	"github.com/golang/protobuf/ptypes/empty"
-	"github.com/grpc-ecosystem/grpc-opentracing/go/otgrpc"
 	"github.com/opentracing/opentracing-go"
 	"github.com/sirupsen/logrus"
-	"google.golang.org/grpc"
 	"google.golang.org/grpc/status"
 
 	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/crossconnect"
@@ -110,12 +108,7 @@ func (v *VPPAgent) connectOrDisconnect(ctx context.Context, crossConnect *crossc
 	}
 
 	// TODO look at whether keepin a single conn might be better
-	tracer := opentracing.GlobalTracer()
-	conn, err := grpc.Dial(v.vppAgentEndpoint, grpc.WithInsecure(),
-		grpc.WithUnaryInterceptor(
-			otgrpc.OpenTracingClientInterceptor(tracer, otgrpc.LogPayloads())),
-		grpc.WithStreamInterceptor(
-			otgrpc.OpenTracingStreamClientInterceptor(tracer)))
+	conn, err := tools.DialTCP(v.vppAgentEndpoint)
 	if err != nil {
 		logrus.Errorf("can't dial grpc server: %v", err)
 		return nil, err
@@ -160,12 +153,8 @@ func (v *VPPAgent) reset() error {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 	tools.WaitForPortAvailable(ctx, "tcp", v.vppAgentEndpoint, 100*time.Millisecond)
-	tracer := opentracing.GlobalTracer()
-	conn, err := grpc.Dial(v.vppAgentEndpoint, grpc.WithInsecure(),
-		grpc.WithUnaryInterceptor(
-			otgrpc.OpenTracingClientInterceptor(tracer, otgrpc.LogPayloads())),
-		grpc.WithStreamInterceptor(
-			otgrpc.OpenTracingStreamClientInterceptor(tracer)))
+
+	conn, err := tools.DialTCP(v.vppAgentEndpoint)
 	if err != nil {
 		logrus.Errorf("can't dial grpc server: %v", err)
 		return err
@@ -185,12 +174,8 @@ func (v *VPPAgent) programMgmtInterface() error {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 	tools.WaitForPortAvailable(ctx, "tcp", v.vppAgentEndpoint, 100*time.Millisecond)
-	tracer := opentracing.GlobalTracer()
-	conn, err := grpc.Dial(v.vppAgentEndpoint, grpc.WithInsecure(),
-		grpc.WithUnaryInterceptor(
-			otgrpc.OpenTracingClientInterceptor(tracer, otgrpc.LogPayloads())),
-		grpc.WithStreamInterceptor(
-			otgrpc.OpenTracingStreamClientInterceptor(tracer)))
+
+	conn, err := tools.DialTCP(v.vppAgentEndpoint)
 	if err != nil {
 		logrus.Errorf("can't dial grpc server: %v", err)
 		return err

--- a/k8s/cmd/crossconnect-monitor/crossconnect_monitor.go
+++ b/k8s/cmd/crossconnect-monitor/crossconnect_monitor.go
@@ -4,13 +4,13 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"github.com/networkservicemesh/networkservicemesh/pkg/tools"
 	"path/filepath"
 	"time"
 
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/sirupsen/logrus"
-	"google.golang.org/grpc"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -27,7 +27,7 @@ var managers = map[string]string{}
 func monitorCrossConnects(address string, continuousMonitor bool) {
 	var err error
 	logrus.Infof("Starting CrossConnections Monitor on %s", address)
-	conn, err := grpc.Dial(address, grpc.WithInsecure())
+	conn, err := tools.DialTCP(address)
 	if err != nil {
 		logrus.Errorf("failure to communicate with the socket %s with error: %+v", address, err)
 		return

--- a/k8s/cmd/nsmdp/nsmdp.go
+++ b/k8s/cmd/nsmdp/nsmdp.go
@@ -91,19 +91,12 @@ func (n *nsmClientEndpoints) Allocate(ctx context.Context, reqs *pluginapi.Alloc
 
 // Register registers
 func Register(kubeletEndpoint string) error {
-	tracer := opentracing.GlobalTracer()
-	conn, err := grpc.Dial(kubeletEndpoint, grpc.WithInsecure(),
-		grpc.WithDialer(func(addr string, timeout time.Duration) (net.Conn, error) {
-			return net.DialTimeout("unix", addr, timeout)
-		}),
-		grpc.WithUnaryInterceptor(
-			otgrpc.OpenTracingClientInterceptor(tracer, otgrpc.LogPayloads())),
-		grpc.WithStreamInterceptor(
-			otgrpc.OpenTracingStreamClientInterceptor(tracer)))
-	defer conn.Close()
+	conn, err := tools.DialUnix(kubeletEndpoint)
 	if err != nil {
 		return fmt.Errorf("device-plugin: cannot connect to kubelet service: %v", err)
 	}
+	defer func() { _ = conn.Close() }()
+
 	client := pluginapi.NewRegistrationClient(conn)
 	reqt := &pluginapi.RegisterRequest{
 		Version:      pluginapi.Version,
@@ -189,7 +182,7 @@ func startDeviceServer(nsm *nsmClientEndpoints) error {
 		}
 	}()
 	// Check if the socket of device plugin server is operation
-	conn, err := tools.SocketOperationCheck(tools.SocketPath(listenEndpoint))
+	conn, err := tools.DialUnix(listenEndpoint)
 	if err != nil {
 		return err
 	}

--- a/pkg/tools/socket.go
+++ b/pkg/tools/socket.go
@@ -1,0 +1,135 @@
+package tools
+
+import (
+	"context"
+	"github.com/grpc-ecosystem/grpc-opentracing/go/otgrpc"
+	"github.com/opentracing/opentracing-go"
+	"github.com/sirupsen/logrus"
+	"google.golang.org/grpc"
+	"net"
+	"os"
+	"strconv"
+	"time"
+)
+
+const (
+	opentracingEnv     = "OPEN_TRACING"
+	opentracingDefault = true
+	insecureEnv        = "INSECURE"
+	insecureDefault    = true
+	dialTimeoutDefault = 5 * time.Second
+)
+
+type dialConfig struct {
+	opentracing bool
+	insecure    bool
+}
+
+var cfg dialConfig
+
+func init() {
+	var err error
+	cfg, err = readConfiguration()
+	if err != nil {
+		logrus.Fatal(err)
+	}
+}
+
+func readConfiguration() (dialConfig, error) {
+	rv := dialConfig{}
+
+	if ot, err := readEnvBool(opentracingEnv, opentracingDefault); err == nil {
+		rv.opentracing = ot
+	} else {
+		return dialConfig{}, err
+	}
+
+	if insecure, err := readEnvBool(insecureEnv, insecureDefault); err == nil {
+		rv.insecure = insecure
+	} else {
+		return dialConfig{}, err
+	}
+
+	return rv, nil
+}
+
+func readEnvBool(env string, value bool) (bool, error) {
+	str := os.Getenv(env)
+	if str == "" {
+		return value, nil
+	}
+
+	return strconv.ParseBool(str)
+}
+
+// DialContext checks dialConfig and calls grpc.DialContext with certain grpc.DialOption
+func DialContext(ctx context.Context, addr net.Addr, opts ...grpc.DialOption) (*grpc.ClientConn, error) {
+	if cfg.insecure {
+		opts = append(opts, grpc.WithInsecure())
+	}
+
+	if cfg.opentracing {
+		opts = append(opts,
+			grpc.WithUnaryInterceptor(
+				otgrpc.OpenTracingClientInterceptor(opentracing.GlobalTracer(), otgrpc.LogPayloads())),
+			grpc.WithStreamInterceptor(
+				otgrpc.OpenTracingStreamClientInterceptor(opentracing.GlobalTracer())))
+	}
+
+	opts = append(opts,
+		grpc.WithBlock(),
+		grpc.WithContextDialer(func(ctx context.Context, target string) (net.Conn, error) {
+			return net.Dial(addr.Network(), target)
+		}))
+
+	return grpc.DialContext(ctx, addr.String(), opts...)
+}
+
+// DialTimeout tries to establish connection with addr during timeout
+func DialTimeout(addr net.Addr, timeout time.Duration, opts ...grpc.DialOption) (*grpc.ClientConn, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	return DialContext(ctx, addr, opts...)
+}
+
+// DialContextUnix establish connection with passed unix socket
+func DialContextUnix(ctx context.Context, path string, opts ...grpc.DialOption) (*grpc.ClientConn, error) {
+	addr, err := net.ResolveUnixAddr("unix", path)
+	if err != nil {
+		return nil, err
+	}
+	return DialContext(ctx, addr, opts...)
+}
+
+// DialTimeoutUnix tries to establish connection with passed unix socket during timeout
+func DialTimeoutUnix(path string, timeout time.Duration, opts ...grpc.DialOption) (*grpc.ClientConn, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	return DialContextUnix(ctx, path, opts...)
+}
+
+// DialUnix simply calls DialTimeoutUnix with default timeout
+func DialUnix(path string, opts ...grpc.DialOption) (*grpc.ClientConn, error) {
+	return DialTimeoutUnix(path, dialTimeoutDefault, opts...)
+}
+
+// DialContextTCP establish TCP connection with address
+func DialContextTCP(ctx context.Context, address string, opts ...grpc.DialOption) (*grpc.ClientConn, error) {
+	addr, err := net.ResolveTCPAddr("tcp", address)
+	if err != nil {
+		return nil, err
+	}
+	return DialContext(ctx, addr, opts...)
+}
+
+// DialTimeoutTCP tries to establish connection with passed address during timeout
+func DialTimeoutTCP(address string, timeout time.Duration, opts ...grpc.DialOption) (*grpc.ClientConn, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	return DialContextTCP(ctx, address, opts...)
+}
+
+// DialTCP simply calls DialTimeoutTCP with default timeout
+func DialTCP(address string, opts ...grpc.DialOption) (*grpc.ClientConn, error) {
+	return DialTimeoutTCP(address, dialTimeoutDefault, opts...)
+}

--- a/sdk/common/connection.go
+++ b/sdk/common/connection.go
@@ -58,21 +58,13 @@ func NewNSMConnection(ctx context.Context, configuration *NSConfiguration) (*Nsm
 	// logrus.Infof("Starting NSE, linux namespace: %s", linuxNS)
 
 	// NSE connection server is ready and now endpoints can be advertised to NSM
-
-	// Check if the socket of Endpoint Connection Server is operable
-	testSocket, err := tools.SocketOperationCheck(tools.SocketPath(configuration.NsmServerSocket))
-	if err != nil {
-		logrus.Errorf("nse: failure to communicate with the nsm on socket %s with error: %v", configuration.NsmServerSocket, err)
-		return nil, err
-	}
-	testSocket.Close()
-
 	if _, err := os.Stat(configuration.NsmServerSocket); err != nil {
 		logrus.Errorf("nse: failure to access nsm socket at %s with error: %+v, exiting...", configuration.NsmServerSocket, err)
 		return nil, err
 	}
 
-	conn.GrpcClient, err = tools.SocketOperationCheck(tools.SocketPath(configuration.NsmServerSocket))
+	var err error
+	conn.GrpcClient, err = tools.DialUnix(configuration.NsmServerSocket)
 	if err != nil {
 		logrus.Errorf("nse: failure to communicate with the registrySocket %s with error: %+v", configuration.NsmServerSocket, err)
 		return nil, err

--- a/sdk/vppagent/flush.go
+++ b/sdk/vppagent/flush.go
@@ -6,14 +6,12 @@ import (
 	"time"
 
 	"github.com/golang/protobuf/ptypes/empty"
-	"github.com/grpc-ecosystem/grpc-opentracing/go/otgrpc"
 	"github.com/ligato/vpp-agent/api/configurator"
 	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/local/connection"
 	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/local/networkservice"
 	"github.com/networkservicemesh/networkservicemesh/pkg/tools"
 	"github.com/networkservicemesh/networkservicemesh/sdk/common"
 	"github.com/networkservicemesh/networkservicemesh/sdk/endpoint"
-	"github.com/opentracing/opentracing-go"
 	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
 )
@@ -120,13 +118,7 @@ func (f *Flush) createConnection(ctx context.Context) (*grpc.ClientConn, error) 
 		return nil, err
 	}
 
-	tracer := opentracing.GlobalTracer()
-	rv, err := grpc.Dial(f.Endpoint, grpc.WithInsecure(),
-		grpc.WithUnaryInterceptor(
-			otgrpc.OpenTracingClientInterceptor(tracer, otgrpc.LogPayloads())),
-		grpc.WithStreamInterceptor(
-			otgrpc.OpenTracingStreamClientInterceptor(tracer)))
-
+	rv, err := tools.DialTCP(f.Endpoint)
 	if err != nil {
 		logrus.Errorf("Can't dial grpc server: %v", err)
 		return nil, err

--- a/test/applications/cmd/proxy-xcon-monitor/main.go
+++ b/test/applications/cmd/proxy-xcon-monitor/main.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/crossconnect"
+	"github.com/networkservicemesh/networkservicemesh/pkg/tools"
 	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
 	"net"
@@ -28,7 +29,7 @@ type proxyMonitor struct {
 func (p *proxyMonitor) MonitorCrossConnects(empty *empty.Empty, src crossconnect.MonitorCrossConnect_MonitorCrossConnectsServer) error {
 	logrus.Infof("MonitorCrossConnects called, address - %v", p.address)
 
-	conn, err := grpc.Dial(p.address, grpc.WithInsecure())
+	conn, err := tools.DialTCP(p.address)
 	if err != nil {
 		logrus.Error(err)
 		return err

--- a/test/integration/basic_dataplane_standalone_test.go
+++ b/test/integration/basic_dataplane_standalone_test.go
@@ -175,7 +175,7 @@ func (fixture *standaloneDataplaneFixture) forwardDataplanePort(port int) {
 }
 
 func (fixture *standaloneDataplaneFixture) connectDataplane() {
-	dataplaneConn, err := tools.SocketOperationCheck(localPort(dataplaneSocketType, fixture.forwarding.ListenPort))
+	dataplaneConn, err := tools.DialTimeout(localPort(dataplaneSocketType, fixture.forwarding.ListenPort), 5*time.Second)
 	Expect(err).To(BeNil())
 	fixture.dataplaneClient = dataplaneapi.NewDataplaneClient(dataplaneConn)
 }

--- a/test/integration/basic_monitor_crossconnect_metrics_test.go
+++ b/test/integration/basic_monitor_crossconnect_metrics_test.go
@@ -3,8 +3,6 @@
 package nsmd_integration_tests
 
 import (
-	"context"
-	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/crossconnect"
 
 	"testing"
@@ -15,7 +13,6 @@ import (
 	"github.com/networkservicemesh/networkservicemesh/test/kubetest/pods"
 	. "github.com/onsi/gomega"
 	"github.com/sirupsen/logrus"
-	"google.golang.org/grpc"
 )
 
 func TestSimpleMetrics(t *testing.T) {
@@ -66,29 +63,6 @@ func TestSimpleMetrics(t *testing.T) {
 	case <-time.After(defaultTimeout):
 		t.Fatalf("Fail to get metrics during %v", defaultTimeout)
 	}
-}
-
-func crossConnectClient(address string) (crossconnect.MonitorCrossConnect_MonitorCrossConnectsClient, func()) {
-	var err error
-	logrus.Infof("Starting CrossConnections Monitor on %s", address)
-	conn, err := grpc.Dial(address, grpc.WithInsecure())
-	if err != nil {
-		Expect(err).To(BeNil())
-		return nil, nil
-	}
-	monitorClient := crossconnect.NewMonitorCrossConnectClient(conn)
-	stream, err := monitorClient.MonitorCrossConnects(context.Background(), &empty.Empty{})
-	if err != nil {
-		Expect(err).To(BeNil())
-		return nil, nil
-	}
-
-	closeFunc := func() {
-		if err := conn.Close(); err != nil {
-			logrus.Errorf("Closing the stream with: %v", err)
-		}
-	}
-	return stream, closeFunc
 }
 
 func metricsFromEventCh(eventCh <-chan *crossconnect.CrossConnectEvent) chan map[string]string {

--- a/test/kubetest/monitor_utils.go
+++ b/test/kubetest/monitor_utils.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/networkservicemesh/networkservicemesh/pkg/tools"
 	"github.com/networkservicemesh/networkservicemesh/test/kubetest/pods"
 	"testing"
 	"time"
@@ -13,7 +14,6 @@ import (
 	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/local/connection"
 	. "github.com/onsi/gomega"
 	"github.com/sirupsen/logrus"
-	"google.golang.org/grpc"
 	"k8s.io/api/core/v1"
 )
 
@@ -203,7 +203,7 @@ func getEventCh(mc MonitorClient, cf context.CancelFunc, stopCh <-chan struct{})
 func CreateCrossConnectClient(address string) (MonitorClient, func(), context.CancelFunc) {
 	var err error
 	logrus.Infof("Starting CrossConnections Monitor on %s", address)
-	conn, err := grpc.Dial(address, grpc.WithInsecure())
+	conn, err := tools.DialTCP(address)
 	if err != nil {
 		Expect(err).To(BeNil())
 		return nil, nil, nil


### PR DESCRIPTION
Signed-off-by: lobkovilya <ilya.lobkov@xored.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Wrap `grpc.Dial` to `tools.Dial` with adding specific for project `grpc.DialOption` (configuring opentracing and security)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Throughout the project we have several ways to establish connections, lots of timeouts and opentracing is configured from scratch every time. 

To simplify adding security interceptors and credentials much better to have one configurable Dial that will be used everywhere in project.

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [ ] Covered by existing integration testing
- [ ] Added integration testing to cover
- [ ] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
