### PR TITLE
Using NewWithT instead of RegisterTestingT

### DIFF
--- a/controlplane/pkg/model/base_test.go
+++ b/controlplane/pkg/model/base_test.go
@@ -19,7 +19,7 @@ func (r *testResource) clone() cloneable {
 }
 
 func TestModificationHandler(t *testing.T) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
 
 	bd := baseDomain{}
 	resource := &testResource{"test"}
@@ -33,16 +33,16 @@ func TestModificationHandler(t *testing.T) {
 		bd.addHandler(&ModificationHandler{
 			AddFunc: func(new interface{}) {
 				defer wg.Done()
-				Expect(new.(*testResource).value).To(Equal(resource.value))
+				g.Expect(new.(*testResource).value).To(Equal(resource.value))
 			},
 			UpdateFunc: func(old interface{}, new interface{}) {
 				defer wg.Done()
-				Expect(old.(*testResource).value).To(Equal(resource.value))
-				Expect(new.(*testResource).value).To(Equal(updResource.value))
+				g.Expect(old.(*testResource).value).To(Equal(resource.value))
+				g.Expect(new.(*testResource).value).To(Equal(updResource.value))
 			},
 			DeleteFunc: func(del interface{}) {
 				defer wg.Done()
-				Expect(del.(*testResource).value).To(Equal(resource.value))
+				g.Expect(del.(*testResource).value).To(Equal(resource.value))
 			},
 		})
 	}

--- a/controlplane/pkg/model/client_connection_test.go
+++ b/controlplane/pkg/model/client_connection_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestAddAndGetСс(t *testing.T) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
 
 	cc := &ClientConnection{
 		ConnectionID: "1",
@@ -46,22 +46,22 @@ func TestAddAndGetСс(t *testing.T) {
 	ccd.AddClientConnection(cc)
 	getConn := ccd.GetClientConnection("1")
 
-	Expect(getConn.ConnectionID).To(Equal(cc.ConnectionID))
-	Expect(getConn.ConnectionState).To(Equal(cc.ConnectionState))
-	Expect(getConn.DataplaneState).To(Equal(cc.DataplaneState))
-	Expect(getConn.Request).To(BeNil())
+	g.Expect(getConn.ConnectionID).To(Equal(cc.ConnectionID))
+	g.Expect(getConn.ConnectionState).To(Equal(cc.ConnectionState))
+	g.Expect(getConn.DataplaneState).To(Equal(cc.DataplaneState))
+	g.Expect(getConn.Request).To(BeNil())
 
-	Expect(getConn.GetNetworkService()).To(Equal(cc.GetNetworkService()))
-	Expect(getConn.GetID()).To(Equal(cc.GetID()))
+	g.Expect(getConn.GetNetworkService()).To(Equal(cc.GetNetworkService()))
+	g.Expect(getConn.GetID()).To(Equal(cc.GetID()))
 
-	Expect(fmt.Sprintf("%p", getConn.RemoteNsm)).ToNot(Equal(fmt.Sprintf("%p", cc.RemoteNsm)))
-	Expect(fmt.Sprintf("%p", getConn.Endpoint)).ToNot(Equal(fmt.Sprintf("%p", cc.Endpoint)))
-	Expect(fmt.Sprintf("%p", getConn.Endpoint.NetworkServiceManager)).
+	g.Expect(fmt.Sprintf("%p", getConn.RemoteNsm)).ToNot(Equal(fmt.Sprintf("%p", cc.RemoteNsm)))
+	g.Expect(fmt.Sprintf("%p", getConn.Endpoint)).ToNot(Equal(fmt.Sprintf("%p", cc.Endpoint)))
+	g.Expect(fmt.Sprintf("%p", getConn.Endpoint.NetworkServiceManager)).
 		ToNot(Equal(fmt.Sprintf("%p", cc.Endpoint.NetworkServiceManager)))
 }
 
 func TestGetAllСс(t *testing.T) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
 
 	ccd := newClientConnectionDomain()
 	amount := 5
@@ -97,7 +97,7 @@ func TestGetAllСс(t *testing.T) {
 	}
 
 	all := ccd.GetAllClientConnections()
-	Expect(len(all)).To(Equal(amount))
+	g.Expect(len(all)).To(Equal(amount))
 
 	expected := make([]bool, amount)
 	for i := 0; i < amount; i++ {
@@ -106,12 +106,12 @@ func TestGetAllСс(t *testing.T) {
 	}
 
 	for i := 0; i < amount; i++ {
-		Expect(expected[i]).To(BeTrue())
+		g.Expect(expected[i]).To(BeTrue())
 	}
 }
 
 func TestDeleteСс(t *testing.T) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
 
 	ccd := newClientConnectionDomain()
 	ccd.AddClientConnection(&ClientConnection{
@@ -143,19 +143,19 @@ func TestDeleteСс(t *testing.T) {
 	})
 
 	cc := ccd.GetClientConnection("1")
-	Expect(cc).ToNot(BeNil())
+	g.Expect(cc).ToNot(BeNil())
 
 	ccd.DeleteClientConnection("1")
 
 	ccDel := ccd.GetClientConnection("1")
-	Expect(ccDel).To(BeNil())
+	g.Expect(ccDel).To(BeNil())
 
 	ccd.DeleteClientConnection("NotExistingId")
 
 }
 
 func TestUpdateExistingСс(t *testing.T) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
 
 	cc := &ClientConnection{
 		ConnectionID: "1",
@@ -194,17 +194,17 @@ func TestUpdateExistingСс(t *testing.T) {
 	cc.DataplaneRegisteredName = newDpName
 
 	notUpdated := ccd.GetClientConnection("1")
-	Expect(notUpdated.Endpoint.NetworkServiceManager.Url).ToNot(Equal(newUrl))
-	Expect(notUpdated.DataplaneRegisteredName).ToNot(Equal(newDpName))
+	g.Expect(notUpdated.Endpoint.NetworkServiceManager.Url).ToNot(Equal(newUrl))
+	g.Expect(notUpdated.DataplaneRegisteredName).ToNot(Equal(newDpName))
 
 	ccd.UpdateClientConnection(cc)
 	updated := ccd.GetClientConnection("1")
-	Expect(updated.Endpoint.NetworkServiceManager.Url).To(Equal(newUrl))
-	Expect(updated.DataplaneRegisteredName).To(Equal(newDpName))
+	g.Expect(updated.Endpoint.NetworkServiceManager.Url).To(Equal(newUrl))
+	g.Expect(updated.DataplaneRegisteredName).To(Equal(newDpName))
 }
 
 func TestUpdateNotExistingСс(t *testing.T) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
 
 	cc := &ClientConnection{
 		ConnectionID: "1",
@@ -238,12 +238,12 @@ func TestUpdateNotExistingСс(t *testing.T) {
 
 	ccd.UpdateClientConnection(cc)
 	updated := ccd.GetClientConnection("1")
-	Expect(updated.Endpoint.NetworkServiceManager.Url).To(Equal("2.2.2.2"))
-	Expect(updated.DataplaneRegisteredName).To(Equal("dp1"))
+	g.Expect(updated.Endpoint.NetworkServiceManager.Url).To(Equal("2.2.2.2"))
+	g.Expect(updated.DataplaneRegisteredName).To(Equal("dp1"))
 }
 
 func TestApplyChanges(t *testing.T) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
 
 	ccd := newClientConnectionDomain()
 	ccd.AddClientConnection(&ClientConnection{
@@ -278,5 +278,5 @@ func TestApplyChanges(t *testing.T) {
 		cc.RemoteNsm.Name = "updatedMaster"
 	})
 	upd := ccd.GetClientConnection("1")
-	Expect(upd.RemoteNsm.Name).To(Equal("updatedMaster"))
+	g.Expect(upd.RemoteNsm.Name).To(Equal("updatedMaster"))
 }

--- a/controlplane/pkg/model/dataplane_test.go
+++ b/controlplane/pkg/model/dataplane_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestAddAndGetDp(t *testing.T) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
 
 	dp := &Dataplane{
 		RegisteredName: "dp1",
@@ -40,18 +40,18 @@ func TestAddAndGetDp(t *testing.T) {
 	dd.AddDataplane(dp)
 	getDp := dd.GetDataplane("dp1")
 
-	Expect(getDp.RegisteredName).To(Equal(dp.RegisteredName))
-	Expect(getDp.SocketLocation).To(Equal(dp.SocketLocation))
-	Expect(getDp.MechanismsConfigured).To(Equal(dp.MechanismsConfigured))
-	Expect(getDp.LocalMechanisms).To(Equal(dp.LocalMechanisms))
-	Expect(getDp.RemoteMechanisms).To(Equal(dp.RemoteMechanisms))
+	g.Expect(getDp.RegisteredName).To(Equal(dp.RegisteredName))
+	g.Expect(getDp.SocketLocation).To(Equal(dp.SocketLocation))
+	g.Expect(getDp.MechanismsConfigured).To(Equal(dp.MechanismsConfigured))
+	g.Expect(getDp.LocalMechanisms).To(Equal(dp.LocalMechanisms))
+	g.Expect(getDp.RemoteMechanisms).To(Equal(dp.RemoteMechanisms))
 
-	Expect(fmt.Sprintf("%p", getDp.LocalMechanisms)).ToNot(Equal(fmt.Sprintf("%p", dp.LocalMechanisms)))
-	Expect(fmt.Sprintf("%p", getDp.RemoteMechanisms)).ToNot(Equal(fmt.Sprintf("%p", dp.RemoteMechanisms)))
+	g.Expect(fmt.Sprintf("%p", getDp.LocalMechanisms)).ToNot(Equal(fmt.Sprintf("%p", dp.LocalMechanisms)))
+	g.Expect(fmt.Sprintf("%p", getDp.RemoteMechanisms)).ToNot(Equal(fmt.Sprintf("%p", dp.RemoteMechanisms)))
 }
 
 func TestDeleteDp(t *testing.T) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
 
 	dd := newDataplaneDomain()
 	dd.AddDataplane(&Dataplane{
@@ -77,18 +77,18 @@ func TestDeleteDp(t *testing.T) {
 	})
 
 	cc := dd.GetDataplane("dp1")
-	Expect(cc).ToNot(BeNil())
+	g.Expect(cc).ToNot(BeNil())
 
 	dd.DeleteDataplane("dp1")
 
 	dpDel := dd.GetDataplane("dp1")
-	Expect(dpDel).To(BeNil())
+	g.Expect(dpDel).To(BeNil())
 
 	dd.DeleteDataplane("NotExistingId")
 }
 
 func TestSelectDp(t *testing.T) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
 
 	amount := 5
 	dd := newDataplaneDomain()
@@ -121,17 +121,17 @@ func TestSelectDp(t *testing.T) {
 	}
 
 	selectedDp, err := dd.SelectDataplane(selector)
-	Expect(err).To(BeNil())
-	Expect(selectedDp.RegisteredName).To(Equal("dp4"))
+	g.Expect(err).To(BeNil())
+	g.Expect(selectedDp.RegisteredName).To(Equal("dp4"))
 
 	emptySelector := func(dp *Dataplane) bool {
 		return false
 	}
 	selectedDp, err = dd.SelectDataplane(emptySelector)
-	Expect(err.Error()).To(ContainSubstring("no appropriate dataplanes found"))
-	Expect(selectedDp).To(BeNil())
+	g.Expect(err.Error()).To(ContainSubstring("no appropriate dataplanes found"))
+	g.Expect(selectedDp).To(BeNil())
 
 	first, err := dd.SelectDataplane(nil)
-	Expect(err).To(BeNil())
-	Expect(first.RegisteredName).ToNot(BeNil())
+	g.Expect(err).To(BeNil())
+	g.Expect(first.RegisteredName).ToNot(BeNil())
 }

--- a/controlplane/pkg/model/endpoint_test.go
+++ b/controlplane/pkg/model/endpoint_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestAddAndGetEndpoint(t *testing.T) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
 
 	endp := &Endpoint{
 		Endpoint: &registry.NSERegistration{
@@ -35,21 +35,21 @@ func TestAddAndGetEndpoint(t *testing.T) {
 	ed.AddEndpoint(endp)
 	getEndp := ed.GetEndpoint("endp1")
 
-	Expect(getEndp.SocketLocation).To(Equal(endp.SocketLocation))
-	Expect(getEndp.Workspace).To(Equal(endp.Workspace))
-	Expect(getEndp.Endpoint).To(Equal(endp.Endpoint))
+	g.Expect(getEndp.SocketLocation).To(Equal(endp.SocketLocation))
+	g.Expect(getEndp.Workspace).To(Equal(endp.Workspace))
+	g.Expect(getEndp.Endpoint).To(Equal(endp.Endpoint))
 
-	Expect(fmt.Sprintf("%p", getEndp.Endpoint)).ToNot(Equal(fmt.Sprintf("%p", endp.Endpoint)))
-	Expect(fmt.Sprintf("%p", getEndp.Endpoint.NetworkService)).
+	g.Expect(fmt.Sprintf("%p", getEndp.Endpoint)).ToNot(Equal(fmt.Sprintf("%p", endp.Endpoint)))
+	g.Expect(fmt.Sprintf("%p", getEndp.Endpoint.NetworkService)).
 		ToNot(Equal(fmt.Sprintf("%p", endp.Endpoint.NetworkService)))
-	Expect(fmt.Sprintf("%p", getEndp.Endpoint.NetworkserviceEndpoint)).
+	g.Expect(fmt.Sprintf("%p", getEndp.Endpoint.NetworkserviceEndpoint)).
 		ToNot(Equal(fmt.Sprintf("%p", endp.Endpoint.NetworkserviceEndpoint)))
-	Expect(fmt.Sprintf("%p", getEndp.Endpoint.NetworkServiceManager)).
+	g.Expect(fmt.Sprintf("%p", getEndp.Endpoint.NetworkServiceManager)).
 		ToNot(Equal(fmt.Sprintf("%p", endp.Endpoint.NetworkServiceManager)))
 }
 
 func TestGetEndpointsByNs(t *testing.T) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
 
 	ed := newEndpointDomain()
 	amount := 5
@@ -76,35 +76,35 @@ func TestGetEndpointsByNs(t *testing.T) {
 
 	ns0 := ed.GetEndpointsByNetworkService("0")
 	count0 := (amount + 1) / 2
-	Expect(len(ns0)).To(Equal(count0))
+	g.Expect(len(ns0)).To(Equal(count0))
 
 	ns1 := ed.GetEndpointsByNetworkService("1")
 	count1 := amount - count0
-	Expect(len(ns1)).To(Equal(count1))
+	g.Expect(len(ns1)).To(Equal(count1))
 
 	expected := make([]bool, amount)
 
 	for i := 0; i < count0; i++ {
 		idxNs, _ := strconv.ParseInt(ns0[i].NetworkServiceName(), 10, 64)
 		idxEndp, _ := strconv.ParseInt(ns0[i].EndpointName(), 10, 64)
-		Expect(idxNs).To(Equal(idxEndp % 2))
+		g.Expect(idxNs).To(Equal(idxEndp % 2))
 		expected[idxEndp] = true
 	}
 
 	for i := 0; i < count1; i++ {
 		idxNs, _ := strconv.ParseInt(ns1[i].NetworkServiceName(), 10, 64)
 		idxEndp, _ := strconv.ParseInt(ns1[i].EndpointName(), 10, 64)
-		Expect(idxNs).To(Equal(idxEndp % 2))
+		g.Expect(idxNs).To(Equal(idxEndp % 2))
 		expected[idxEndp] = true
 	}
 
 	for i := 0; i < amount; i++ {
-		Expect(expected[i]).To(BeTrue())
+		g.Expect(expected[i]).To(BeTrue())
 	}
 }
 
 func TestDeleteEndpoint(t *testing.T) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
 
 	ed := newEndpointDomain()
 	ed.AddEndpoint(&Endpoint{
@@ -126,18 +126,18 @@ func TestDeleteEndpoint(t *testing.T) {
 	})
 
 	endp := ed.GetEndpoint("endp1")
-	Expect(endp).ToNot(BeNil())
+	g.Expect(endp).ToNot(BeNil())
 
 	ed.DeleteEndpoint("endp1")
 
 	endpDel := ed.GetEndpoint("endp1")
-	Expect(endpDel).To(BeNil())
+	g.Expect(endpDel).To(BeNil())
 
 	ed.DeleteEndpoint("NotExistingId")
 }
 
 func TestUpdateExistingEndpoint(t *testing.T) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
 
 	endp := &Endpoint{
 		Endpoint: &registry.NSERegistration{
@@ -166,17 +166,17 @@ func TestUpdateExistingEndpoint(t *testing.T) {
 	endp.Endpoint.NetworkService.Name = newNs
 
 	notUpdated := ed.GetEndpoint("endp1")
-	Expect(notUpdated.Endpoint.NetworkServiceManager.Url).ToNot(Equal(newUrl))
-	Expect(notUpdated.Endpoint.NetworkService.Name).ToNot(Equal(newNs))
+	g.Expect(notUpdated.Endpoint.NetworkServiceManager.Url).ToNot(Equal(newUrl))
+	g.Expect(notUpdated.Endpoint.NetworkService.Name).ToNot(Equal(newNs))
 
 	ed.UpdateEndpoint(endp)
 	updated := ed.GetEndpoint("endp1")
-	Expect(updated.Endpoint.NetworkServiceManager.Url).To(Equal(newUrl))
-	Expect(updated.Endpoint.NetworkService.Name).To(Equal(newNs))
+	g.Expect(updated.Endpoint.NetworkServiceManager.Url).To(Equal(newUrl))
+	g.Expect(updated.Endpoint.NetworkService.Name).To(Equal(newNs))
 }
 
 func TestUpdateNotExisting(t *testing.T) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
 
 	endp := &Endpoint{
 		Endpoint: &registry.NSERegistration{
@@ -200,6 +200,6 @@ func TestUpdateNotExisting(t *testing.T) {
 
 	ed.UpdateEndpoint(endp)
 	updated := ed.GetEndpoint("endp1")
-	Expect(updated.Endpoint.NetworkServiceManager.Url).To(Equal("2.2.2.2"))
-	Expect(updated.Endpoint.NetworkService.Name).To(Equal("ns1"))
+	g.Expect(updated.Endpoint.NetworkServiceManager.Url).To(Equal("2.2.2.2"))
+	g.Expect(updated.Endpoint.NetworkService.Name).To(Equal("ns1"))
 }

--- a/controlplane/pkg/model/listener_test.go
+++ b/controlplane/pkg/model/listener_test.go
@@ -4,8 +4,6 @@ import (
 	"sync"
 	"testing"
 	"time"
-
-	. "github.com/onsi/gomega"
 )
 
 type testListener struct {

--- a/controlplane/pkg/model/listener_test.go
+++ b/controlplane/pkg/model/listener_test.go
@@ -45,8 +45,6 @@ func (t *testListener) ClientConnectionUpdated(old, new *ClientConnection) {
 }
 
 func TestModelListener(t *testing.T) {
-	RegisterTestingT(t)
-
 	m := NewModel()
 	ln := testListener{}
 	ln.Add(8)

--- a/controlplane/pkg/nsm/nsm_heal_processor_test.go
+++ b/controlplane/pkg/nsm/nsm_heal_processor_test.go
@@ -91,7 +91,7 @@ func newHealTestData() *healTestData {
 }
 
 func TestHealDstDown_RemoteClientLocalEndpoint(t *testing.T) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
 	data := newHealTestData()
 
 	nse1 := data.createEndpoint(nse1Name, localNSMName)
@@ -105,7 +105,7 @@ func TestHealDstDown_RemoteClientLocalEndpoint(t *testing.T) {
 	data.model.AddClientConnection(connection)
 
 	healed := data.healProcessor.healDstDown("", data.cloneClientConnection(connection))
-	Expect(healed).To(BeFalse())
+	g.Expect(healed).To(BeFalse())
 
 	test_utils.NewModelVerifier(data.model).
 		EndpointExists(nse1Name, localNSMName).
@@ -115,7 +115,7 @@ func TestHealDstDown_RemoteClientLocalEndpoint(t *testing.T) {
 }
 
 func TestHealDstDown_LocalClientLocalEndpoint(t *testing.T) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
 	data := newHealTestData()
 
 	nse1 := data.createEndpoint(nse1Name, localNSMName)
@@ -133,7 +133,7 @@ func TestHealDstDown_LocalClientLocalEndpoint(t *testing.T) {
 	data.serviceRegistry.discoveryClient.response = data.createFindNetworkServiceResponse(nse2)
 
 	healed := data.healProcessor.healDstDown("", data.cloneClientConnection(connection))
-	Expect(healed).To(BeTrue())
+	g.Expect(healed).To(BeTrue())
 
 	test_utils.NewModelVerifier(data.model).
 		EndpointNotExists(nse1Name).
@@ -144,7 +144,7 @@ func TestHealDstDown_LocalClientLocalEndpoint(t *testing.T) {
 }
 
 func TestHealDstDown_LocalClientLocalEndpoint_NoNSEFound(t *testing.T) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
 	data := newHealTestData()
 
 	nse1 := data.createEndpoint(nse1Name, localNSMName)
@@ -158,7 +158,7 @@ func TestHealDstDown_LocalClientLocalEndpoint_NoNSEFound(t *testing.T) {
 	data.model.AddClientConnection(connection)
 
 	healed := data.healProcessor.healDstDown("", data.cloneClientConnection(connection))
-	Expect(healed).To(BeFalse())
+	g.Expect(healed).To(BeFalse())
 
 	test_utils.NewModelVerifier(data.model).
 		EndpointExists(nse1Name, localNSMName).
@@ -168,7 +168,7 @@ func TestHealDstDown_LocalClientLocalEndpoint_NoNSEFound(t *testing.T) {
 }
 
 func TestHealDstDown_LocalClientLocalEndpoint_RequestFailed(t *testing.T) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
 	data := newHealTestData()
 
 	nse1 := data.createEndpoint(nse1Name, localNSMName)
@@ -184,7 +184,7 @@ func TestHealDstDown_LocalClientLocalEndpoint_RequestFailed(t *testing.T) {
 	data.connectionManager.requestError = fmt.Errorf("request error")
 
 	healed := data.healProcessor.healDstDown("", data.cloneClientConnection(connection))
-	Expect(healed).To(BeFalse())
+	g.Expect(healed).To(BeFalse())
 
 	test_utils.NewModelVerifier(data.model).
 		EndpointExists(nse1Name, localNSMName).
@@ -193,7 +193,7 @@ func TestHealDstDown_LocalClientLocalEndpoint_RequestFailed(t *testing.T) {
 }
 
 func TestHealDstDown_LocalClientRemoteEndpoint(t *testing.T) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
 	data := newHealTestData()
 
 	nse1 := data.createEndpoint(nse1Name, remoteNSMName)
@@ -210,10 +210,10 @@ func TestHealDstDown_LocalClientRemoteEndpoint(t *testing.T) {
 	data.connectionManager.nse = nse2
 
 	healed := data.healProcessor.healDstDown("", data.cloneClientConnection(connection))
-	Expect(healed).To(BeTrue())
+	g.Expect(healed).To(BeTrue())
 
-	Expect(data.nseManager.nseClients[nse1Name].cleanedUp).To(BeTrue())
-	Expect(data.nseManager.nseClients[nse2Name]).To(BeNil())
+	g.Expect(data.nseManager.nseClients[nse1Name].cleanedUp).To(BeTrue())
+	g.Expect(data.nseManager.nseClients[nse2Name]).To(BeNil())
 
 	test_utils.NewModelVerifier(data.model).
 		EndpointNotExists(nse1Name).
@@ -224,7 +224,7 @@ func TestHealDstDown_LocalClientRemoteEndpoint(t *testing.T) {
 }
 
 func TestHealDstDown_LocalClientRemoteEndpoint_NoNSEFound(t *testing.T) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
 	data := newHealTestData()
 
 	nse1 := data.createEndpoint(nse1Name, remoteNSMName)
@@ -235,9 +235,9 @@ func TestHealDstDown_LocalClientRemoteEndpoint_NoNSEFound(t *testing.T) {
 	data.model.AddClientConnection(connection)
 
 	healed := data.healProcessor.healDstDown("", data.cloneClientConnection(connection))
-	Expect(healed).To(BeFalse())
+	g.Expect(healed).To(BeFalse())
 
-	Expect(data.nseManager.nseClients[nse1Name].cleanedUp).To(BeTrue())
+	g.Expect(data.nseManager.nseClients[nse1Name].cleanedUp).To(BeTrue())
 
 	test_utils.NewModelVerifier(data.model).
 		EndpointNotExists(nse1Name).
@@ -252,7 +252,9 @@ type discoveryClientStub struct {
 }
 
 func (stub *discoveryClientStub) FindNetworkService(ctx net_context.Context, in *registry.FindNetworkServiceRequest, opts ...grpc.CallOption) (*registry.FindNetworkServiceResponse, error) {
-	Expect(in.GetNetworkServiceName()).To(Equal(networkServiceName))
+	if in.GetNetworkServiceName() != networkServiceName {
+		return nil, fmt.Errorf("wrong Network Service name")
+	}
 	return stub.response, stub.error
 }
 

--- a/controlplane/pkg/prefix_pool/prefixpool_test.go
+++ b/controlplane/pkg/prefix_pool/prefixpool_test.go
@@ -12,78 +12,78 @@ import (
 )
 
 func TestPrefixPoolSubnet1(t *testing.T) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
 
 	prefixes := []string{"10.10.1.0/24"}
 	logrus.Printf("Address count: %d", AddressCount(prefixes...))
-	Expect(AddressCount(prefixes...)).To(Equal(uint64(256)))
+	g.Expect(AddressCount(prefixes...)).To(Equal(uint64(256)))
 
 	_, snet1, _ := net.ParseCIDR("10.10.1.0/24")
 	sn1, err := subnet(snet1, 0)
-	Expect(err).To(BeNil())
+	g.Expect(err).To(BeNil())
 	logrus.Printf(sn1.String())
-	Expect(sn1.String()).To(Equal("10.10.1.0/25"))
+	g.Expect(sn1.String()).To(Equal("10.10.1.0/25"))
 	s, e := AddressRange(sn1)
-	Expect(s.String()).To(Equal("10.10.1.0"))
-	Expect(e.String()).To(Equal("10.10.1.127"))
-	Expect(addressCount(sn1.String())).To(Equal(uint64(128)))
+	g.Expect(s.String()).To(Equal("10.10.1.0"))
+	g.Expect(e.String()).To(Equal("10.10.1.127"))
+	g.Expect(addressCount(sn1.String())).To(Equal(uint64(128)))
 
 	lastIp := s
 	for i := uint64(0); i < addressCount((sn1.String()))-1; i++ {
 		ip, err := IncrementIP(lastIp, sn1)
-		Expect(err).To(BeNil())
+		g.Expect(err).To(BeNil())
 		lastIp = ip
 	}
 
 	_, err = IncrementIP(lastIp, sn1)
-	Expect(err.Error()).To(Equal("Overflowed CIDR while incrementing IP"))
+	g.Expect(err.Error()).To(Equal("Overflowed CIDR while incrementing IP"))
 
 	sn2, err := subnet(snet1, 1)
-	Expect(err).To(BeNil())
+	g.Expect(err).To(BeNil())
 	logrus.Printf(sn2.String())
-	Expect(sn2.String()).To(Equal("10.10.1.128/25"))
+	g.Expect(sn2.String()).To(Equal("10.10.1.128/25"))
 	s, e = AddressRange(sn2)
-	Expect(s.String()).To(Equal("10.10.1.128"))
-	Expect(e.String()).To(Equal("10.10.1.255"))
-	Expect(addressCount(sn2.String())).To(Equal(uint64(128)))
+	g.Expect(s.String()).To(Equal("10.10.1.128"))
+	g.Expect(e.String()).To(Equal("10.10.1.255"))
+	g.Expect(addressCount(sn2.String())).To(Equal(uint64(128)))
 }
 
 func TestNetExtractIPv4(t *testing.T) {
-	RegisterTestingT(t)
-	testNetExtract("10.10.1.0/24", "10.10.1.1/30", "10.10.1.2/30", connectioncontext.IpFamily_IPV4)
+	testNetExtract(t, "10.10.1.0/24", "10.10.1.1/30", "10.10.1.2/30", connectioncontext.IpFamily_IPV4)
 }
 
 func TestNetExtractIPv6(t *testing.T) {
-	RegisterTestingT(t)
-	testNetExtract("100::/64", "100::1/126", "100::2/126", connectioncontext.IpFamily_IPV6)
+	testNetExtract(t, "100::/64", "100::1/126", "100::2/126", connectioncontext.IpFamily_IPV6)
 }
 
-func testNetExtract(inPool, srcDesired, dstDesired string, family connectioncontext.IpFamily_Family) {
+func testNetExtract(t *testing.T, inPool, srcDesired, dstDesired string, family connectioncontext.IpFamily_Family) {
+	g := NewWithT(t)
+
 	pool, err := NewPrefixPool(inPool)
-	Expect(err).To(BeNil())
+	g.Expect(err).To(BeNil())
 
 	srcIP, dstIP, requested, err := pool.Extract("c1", family)
-	Expect(err).To(BeNil())
-	Expect(requested).To(BeNil())
+	g.Expect(err).To(BeNil())
+	g.Expect(requested).To(BeNil())
 
-	Expect(srcIP.String()).To(Equal(srcDesired))
-	Expect(dstIP.String()).To(Equal(dstDesired))
+	g.Expect(srcIP.String()).To(Equal(srcDesired))
+	g.Expect(dstIP.String()).To(Equal(dstDesired))
 
 	err = pool.Release("c1")
-	Expect(err).To(BeNil())
+	g.Expect(err).To(BeNil())
 }
 
 func TestExtract1(t *testing.T) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
 
 	newPrefixes, err := ReleasePrefixes([]string{"10.10.1.0/25"}, "10.10.1.127/25")
-	Expect(err).To(BeNil())
-	Expect(newPrefixes).To(Equal([]string{"10.10.1.0/24"}))
+	g.Expect(err).To(BeNil())
+	g.Expect(newPrefixes).To(Equal([]string{"10.10.1.0/24"}))
 	logrus.Printf("%v", newPrefixes)
 }
 
 func TestExtractPrefixes_1_ipv4(t *testing.T) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
 
 	newPrefixes, prefixes, err := ExtractPrefixes([]string{"10.10.1.0/24"},
 		&connectioncontext.ExtraPrefixRequest{
@@ -93,14 +93,14 @@ func TestExtractPrefixes_1_ipv4(t *testing.T) {
 			PrefixLen:       31,
 		},
 	)
-	Expect(err).To(BeNil())
-	Expect(len(newPrefixes)).To(Equal(20))
-	Expect(len(prefixes)).To(Equal(4))
+	g.Expect(err).To(BeNil())
+	g.Expect(len(newPrefixes)).To(Equal(20))
+	g.Expect(len(prefixes)).To(Equal(4))
 	logrus.Printf("%v", newPrefixes)
 }
 
 func TestExtractPrefixes_1_ipv6(t *testing.T) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
 
 	newPrefixes, prefixes, err := ExtractPrefixes([]string{"100::/64"},
 		&connectioncontext.ExtraPrefixRequest{
@@ -110,42 +110,42 @@ func TestExtractPrefixes_1_ipv6(t *testing.T) {
 			PrefixLen:       128,
 		},
 	)
-	Expect(err).To(BeNil())
-	Expect(len(newPrefixes)).To(Equal(200))
-	Expect(len(prefixes)).To(Equal(59))
+	g.Expect(err).To(BeNil())
+	g.Expect(len(newPrefixes)).To(Equal(200))
+	g.Expect(len(prefixes)).To(Equal(59))
 	logrus.Printf("%v", newPrefixes)
 }
 
 func TestExtract2(t *testing.T) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
 
 	prefix, prefixes, err := ExtractPrefix([]string{"10.10.1.0/24"}, 24)
-	Expect(err).To(BeNil())
-	Expect(prefix).To(Equal("10.10.1.0/24"))
-	Expect(len(prefixes)).To(Equal(0))
+	g.Expect(err).To(BeNil())
+	g.Expect(prefix).To(Equal("10.10.1.0/24"))
+	g.Expect(len(prefixes)).To(Equal(0))
 }
 
 func TestExtract2_ipv6(t *testing.T) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
 
 	prefix, prefixes, err := ExtractPrefix([]string{"100::/64"}, 65)
-	Expect(err).To(BeNil())
-	Expect(prefix).To(Equal("100::/65"))
-	Expect(len(prefixes)).To(Equal(1))
-	Expect(prefixes[0]).To(Equal("100::8000:0:0:0/65"))
+	g.Expect(err).To(BeNil())
+	g.Expect(prefix).To(Equal("100::/65"))
+	g.Expect(len(prefixes)).To(Equal(1))
+	g.Expect(prefixes[0]).To(Equal("100::8000:0:0:0/65"))
 }
 
 func TestExtract3_ipv6(t *testing.T) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
 
 	prefix, prefixes, err := ExtractPrefix([]string{"100::/64"}, 128)
-	Expect(err).To(BeNil())
-	Expect(prefix).To(Equal("100::/128"))
-	Expect(len(prefixes)).To(Equal(64))
+	g.Expect(err).To(BeNil())
+	g.Expect(prefix).To(Equal("100::/128"))
+	g.Expect(len(prefixes)).To(Equal(64))
 }
 
 func TestRelease_ipv6(t *testing.T) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
 
 	prefixes := []string{
 		"100::1/128",
@@ -214,74 +214,74 @@ func TestRelease_ipv6(t *testing.T) {
 		"100::8000:0:0:0/65",
 	}
 	released, err := ReleasePrefixes(prefixes, "100::/128")
-	Expect(err).To(BeNil())
-	Expect(len(released)).To(Equal(1))
-	Expect(released[0]).To(Equal("100::/64"))
+	g.Expect(err).To(BeNil())
+	g.Expect(len(released)).To(Equal(1))
+	g.Expect(released[0]).To(Equal("100::/64"))
 }
 
 func TestExtract3(t *testing.T) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
 
 	prefix, prefixes, err := ExtractPrefix([]string{"10.10.1.0/24"}, 23)
-	Expect(err.Error()).To(Equal("Failed to find room to have prefix len 23 at [10.10.1.0/24]"))
-	Expect(prefix).To(Equal(""))
-	Expect(len(prefixes)).To(Equal(1))
+	g.Expect(err.Error()).To(Equal("Failed to find room to have prefix len 23 at [10.10.1.0/24]"))
+	g.Expect(prefix).To(Equal(""))
+	g.Expect(len(prefixes)).To(Equal(1))
 }
 
 func TestExtract4(t *testing.T) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
 
 	prefix, prefixes, err := ExtractPrefix([]string{"10.10.1.0/24"}, 25)
-	Expect(err).To(BeNil())
-	Expect(prefix).To(Equal("10.10.1.0/25"))
-	Expect(prefixes).To(Equal([]string{"10.10.1.128/25"}))
+	g.Expect(err).To(BeNil())
+	g.Expect(prefix).To(Equal("10.10.1.0/25"))
+	g.Expect(prefixes).To(Equal([]string{"10.10.1.128/25"}))
 }
 
 func TestExtract5(t *testing.T) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
 
 	prefix, prefixes, err := ExtractPrefix([]string{"10.10.1.0/24"}, 26)
-	Expect(err).To(BeNil())
-	Expect(prefix).To(Equal("10.10.1.0/26"))
-	Expect(prefixes).To(Equal([]string{"10.10.1.64/26", "10.10.1.128/25"}))
+	g.Expect(err).To(BeNil())
+	g.Expect(prefix).To(Equal("10.10.1.0/26"))
+	g.Expect(prefixes).To(Equal([]string{"10.10.1.64/26", "10.10.1.128/25"}))
 }
 
 func TestExtract6(t *testing.T) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
 
 	prefix, prefixes, err := ExtractPrefix([]string{"10.10.1.0/24"}, 32)
-	Expect(err).To(BeNil())
-	Expect(prefix).To(Equal("10.10.1.0/32"))
-	Expect(prefixes).To(Equal([]string{"10.10.1.1/32", "10.10.1.2/31", "10.10.1.4/30", "10.10.1.8/29", "10.10.1.16/28", "10.10.1.32/27", "10.10.1.64/26", "10.10.1.128/25"}))
+	g.Expect(err).To(BeNil())
+	g.Expect(prefix).To(Equal("10.10.1.0/32"))
+	g.Expect(prefixes).To(Equal([]string{"10.10.1.1/32", "10.10.1.2/31", "10.10.1.4/30", "10.10.1.8/29", "10.10.1.16/28", "10.10.1.32/27", "10.10.1.64/26", "10.10.1.128/25"}))
 }
 
 func TestExtract7(t *testing.T) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
 
 	prefix, prefixes, err := ExtractPrefix([]string{"10.10.1.1/32", "10.10.1.2/31", "10.10.1.4/30", "10.10.1.8/29", "10.10.1.16/28", "10.10.1.32/27", "10.10.1.64/26", "10.10.1.128/25"}, 31)
-	Expect(err).To(BeNil())
-	Expect(prefix).To(Equal("10.10.1.2/31"))
-	Expect(prefixes).To(Equal([]string{"10.10.1.1/32", "10.10.1.4/30", "10.10.1.8/29", "10.10.1.16/28", "10.10.1.32/27", "10.10.1.64/26", "10.10.1.128/25"}))
+	g.Expect(err).To(BeNil())
+	g.Expect(prefix).To(Equal("10.10.1.2/31"))
+	g.Expect(prefixes).To(Equal([]string{"10.10.1.1/32", "10.10.1.4/30", "10.10.1.8/29", "10.10.1.16/28", "10.10.1.32/27", "10.10.1.64/26", "10.10.1.128/25"}))
 }
 func TestExtract8(t *testing.T) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
 
 	prefix, prefixes, err := ExtractPrefix([]string{"10.10.1.128/25", "10.10.1.2/31", "10.10.1.4/30", "10.10.1.8/29", "10.10.1.16/28", "10.10.1.32/27", "10.10.1.64/26"}, 32)
-	Expect(err).To(BeNil())
-	Expect(prefix).To(Equal("10.10.1.2/32"))
-	Expect(prefixes).To(Equal([]string{"10.10.1.128/25", "10.10.1.3/32", "10.10.1.4/30", "10.10.1.8/29", "10.10.1.16/28", "10.10.1.32/27", "10.10.1.64/26"}))
+	g.Expect(err).To(BeNil())
+	g.Expect(prefix).To(Equal("10.10.1.2/32"))
+	g.Expect(prefixes).To(Equal([]string{"10.10.1.128/25", "10.10.1.3/32", "10.10.1.4/30", "10.10.1.8/29", "10.10.1.16/28", "10.10.1.32/27", "10.10.1.64/26"}))
 }
 
 func TestRelease1(t *testing.T) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
 
 	newPrefixes, err := ReleasePrefixes([]string{"10.10.1.0/25"}, "10.10.1.127/25")
-	Expect(err).To(BeNil())
-	Expect(newPrefixes).To(Equal([]string{"10.10.1.0/24"}))
+	g.Expect(err).To(BeNil())
+	g.Expect(newPrefixes).To(Equal([]string{"10.10.1.0/24"}))
 }
 
 func TestRelease2(t *testing.T) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
 
 	_, snet, _ := net.ParseCIDR("10.10.1.0/25")
 	sn1, err := subnet(snet, 0)
@@ -297,137 +297,137 @@ func TestRelease2(t *testing.T) {
 	logrus.Printf("%v %v", sn20.String(), sn21.String())
 
 	newPrefixes, err := ReleasePrefixes([]string{"10.10.1.64/26", "10.10.1.128/25"}, "10.10.1.0/26")
-	Expect(err).To(BeNil())
-	Expect(newPrefixes).To(Equal([]string{"10.10.1.0/24"}))
+	g.Expect(err).To(BeNil())
+	g.Expect(newPrefixes).To(Equal([]string{"10.10.1.0/24"}))
 }
 
 func TestIntersect1(t *testing.T) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
 
 	pp, err := NewPrefixPool("10.10.1.0/24")
-	Expect(err).To(BeNil())
+	g.Expect(err).To(BeNil())
 
-	Expect(pp.Intersect("10.10.1.0/28")).To(Equal(true))
-	Expect(pp.Intersect("10.10.1.10/28")).To(Equal(true))
-	Expect(pp.Intersect("10.10.1.0/10")).To(Equal(true))
-	Expect(pp.Intersect("10.10.0.0/10")).To(Equal(true))
-	Expect(pp.Intersect("10.10.0.0/24")).To(Equal(false))
-	Expect(pp.Intersect("10.10.1.0/24")).To(Equal(true))
+	g.Expect(pp.Intersect("10.10.1.0/28")).To(Equal(true))
+	g.Expect(pp.Intersect("10.10.1.10/28")).To(Equal(true))
+	g.Expect(pp.Intersect("10.10.1.0/10")).To(Equal(true))
+	g.Expect(pp.Intersect("10.10.0.0/10")).To(Equal(true))
+	g.Expect(pp.Intersect("10.10.0.0/24")).To(Equal(false))
+	g.Expect(pp.Intersect("10.10.1.0/24")).To(Equal(true))
 }
 
 func TestIntersect2(t *testing.T) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
 
 	pp, err := NewPrefixPool("10.10.1.0/24", "10.32.1.0/16")
-	Expect(err).To(BeNil())
+	g.Expect(err).To(BeNil())
 
-	Expect(pp.Intersect("10.10.1.0/28")).To(Equal(true))
-	Expect(pp.Intersect("10.10.1.10/28")).To(Equal(true))
-	Expect(pp.Intersect("10.10.1.0/10")).To(Equal(true))
-	Expect(pp.Intersect("10.10.0.0/10")).To(Equal(true))
+	g.Expect(pp.Intersect("10.10.1.0/28")).To(Equal(true))
+	g.Expect(pp.Intersect("10.10.1.10/28")).To(Equal(true))
+	g.Expect(pp.Intersect("10.10.1.0/10")).To(Equal(true))
+	g.Expect(pp.Intersect("10.10.0.0/10")).To(Equal(true))
 
-	Expect(pp.Intersect("10.32.0.0/10")).To(Equal(true))
-	Expect(pp.Intersect("10.32.0.0/24")).To(Equal(true))
-	Expect(pp.Intersect("10.2.0.0/16")).To(Equal(false))
+	g.Expect(pp.Intersect("10.32.0.0/10")).To(Equal(true))
+	g.Expect(pp.Intersect("10.32.0.0/24")).To(Equal(true))
+	g.Expect(pp.Intersect("10.2.0.0/16")).To(Equal(false))
 
 }
 
 func TestReleaseExcludePrefixes(t *testing.T) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
 
 	pool, err := NewPrefixPool("10.20.0.0/16")
-	Expect(err).To(BeNil())
+	g.Expect(err).To(BeNil())
 	excludedPrefix := []string{"10.20.1.10/24", "10.20.32.0/19"}
 
 	excluded, err := pool.ExcludePrefixes(excludedPrefix)
 
-	Expect(err).To(BeNil())
-	Expect(pool.GetPrefixes()).To(Equal([]string{"10.20.0.0/24", "10.20.128.0/17", "10.20.64.0/18", "10.20.16.0/20", "10.20.8.0/21", "10.20.4.0/22", "10.20.2.0/23"}))
+	g.Expect(err).To(BeNil())
+	g.Expect(pool.GetPrefixes()).To(Equal([]string{"10.20.0.0/24", "10.20.128.0/17", "10.20.64.0/18", "10.20.16.0/20", "10.20.8.0/21", "10.20.4.0/22", "10.20.2.0/23"}))
 
 	err = pool.ReleaseExcludedPrefixes(excluded)
-	Expect(err).To(BeNil())
-	Expect(pool.GetPrefixes()).To(Equal([]string{"10.20.0.0/16"}))
+	g.Expect(err).To(BeNil())
+	g.Expect(pool.GetPrefixes()).To(Equal([]string{"10.20.0.0/16"}))
 }
 
 func TestReleaseExcludePrefixesNoOverlap(t *testing.T) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
 
 	pool, err := NewPrefixPool("10.20.0.0/16")
-	Expect(err).To(BeNil())
+	g.Expect(err).To(BeNil())
 	excludedPrefix := []string{"10.32.0.0/16"}
 
 	excluded, err := pool.ExcludePrefixes(excludedPrefix)
 
-	Expect(err).To(BeNil())
-	Expect(pool.GetPrefixes()).To(Equal([]string{"10.20.0.0/16"}))
+	g.Expect(err).To(BeNil())
+	g.Expect(pool.GetPrefixes()).To(Equal([]string{"10.20.0.0/16"}))
 
 	err = pool.ReleaseExcludedPrefixes(excluded)
-	Expect(err).To(BeNil())
-	Expect(pool.GetPrefixes()).To(Equal([]string{"10.20.0.0/16"}))
+	g.Expect(err).To(BeNil())
+	g.Expect(pool.GetPrefixes()).To(Equal([]string{"10.20.0.0/16"}))
 }
 
 func TestReleaseExcludePrefixesFullOverlap(t *testing.T) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
 	pool, err := NewPrefixPool("10.20.0.0/16", "2.20.0.0/16")
-	Expect(err).To(BeNil())
+	g.Expect(err).To(BeNil())
 	excludedPrefix := []string{"2.20.0.0/8"}
 
 	excluded, err := pool.ExcludePrefixes(excludedPrefix)
 
-	Expect(err).To(BeNil())
-	Expect(pool.GetPrefixes()).To(Equal([]string{"10.20.0.0/16"}))
+	g.Expect(err).To(BeNil())
+	g.Expect(pool.GetPrefixes()).To(Equal([]string{"10.20.0.0/16"}))
 
 	err = pool.ReleaseExcludedPrefixes(excluded)
-	Expect(err).To(BeNil())
-	Expect(pool.GetPrefixes()).To(Equal([]string{"10.20.0.0/16", "2.20.0.0/16"}))
+	g.Expect(err).To(BeNil())
+	g.Expect(pool.GetPrefixes()).To(Equal([]string{"10.20.0.0/16", "2.20.0.0/16"}))
 }
 
 func TestExcludePrefixesPartialOverlap(t *testing.T) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
 
 	pool, err := NewPrefixPool("10.20.0.0/16", "10.32.0.0/16")
-	Expect(err).To(BeNil())
+	g.Expect(err).To(BeNil())
 	excludedPrefix := []string{"10.20.1.10/24", "10.20.32.0/19"}
 
 	_, err = pool.ExcludePrefixes(excludedPrefix)
 
-	Expect(err).To(BeNil())
-	Expect(pool.GetPrefixes()).To(Equal([]string{"10.20.0.0/24", "10.20.128.0/17", "10.20.64.0/18", "10.20.16.0/20", "10.20.8.0/21", "10.20.4.0/22", "10.20.2.0/23", "10.32.0.0/16"}))
+	g.Expect(err).To(BeNil())
+	g.Expect(pool.GetPrefixes()).To(Equal([]string{"10.20.0.0/24", "10.20.128.0/17", "10.20.64.0/18", "10.20.16.0/20", "10.20.8.0/21", "10.20.4.0/22", "10.20.2.0/23", "10.32.0.0/16"}))
 }
 
 func TestExcludePrefixesPartialOverlapSmallNetworks(t *testing.T) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
 
 	pool, err := NewPrefixPool("10.20.0.0/16")
-	Expect(err).To(BeNil())
+	g.Expect(err).To(BeNil())
 	excludedPrefix := []string{"10.20.1.0/30", "10.20.10.0/30", "10.20.20.0/30", "10.20.20.20/30", "10.20.40.20/30"}
 
 	_, err = pool.ExcludePrefixes(excludedPrefix)
 
-	Expect(err).To(BeNil())
-	Expect(pool.GetPrefixes()).To(Equal([]string{"10.20.32.0/21", "10.20.40.0/28", "10.20.40.16/30", "10.20.48.0/20", "10.20.44.0/22", "10.20.42.0/23", "10.20.41.0/24", "10.20.40.128/25", "10.20.40.64/26", "10.20.40.32/27", "10.20.40.24/29", "10.20.20.16/30", "10.20.20.24/29", "10.20.16.0/22", "10.20.24.0/21", "10.20.22.0/23", "10.20.21.0/24", "10.20.20.128/25", "10.20.20.64/26", "10.20.20.32/27", "10.20.20.8/29", "10.20.20.4/30", "10.20.8.0/23", "10.20.12.0/22", "10.20.11.0/24", "10.20.10.128/25", "10.20.10.64/26", "10.20.10.32/27", "10.20.10.16/28", "10.20.10.8/29", "10.20.10.4/30", "10.20.0.0/24", "10.20.128.0/17", "10.20.64.0/18", "10.20.4.0/22", "10.20.2.0/23", "10.20.1.128/25", "10.20.1.64/26", "10.20.1.32/27", "10.20.1.16/28", "10.20.1.8/29", "10.20.1.4/30"}))
+	g.Expect(err).To(BeNil())
+	g.Expect(pool.GetPrefixes()).To(Equal([]string{"10.20.32.0/21", "10.20.40.0/28", "10.20.40.16/30", "10.20.48.0/20", "10.20.44.0/22", "10.20.42.0/23", "10.20.41.0/24", "10.20.40.128/25", "10.20.40.64/26", "10.20.40.32/27", "10.20.40.24/29", "10.20.20.16/30", "10.20.20.24/29", "10.20.16.0/22", "10.20.24.0/21", "10.20.22.0/23", "10.20.21.0/24", "10.20.20.128/25", "10.20.20.64/26", "10.20.20.32/27", "10.20.20.8/29", "10.20.20.4/30", "10.20.8.0/23", "10.20.12.0/22", "10.20.11.0/24", "10.20.10.128/25", "10.20.10.64/26", "10.20.10.32/27", "10.20.10.16/28", "10.20.10.8/29", "10.20.10.4/30", "10.20.0.0/24", "10.20.128.0/17", "10.20.64.0/18", "10.20.4.0/22", "10.20.2.0/23", "10.20.1.128/25", "10.20.1.64/26", "10.20.1.32/27", "10.20.1.16/28", "10.20.1.8/29", "10.20.1.4/30"}))
 }
 
 func TestExcludePrefixesNoOverlap(t *testing.T) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
 
 	pool, err := NewPrefixPool("10.20.0.0/16")
-	Expect(err).To(BeNil())
+	g.Expect(err).To(BeNil())
 	excludedPrefix := []string{"10.32.1.0/16"}
 
 	_, err = pool.ExcludePrefixes(excludedPrefix)
 
-	Expect(pool.GetPrefixes()).To(Equal([]string{"10.20.0.0/16"}))
+	g.Expect(pool.GetPrefixes()).To(Equal([]string{"10.20.0.0/16"}))
 }
 
 func TestExcludePrefixesFullOverlap(t *testing.T) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
 
 	pool, err := NewPrefixPool("10.20.0.0/24")
-	Expect(err).To(BeNil())
+	g.Expect(err).To(BeNil())
 	excludedPrefix := []string{"10.20.1.0/16"}
 
 	_, err = pool.ExcludePrefixes(excludedPrefix)
 
-	Expect(err).To(Equal(fmt.Errorf("IPAM: The available address pool is empty, probably intersected by excludedPrefix")))
+	g.Expect(err).To(Equal(fmt.Errorf("IPAM: The available address pool is empty, probably intersected by excludedPrefix")))
 }

--- a/controlplane/pkg/tests/connection_context_test.go
+++ b/controlplane/pkg/tests/connection_context_test.go
@@ -9,14 +9,14 @@ import (
 )
 
 func TestEmptyConnectionContext(t *testing.T) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
 
 	ctx := &connectioncontext.ConnectionContext{}
-	Expect(ctx.IsValid()).To(BeNil())
+	g.Expect(ctx.IsValid()).To(BeNil())
 }
 
 func TestPrefixConnectionContext(t *testing.T) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
 
 	ctx := &connectioncontext.ConnectionContext{
 		IpContext: &connectioncontext.IPContext{
@@ -27,7 +27,7 @@ func TestPrefixConnectionContext(t *testing.T) {
 			},
 		},
 	}
-	Expect(ctx.IsValid().Error()).To(Equal("ConnectionContext.Route.Prefix is required and cannot be empty/nil: src_routes:<> "))
+	g.Expect(ctx.IsValid().Error()).To(Equal("ConnectionContext.Route.Prefix is required and cannot be empty/nil: src_routes:<> "))
 
 	ctx = &connectioncontext.ConnectionContext{
 		IpContext: &connectioncontext.IPContext{
@@ -38,10 +38,10 @@ func TestPrefixConnectionContext(t *testing.T) {
 			},
 		},
 	}
-	Expect(ctx.IsValid().Error()).To(Equal("ConnectionContext.Route.Prefix is required and cannot be empty/nil: dst_routes:<> "))
+	g.Expect(ctx.IsValid().Error()).To(Equal("ConnectionContext.Route.Prefix is required and cannot be empty/nil: dst_routes:<> "))
 }
 func TestPrefixWrongConnectionContext(t *testing.T) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
 
 	ctx := &connectioncontext.ConnectionContext{
 		IpContext: &connectioncontext.IPContext{
@@ -52,7 +52,7 @@ func TestPrefixWrongConnectionContext(t *testing.T) {
 			},
 		},
 	}
-	Expect(ctx.IsValid().Error()).To(Equal("ConnectionContext.Route.Prefix should be a valid CIDR address: src_routes:<prefix:\"8.8.8.8\" > "))
+	g.Expect(ctx.IsValid().Error()).To(Equal("ConnectionContext.Route.Prefix should be a valid CIDR address: src_routes:<prefix:\"8.8.8.8\" > "))
 
 	ctx = &connectioncontext.ConnectionContext{
 		IpContext: &connectioncontext.IPContext{
@@ -63,10 +63,10 @@ func TestPrefixWrongConnectionContext(t *testing.T) {
 			},
 		},
 	}
-	Expect(ctx.IsValid().Error()).To(Equal("ConnectionContext.Route.Prefix should be a valid CIDR address: dst_routes:<prefix:\"8.8.8.8\" > "))
+	g.Expect(ctx.IsValid().Error()).To(Equal("ConnectionContext.Route.Prefix should be a valid CIDR address: dst_routes:<prefix:\"8.8.8.8\" > "))
 }
 func TestPrefixFineConnectionContext(t *testing.T) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
 
 	ctx := &connectioncontext.ConnectionContext{
 		IpContext: &connectioncontext.IPContext{
@@ -77,7 +77,7 @@ func TestPrefixFineConnectionContext(t *testing.T) {
 			},
 		},
 	}
-	Expect(ctx.IsValid()).To(BeNil())
+	g.Expect(ctx.IsValid()).To(BeNil())
 
 	ctx = &connectioncontext.ConnectionContext{
 		IpContext: &connectioncontext.IPContext{
@@ -88,11 +88,11 @@ func TestPrefixFineConnectionContext(t *testing.T) {
 			},
 		},
 	}
-	Expect(ctx.IsValid()).To(BeNil())
+	g.Expect(ctx.IsValid()).To(BeNil())
 }
 
 func TestIpNeighbors(t *testing.T) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
 
 	ctx := &connectioncontext.ConnectionContext{
 		IpContext: &connectioncontext.IPContext{
@@ -103,11 +103,11 @@ func TestIpNeighbors(t *testing.T) {
 			},
 		},
 	}
-	Expect(ctx.IsValid().Error()).To(Equal("ConnectionContext.IpNeighbors.Ip is required and cannot be empty/nil: ip_neighbors:<> "))
+	g.Expect(ctx.IsValid().Error()).To(Equal("ConnectionContext.IpNeighbors.Ip is required and cannot be empty/nil: ip_neighbors:<> "))
 }
 
 func TestHWNeighbors(t *testing.T) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
 
 	ctx := &connectioncontext.ConnectionContext{
 		IpContext: &connectioncontext.IPContext{
@@ -119,12 +119,12 @@ func TestHWNeighbors(t *testing.T) {
 		},
 	}
 	err := ctx.IsValid()
-	Expect(err).ShouldNot(BeNil())
-	Expect(err.Error()).To(Equal("ConnectionContext.IpNeighbors.HardwareAddress is required and cannot be empty/nil: ip_neighbors:<ip:\"8.8.8.8\" > "))
+	g.Expect(err).ShouldNot(BeNil())
+	g.Expect(err.Error()).To(Equal("ConnectionContext.IpNeighbors.HardwareAddress is required and cannot be empty/nil: ip_neighbors:<ip:\"8.8.8.8\" > "))
 }
 
 func TestValidNeighbors(t *testing.T) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
 
 	ctx := &connectioncontext.ConnectionContext{
 		IpContext: &connectioncontext.IPContext{
@@ -136,5 +136,5 @@ func TestValidNeighbors(t *testing.T) {
 			},
 		},
 	}
-	Expect(ctx.IsValid()).To(BeNil())
+	g.Expect(ctx.IsValid()).To(BeNil())
 }

--- a/controlplane/pkg/tests/dataplane_heal_test.go
+++ b/controlplane/pkg/tests/dataplane_heal_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestHealLocalDataplane(t *testing.T) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
 
 	storage := newSharedStorage()
 	srv := newNSMDFullServer(Master, storage, defaultClusterConfiguration)
@@ -65,16 +65,16 @@ func TestHealLocalDataplane(t *testing.T) {
 	}
 
 	nsmResponse, err := nsmClient.Request(context.Background(), request)
-	Expect(err).To(BeNil())
-	Expect(nsmResponse.GetNetworkService()).To(Equal("golden_network"))
+	g.Expect(err).To(BeNil())
+	g.Expect(nsmResponse.GetNetworkService()).To(Equal("golden_network"))
 
 	// We need to check for cross connections.
 	clientConnection1 := srv.testModel.GetClientConnection(nsmResponse.GetId())
-	Expect(clientConnection1.GetID()).To(Equal("1"))
-	Expect(clientConnection1.Xcon.GetRemoteDestination().GetMechanism().GetParameters()[connection2.VXLANSrcIP]).To(Equal("127.0.0.1"))
+	g.Expect(clientConnection1.GetID()).To(Equal("1"))
+	g.Expect(clientConnection1.Xcon.GetRemoteDestination().GetMechanism().GetParameters()[connection2.VXLANSrcIP]).To(Equal("127.0.0.1"))
 
 	clientConnection2 := srv2.testModel.GetClientConnection(clientConnection1.Xcon.GetRemoteDestination().GetId())
-	Expect(clientConnection2.GetID()).To(Equal("1"))
+	g.Expect(clientConnection2.GetID()).To(Equal("1"))
 
 	timeout := time.Second * 10
 
@@ -99,9 +99,9 @@ func TestHealLocalDataplane(t *testing.T) {
 	// We need to inform cross connection monitor about this connection, since dataplane is fake one.
 
 	clientConnection1_1 := srv.testModel.GetClientConnection(nsmResponse.GetId())
-	Expect(clientConnection1_1 != nil).To(Equal(true))
-	Expect(clientConnection1_1.GetID()).To(Equal("1"))
-	Expect(clientConnection1_1.Xcon.GetRemoteDestination().GetId()).To(Equal("1"))
-	Expect(clientConnection1_1.Xcon.GetRemoteDestination().GetNetworkServiceEndpointName()).To(Equal(epName))
-	Expect(clientConnection1_1.Xcon.GetRemoteDestination().GetMechanism().GetParameters()[connection2.VXLANSrcIP]).To(Equal("127.0.0.7"))
+	g.Expect(clientConnection1_1 != nil).To(Equal(true))
+	g.Expect(clientConnection1_1.GetID()).To(Equal("1"))
+	g.Expect(clientConnection1_1.Xcon.GetRemoteDestination().GetId()).To(Equal("1"))
+	g.Expect(clientConnection1_1.Xcon.GetRemoteDestination().GetNetworkServiceEndpointName()).To(Equal(epName))
+	g.Expect(clientConnection1_1.Xcon.GetRemoteDestination().GetMechanism().GetParameters()[connection2.VXLANSrcIP]).To(Equal("127.0.0.7"))
 }

--- a/controlplane/pkg/tests/heal_nse_test.go
+++ b/controlplane/pkg/tests/heal_nse_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestHealRemoteNSE(t *testing.T) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
 
 	storage := newSharedStorage()
 	srv := newNSMDFullServer(Master, storage, defaultClusterConfiguration)
@@ -69,15 +69,15 @@ func TestHealRemoteNSE(t *testing.T) {
 	timeout := time.Second * 10
 
 	nsmResponse, err := nsmClient.Request(context.Background(), request)
-	Expect(err).To(BeNil())
-	Expect(nsmResponse.GetNetworkService()).To(Equal("golden_network"))
+	g.Expect(err).To(BeNil())
+	g.Expect(nsmResponse.GetNetworkService()).To(Equal("golden_network"))
 
 	// We need to check for cross connections.
 	clientConnection1 := srv.testModel.GetClientConnection(nsmResponse.GetId())
-	Expect(clientConnection1.GetID()).To(Equal("1"))
+	g.Expect(clientConnection1.GetID()).To(Equal("1"))
 
 	clientConnection2 := srv2.testModel.GetClientConnection(clientConnection1.Xcon.GetRemoteDestination().GetId())
-	Expect(clientConnection2.GetID()).To(Equal("1"))
+	g.Expect(clientConnection2.GetID()).To(Equal("1"))
 
 	// We need to inform cross connection monitor about this connection, since dataplane is fake one.
 	l1.WaitAdd(1, timeout, t)
@@ -102,6 +102,6 @@ func TestHealRemoteNSE(t *testing.T) {
 	l1.WaitUpdate(7, timeout, t)
 
 	clientConnection1_1 := srv.testModel.GetClientConnection(nsmResponse.GetId())
-	Expect(clientConnection1_1.GetID()).To(Equal("1"))
-	Expect(clientConnection1_1.Xcon.GetRemoteDestination().GetId()).To(Equal("3"))
+	g.Expect(clientConnection1_1.GetID()).To(Equal("1"))
+	g.Expect(clientConnection1_1.Xcon.GetRemoteDestination().GetId()).To(Equal("3"))
 }

--- a/controlplane/pkg/tests/mode_test.go
+++ b/controlplane/pkg/tests/mode_test.go
@@ -14,7 +14,7 @@ func newModel() model.Model {
 }
 
 func TestModelAddRemove(t *testing.T) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
 
 	mdl := newModel()
 
@@ -23,15 +23,15 @@ func TestModelAddRemove(t *testing.T) {
 		SocketLocation: "location",
 	})
 
-	Expect(mdl.GetDataplane("test_name").RegisteredName).To(Equal("test_name"))
+	g.Expect(mdl.GetDataplane("test_name").RegisteredName).To(Equal("test_name"))
 
 	mdl.DeleteDataplane("test_name")
 
-	Expect(mdl.GetDataplane("test_name")).To(BeNil())
+	g.Expect(mdl.GetDataplane("test_name")).To(BeNil())
 }
 
 func TestModelSelectDataplane(t *testing.T) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
 
 	mdl := newModel()
 
@@ -40,29 +40,29 @@ func TestModelSelectDataplane(t *testing.T) {
 		SocketLocation: "location",
 	})
 	dp, err := mdl.SelectDataplane(nil)
-	Expect(dp.RegisteredName).To(Equal("test_name"))
-	Expect(err).To(BeNil())
+	g.Expect(dp.RegisteredName).To(Equal("test_name"))
+	g.Expect(err).To(BeNil())
 }
 func TestModelSelectDataplaneNone(t *testing.T) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
 
 	mdl := newModel()
 
 	dp, err := mdl.SelectDataplane(nil)
-	Expect(dp).To(BeNil())
-	Expect(err.Error()).To(Equal("no appropriate dataplanes found"))
+	g.Expect(dp).To(BeNil())
+	g.Expect(err.Error()).To(Equal("no appropriate dataplanes found"))
 }
 
 func TestModelAddEndpoint(t *testing.T) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
 
 	mdl := newModel()
 
 	ep1 := createNSERegistration("golden-network", "ep1")
 	mdl.AddEndpoint(ep1)
-	Expect(mdl.GetEndpoint("ep1")).To(Equal(ep1))
+	g.Expect(mdl.GetEndpoint("ep1")).To(Equal(ep1))
 
-	Expect(mdl.GetEndpointsByNetworkService("golden-network")[0]).To(Equal(ep1))
+	g.Expect(mdl.GetEndpointsByNetworkService("golden-network")[0]).To(Equal(ep1))
 }
 
 func createNSERegistration(networkServiceName string, endpointName string) *model.Endpoint {
@@ -81,7 +81,7 @@ func createNSERegistration(networkServiceName string, endpointName string) *mode
 }
 
 func TestModelTwoEndpoint(t *testing.T) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
 
 	model := newModel()
 
@@ -89,14 +89,14 @@ func TestModelTwoEndpoint(t *testing.T) {
 	ep2 := createNSERegistration("golden-network", "ep2")
 	model.AddEndpoint(ep1)
 	model.AddEndpoint(ep2)
-	Expect(model.GetEndpoint("ep1")).To(Equal(ep1))
-	Expect(model.GetEndpoint("ep2")).To(Equal(ep2))
+	g.Expect(model.GetEndpoint("ep1")).To(Equal(ep1))
+	g.Expect(model.GetEndpoint("ep2")).To(Equal(ep2))
 
-	Expect(len(model.GetEndpointsByNetworkService("golden-network"))).To(Equal(2))
+	g.Expect(len(model.GetEndpointsByNetworkService("golden-network"))).To(Equal(2))
 }
 
 func TestModelAddDeleteEndpoint(t *testing.T) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
 
 	model := newModel()
 
@@ -105,20 +105,20 @@ func TestModelAddDeleteEndpoint(t *testing.T) {
 	model.AddEndpoint(ep1)
 	model.AddEndpoint(ep2)
 	model.DeleteEndpoint("ep1")
-	Expect(model.GetEndpoint("ep1")).To(BeNil())
-	Expect(model.GetEndpoint("ep2")).To(Equal(ep2))
+	g.Expect(model.GetEndpoint("ep1")).To(BeNil())
+	g.Expect(model.GetEndpoint("ep2")).To(Equal(ep2))
 
-	Expect(len(model.GetEndpointsByNetworkService("golden-network"))).To(Equal(1))
+	g.Expect(len(model.GetEndpointsByNetworkService("golden-network"))).To(Equal(1))
 }
 
 func TestModelRestoreIds(t *testing.T) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
 
 	mdl := newModel()
-	Expect(mdl.ConnectionID()).To(Equal("1"))
-	Expect(mdl.ConnectionID()).To(Equal("2"))
+	g.Expect(mdl.ConnectionID()).To(Equal("1"))
+	g.Expect(mdl.ConnectionID()).To(Equal("2"))
 	mdl2 := newModel()
 	mdl2.CorrectIDGenerator(mdl.ConnectionID())
-	Expect(mdl2.ConnectionID()).To(Equal("4"))
+	g.Expect(mdl2.ConnectionID()).To(Equal("4"))
 
 }

--- a/controlplane/pkg/tests/nsm_monitor_test.go
+++ b/controlplane/pkg/tests/nsm_monitor_test.go
@@ -50,7 +50,7 @@ func (*nsmHelper) ProcessHealing(newConn *connection.Connection, e error) {
 }
 
 func TestNSMMonitorInit(t *testing.T) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
 
 	storage := newSharedStorage()
 	srv := newNSMDFullServer(Master, storage, defaultClusterConfiguration)
@@ -73,8 +73,8 @@ func TestNSMMonitorInit(t *testing.T) {
 	request := createRequest(false)
 
 	nsmResponse, err := nsmClient.Request(context.Background(), request)
-	Expect(err).To(BeNil())
-	Expect(nsmResponse.GetNetworkService()).To(Equal("golden_network"))
+	g.Expect(err).To(BeNil())
+	g.Expect(nsmResponse.GetNetworkService()).To(Equal("golden_network"))
 
 	// Now we need to start monitor and check if it will be able to restore connections.
 

--- a/controlplane/pkg/tests/nsmd_crossconnect_client_test.go
+++ b/controlplane/pkg/tests/nsmd_crossconnect_client_test.go
@@ -82,7 +82,7 @@ func startAPIServer(model model.Model, nsmdApiAddress string) (*grpc.Server, mon
 }
 
 func TestCCServerEmpty(t *testing.T) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
 
 	myModel := model.NewModel()
 
@@ -93,7 +93,7 @@ func TestCCServerEmpty(t *testing.T) {
 
 	crossConnectAddress = sock.Addr().String()
 
-	Expect(err).To(BeNil())
+	g.Expect(err).To(BeNil())
 
 	monitor.Update(&crossconnect.CrossConnect{
 		Id:      "cc1",
@@ -101,9 +101,9 @@ func TestCCServerEmpty(t *testing.T) {
 	})
 	events := readNMSDCrossConnectEvents(crossConnectAddress, 1)
 
-	Expect(len(events)).To(Equal(1))
+	g.Expect(len(events)).To(Equal(1))
 
-	Expect(events[0].CrossConnects["cc1"].Payload).To(Equal("json_data"))
+	g.Expect(events[0].CrossConnects["cc1"].Payload).To(Equal("json_data"))
 }
 
 func readNMSDCrossConnectEvents(address string, count int) []*crossconnect.CrossConnectEvent {

--- a/controlplane/pkg/tests/nsmd_registry_test.go
+++ b/controlplane/pkg/tests/nsmd_registry_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestNSMDRestart1(t *testing.T) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
 
 	storage := newSharedStorage()
 
@@ -48,7 +48,7 @@ func TestNSMDRestart1(t *testing.T) {
 	l1.WaitEndpoints(1, time.Second*30, t)
 
 	endpoints1 := srv.testModel.GetEndpointsByNetworkService("test_nse")
-	Expect(len(endpoints1)).To(Equal(1))
+	g.Expect(len(endpoints1)).To(Equal(1))
 	srv.StopNoClean()
 
 	// We need to restart server
@@ -57,8 +57,8 @@ func TestNSMDRestart1(t *testing.T) {
 	srv.addFakeDataplane("test_data_plane", "tcp:some_addr")
 	endpoints2 := srv.testModel.GetEndpointsByNetworkService("test_nse")
 
-	Expect(len(endpoints2)).To(Equal(1))
-	Expect(endpoints1[0].SocketLocation).To(Equal(endpoints2[0].SocketLocation))
-	Expect(endpoints1[0].Workspace).To(Equal(endpoints2[0].Workspace))
-	Expect(endpoints1[0].Endpoint.NetworkServiceManager.Name).ToNot(Equal(endpoints2[0].Endpoint.NetworkServiceManager.Name))
+	g.Expect(len(endpoints2)).To(Equal(1))
+	g.Expect(endpoints1[0].SocketLocation).To(Equal(endpoints2[0].SocketLocation))
+	g.Expect(endpoints1[0].Workspace).To(Equal(endpoints2[0].Workspace))
+	g.Expect(endpoints1[0].Endpoint.NetworkServiceManager.Name).ToNot(Equal(endpoints2[0].Endpoint.NetworkServiceManager.Name))
 }

--- a/controlplane/pkg/tests/nsmd_remote_test.go
+++ b/controlplane/pkg/tests/nsmd_remote_test.go
@@ -19,7 +19,7 @@ import (
 // Below only tests
 
 func TestNSMDRequestClientRemoteNSMD(t *testing.T) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
 
 	storage := newSharedStorage()
 	srv := newNSMDFullServer(Master, storage, defaultClusterConfiguration)
@@ -63,17 +63,17 @@ func TestNSMDRequestClientRemoteNSMD(t *testing.T) {
 	}
 
 	nsmResponse, err := nsmClient.Request(context.Background(), request)
-	Expect(err).To(BeNil())
-	Expect(nsmResponse.GetNetworkService()).To(Equal("golden_network"))
+	g.Expect(err).To(BeNil())
+	g.Expect(nsmResponse.GetNetworkService()).To(Equal("golden_network"))
 
 	// We need to check for cross connections.
 	cross_connections := srv2.serviceRegistry.testDataplaneConnection.connections
-	Expect(len(cross_connections)).To(Equal(1))
+	g.Expect(len(cross_connections)).To(Equal(1))
 	logrus.Print("End of test")
 }
 
 func TestNSMDCloseCrossConnection(t *testing.T) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
 
 	storage := newSharedStorage()
 	srv := newNSMDFullServer(Master, storage, defaultClusterConfiguration)
@@ -147,33 +147,33 @@ func TestNSMDCloseCrossConnection(t *testing.T) {
 	}
 
 	nsmResponse, err := nsmClient.Request(context.Background(), request)
-	Expect(err).To(BeNil())
-	Expect(nsmResponse.GetNetworkService()).To(Equal("golden_network"))
+	g.Expect(err).To(BeNil())
+	g.Expect(nsmResponse.GetNetworkService()).To(Equal("golden_network"))
 
 	// We need to check for cross connections.
 	cross_connection := srv.testModel.GetClientConnection(nsmResponse.Id)
-	Expect(cross_connection).ToNot(BeNil())
+	g.Expect(cross_connection).ToNot(BeNil())
 
 	destConnectionId := cross_connection.Xcon.GetRemoteDestination().GetId()
 
 	cross_connection2 := srv2.testModel.GetClientConnection(destConnectionId)
-	Expect(cross_connection2).ToNot(BeNil())
+	g.Expect(cross_connection2).ToNot(BeNil())
 
 	//Cross connection successfully created, check it closing
 	_, err = nsmClient.Close(context.Background(), nsmResponse)
-	Expect(err).To(BeNil())
+	g.Expect(err).To(BeNil())
 
 	//We need to check that xcons have been removed from model
 	cross_connection = srv.testModel.GetClientConnection(nsmResponse.Id)
-	Expect(cross_connection).To(BeNil())
+	g.Expect(cross_connection).To(BeNil())
 
 	cross_connection2 = srv2.testModel.GetClientConnection(destConnectionId)
-	Expect(cross_connection2).To(BeNil())
+	g.Expect(cross_connection2).To(BeNil())
 
 }
 
 func TestNSMDDelayRemoteMechanisms(t *testing.T) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
 
 	storage := newSharedStorage()
 	srv := newNSMDFullServer(Master, storage, defaultClusterConfiguration)
@@ -240,11 +240,11 @@ func TestNSMDDelayRemoteMechanisms(t *testing.T) {
 	srv2.testModel.UpdateDataplane(testDataplane2_2)
 
 	res := <-resultChan
-	Expect(res.err).To(BeNil())
-	Expect(res.nsmResponse.GetNetworkService()).To(Equal("golden_network"))
+	g.Expect(res.err).To(BeNil())
+	g.Expect(res.nsmResponse.GetNetworkService()).To(Equal("golden_network"))
 
 	// We need to check for crМфвук31oss connections.
 	cross_connections := srv2.serviceRegistry.testDataplaneConnection.connections
-	Expect(len(cross_connections)).To(Equal(1))
+	g.Expect(len(cross_connections)).To(Equal(1))
 	logrus.Print("End of test")
 }

--- a/controlplane/pkg/tests/nsmd_test_utils.go
+++ b/controlplane/pkg/tests/nsmd_test_utils.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	"github.com/golang/protobuf/ptypes/empty"
-	. "github.com/onsi/gomega"
 	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
 
@@ -470,8 +469,12 @@ func (srv *nsmdFullServerImpl) registerFakeEndpointWithName(networkServiceName s
 		},
 	}
 	regResp, err := srv.nseRegistry.RegisterNSE(context.Background(), reg)
-	Expect(err).To(BeNil())
-	Expect(regResp.NetworkService.Name).To(Equal(networkServiceName))
+	if err != nil {
+		panic(err)
+	}
+	if regResp.NetworkService.Name != networkServiceName {
+		panic(fmt.Errorf("%s is not equal to %s", regResp.NetworkService.Name, networkServiceName))
+	}
 
 	return &model.Endpoint{
 		Endpoint:       reg,
@@ -489,31 +492,39 @@ func (srv *nsmdFullServerImpl) requestNSMConnection(clientName string) (local_ne
 
 func (srv *nsmdFullServerImpl) createNSClient(response *nsmdapi.ClientConnectionReply) (local_networkservice.NetworkServiceClient, *grpc.ClientConn) {
 	nsmClient, conn, err := newNetworkServiceClient(response.HostBasedir + "/" + response.Workspace + "/" + response.NsmServerSocket)
-	Expect(err).To(BeNil())
+	if err != nil {
+		panic(err)
+	}
 	return nsmClient, conn
 }
 
 func (srv *nsmdFullServerImpl) requestNSM(clientName string) *nsmdapi.ClientConnectionReply {
 	client, con, err := srv.serviceRegistry.NSMDApiClient()
-	Expect(err).To(BeNil())
+	if err != nil {
+		panic(err)
+	}
 	defer con.Close()
 
 	response, err := client.RequestClientConnection(context.Background(), &nsmdapi.ClientConnectionRequest{
 		Workspace: clientName,
 	})
 
-	Expect(err).To(BeNil())
+	if err != nil {
+		panic(err)
+	}
 
 	logrus.Printf("workspace %s", response.Workspace)
 
-	Expect(response.Workspace).To(Equal(clientName))
+	if response.Workspace != clientName {
+		panic(fmt.Errorf("%s is not equal to %s", response.Workspace, clientName))
+	}
 	return response
 }
 
 func newNSMDFullServer(nsmgrName string, storage *sharedStorage, cfg *registry.ClusterConfiguration) *nsmdFullServerImpl {
 	rootDir, err := ioutil.TempDir("", "nsmd_test")
 	if err != nil {
-		logrus.Fatal(err)
+		panic(err)
 	}
 
 	return newNSMDFullServerAt(nsmgrName, storage, rootDir, cfg)
@@ -527,7 +538,7 @@ func newNSMDFullServerAt(nsmgrName string, storage *sharedStorage, rootDir strin
 
 	prefixPool, err := prefix_pool.NewPrefixPool("10.20.1.0/24")
 	if err != nil {
-		logrus.Fatal(err)
+		panic(err)
 	}
 	srv.serviceRegistry = &nsmdTestServiceRegistry{
 		nseRegistry:             srv.nseRegistry,
@@ -553,7 +564,9 @@ func newNSMDFullServerAt(nsmgrName string, storage *sharedStorage, rootDir strin
 	// Lets start NSMD NSE registry service
 	nsmServer, err := nsmd.StartNSMServer(srv.testModel, srv.manager, srv.serviceRegistry, srv.apiRegistry)
 	srv.nsmServer = nsmServer
-	Expect(err).To(BeNil())
+	if err != nil {
+		panic(err)
+	}
 
 	monitorCrossConnectClient := nsmd.NewMonitorCrossConnectClient(nsmServer, nsmServer.XconManager(), srv.nsmServer)
 	srv.testModel.AddListener(monitorCrossConnectClient)

--- a/controlplane/pkg/tests/restore_state_test.go
+++ b/controlplane/pkg/tests/restore_state_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestRestoreConnectionState(t *testing.T) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
 
 	storage := newSharedStorage()
 	srv := newNSMDFullServer(Master, storage, defaultClusterConfiguration)
@@ -19,15 +19,15 @@ func TestRestoreConnectionState(t *testing.T) {
 
 	srv.addFakeDataplane("dp1", "tcp:some_address")
 
-	Expect(srv.nsmServer.Manager().WaitForDataplane(1 * time.Millisecond).Error()).To(Equal("Failed to wait for NSMD stare restore... timeout 1ms happened"))
+	g.Expect(srv.nsmServer.Manager().WaitForDataplane(1 * time.Millisecond).Error()).To(Equal("Failed to wait for NSMD stare restore... timeout 1ms happened"))
 
 	xcons := []*crossconnect.CrossConnect{}
 	srv.nsmServer.Manager().RestoreConnections(xcons, "dp1")
-	Expect(srv.nsmServer.Manager().WaitForDataplane(1 * time.Second)).To(BeNil())
+	g.Expect(srv.nsmServer.Manager().WaitForDataplane(1 * time.Second)).To(BeNil())
 }
 
 func TestRestoreConnectionStateWrongDst(t *testing.T) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
 
 	storage := newSharedStorage()
 	srv := newNSMDFullServer(Master, storage, defaultClusterConfiguration)
@@ -63,6 +63,6 @@ func TestRestoreConnectionStateWrongDst(t *testing.T) {
 		},
 	}
 	srv.nsmServer.Manager().RestoreConnections(xcons, "dp1")
-	Expect(srv.nsmServer.Manager().WaitForDataplane(1 * time.Second)).To(BeNil())
-	Expect(len(srv.testModel.GetAllClientConnections())).To(Equal(0))
+	g.Expect(srv.nsmServer.Manager().WaitForDataplane(1 * time.Second)).To(BeNil())
+	g.Expect(len(srv.testModel.GetAllClientConnections())).To(Equal(0))
 }

--- a/controlplane/pkg/tests/select_dataplane_test.go
+++ b/controlplane/pkg/tests/select_dataplane_test.go
@@ -25,7 +25,7 @@ func createTestDataplane(name string, localMechanisms, remoteMechanisms []connec
 }
 
 func TestSelectDataplane(t *testing.T) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
 
 	testDataplane1_1 := createTestDataplane("test_data_plane_2",
 		[]connection.Mechanism{
@@ -98,8 +98,8 @@ func TestSelectDataplane(t *testing.T) {
 	}
 
 	nsmResponse, err := nsmClient.Request(context.Background(), request)
-	Expect(err).To(BeNil())
-	Expect(nsmResponse.GetNetworkService()).To(Equal("golden_network"))
+	g.Expect(err).To(BeNil())
+	g.Expect(nsmResponse.GetNetworkService()).To(Equal("golden_network"))
 
 	request = &networkservice.NetworkServiceRequest{
 		Connection: &local.Connection{
@@ -124,8 +124,8 @@ func TestSelectDataplane(t *testing.T) {
 	}
 
 	nsmResponse, err = nsmClient.Request(context.Background(), request)
-	Expect(err).To(BeNil())
-	Expect(nsmResponse.GetNetworkService()).To(Equal("golden_network"))
+	g.Expect(err).To(BeNil())
+	g.Expect(nsmResponse.GetNetworkService()).To(Equal("golden_network"))
 
 	request = &networkservice.NetworkServiceRequest{
 		Connection: &local.Connection{
@@ -150,6 +150,6 @@ func TestSelectDataplane(t *testing.T) {
 	}
 
 	nsmResponse, err = nsmClient.Request(context.Background(), request)
-	Expect(err).NotTo(BeNil())
-	Expect(err.Error()).To(ContainSubstring("no appropriate dataplanes found"))
+	g.Expect(err).NotTo(BeNil())
+	g.Expect(err.Error()).To(ContainSubstring("no appropriate dataplanes found"))
 }

--- a/controlplane/pkg/tests/utils/verifier.go
+++ b/controlplane/pkg/tests/utils/verifier.go
@@ -140,15 +140,17 @@ type endpointVerifier struct {
 }
 
 func (v *endpointVerifier) Verify(t *testing.T) {
+	g := NewWithT(t)
+
 	nse := v.model.GetEndpoint(v.name)
 	if !v.exists {
-		Expect(nse).To(BeNil())
+		g.Expect(nse).To(BeNil())
 		return
 	}
 
-	Expect(nse).NotTo(BeNil())
+	g.Expect(nse).NotTo(BeNil())
 
-	Expect(nse.Endpoint.GetNetworkServiceManager().GetName()).To(Equal(v.nsm))
+	g.Expect(nse.Endpoint.GetNetworkServiceManager().GetName()).To(Equal(v.nsm))
 }
 
 type clientConnectionVerifier struct {
@@ -164,33 +166,37 @@ type clientConnectionVerifier struct {
 }
 
 func (v *clientConnectionVerifier) Verify(t *testing.T) {
+	g := NewWithT(t)
+
 	connection := v.model.GetClientConnection(v.connectionID)
 	if !v.exists {
-		Expect(connection).To(BeNil())
+		g.Expect(connection).To(BeNil())
 		return
 	}
 
-	Expect(connection).NotTo(BeNil())
+	g.Expect(connection).NotTo(BeNil())
 
 	v.verifyXcon(connection.Xcon, t)
-	Expect(connection.RemoteNsm.GetName()).To(Equal(v.remoteNSM))
-	Expect(connection.Endpoint.GetNetworkserviceEndpoint().GetEndpointName()).To(Equal(v.nse))
-	Expect(connection.DataplaneRegisteredName).To(Equal(v.dataplane))
+	g.Expect(connection.RemoteNsm.GetName()).To(Equal(v.remoteNSM))
+	g.Expect(connection.Endpoint.GetNetworkserviceEndpoint().GetEndpointName()).To(Equal(v.nse))
+	g.Expect(connection.DataplaneRegisteredName).To(Equal(v.dataplane))
 }
 
 func (v *clientConnectionVerifier) verifyXcon(xcon *crossconnect.CrossConnect, t *testing.T) {
+	g := NewWithT(t)
+
 	if source := xcon.GetLocalSource(); source != nil {
-		Expect(source.GetId()).To(Equal(v.srcID))
+		g.Expect(source.GetId()).To(Equal(v.srcID))
 	} else if source := xcon.GetRemoteSource(); source != nil {
-		Expect(source.GetId()).To(Equal(v.srcID))
+		g.Expect(source.GetId()).To(Equal(v.srcID))
 	} else {
 		t.Fatalf("Expected xcon.Source not to be nil")
 	}
 
 	if destination := xcon.GetLocalDestination(); destination != nil {
-		Expect(destination.GetId()).To(Equal(v.dstID))
+		g.Expect(destination.GetId()).To(Equal(v.dstID))
 	} else if destination := xcon.GetRemoteDestination(); destination != nil {
-		Expect(destination.GetId()).To(Equal(v.dstID))
+		g.Expect(destination.GetId()).To(Equal(v.dstID))
 	} else {
 		t.Fatalf("Expected xcon.Destination not to be nil")
 	}
@@ -204,11 +210,13 @@ type dataplaneVerifier struct {
 }
 
 func (v *dataplaneVerifier) Verify(t *testing.T) {
+	g := NewWithT(t)
+
 	dataplane := v.model.GetDataplane(v.name)
 	if !v.exists {
-		Expect(dataplane).To(BeNil())
+		g.Expect(dataplane).To(BeNil())
 		return
 	}
 
-	Expect(dataplane).NotTo(BeNil())
+	g.Expect(dataplane).NotTo(BeNil())
 }

--- a/dataplane/pkg/common/egress_interface_test.go
+++ b/dataplane/pkg/common/egress_interface_test.go
@@ -10,36 +10,36 @@ import (
 )
 
 func TestParseDefaultGateway(t *testing.T) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
 
 	gw := parseGatewayIP("010011AC")
 	logrus.Printf("Value %v", gw.String())
-	Expect(gw.String(), "172.17.0.1")
+	g.Expect(gw.String(), "172.17.0.1")
 }
 
 func TestParseProcContent(t *testing.T) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
 
 	r := bufio.NewReader(strings.NewReader("Iface	Destination	Gateway 	Flags	RefCnt	Use	Metric	Mask		MTU	Window	IRTT\n" +
 		"eth0	00000000	010011AC	0003	0	0	0	00000000	0	0	0\n" +
 		"eth0	000011AC	00000000	0001	0	0	0	0000FFFF	0	0	0\n"))
 
 	eth0, gw, err := parseProcFile(r)
-	Expect(err).To(BeNil())
+	g.Expect(err).To(BeNil())
 	logrus.Printf("Value %v", gw.String())
-	Expect(gw.String()).To(Equal("172.17.0.1"))
-	Expect(eth0).To(Equal("eth0"))
+	g.Expect(gw.String()).To(Equal("172.17.0.1"))
+	g.Expect(eth0).To(Equal("eth0"))
 }
 func TestParseProcWrongContent(t *testing.T) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
 
 	r := bufio.NewReader(strings.NewReader("Iface	Destination	Gateway 	Flags	RefCnt	Use	Metric	Mask		MTU	Window	IRTT\n" +
 		"eth0	00000001	010011AC	0003	0	0	0	00000000	0	0	0\n" +
 		"eth0	000011AC	00000000	0001	0	0	0	0000FFFF	0	0	0\n"))
 
 	eth0, gw, err := parseProcFile(r)
-	Expect(err.Error()).To(Equal("Failed to locate default route..."))
+	g.Expect(err.Error()).To(Equal("Failed to locate default route..."))
 	logrus.Printf("Value %v", gw.String())
-	Expect(eth0).To(Equal(""))
-	Expect(gw).To(BeNil())
+	g.Expect(eth0).To(Equal(""))
+	g.Expect(gw).To(BeNil())
 }

--- a/dataplane/pkg/memifproxy/memif_proxy_test.go
+++ b/dataplane/pkg/memifproxy/memif_proxy_test.go
@@ -10,62 +10,80 @@ import (
 )
 
 func TestClosingOpeningMemifProxy(t *testing.T) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
 	proxy, err := newCustomProxy("source.sock", "target.sock", "unix")
-	Expect(err).Should(BeNil())
+	g.Expect(err).Should(BeNil())
 	for i := 0; i < 10; i++ {
-		startProxy(proxy)
-		stopProxy(proxy)
+		err = startProxy(proxy)
+		g.Expect(err).To(BeNil())
+		err = stopProxy(proxy)
+		g.Expect(err).To(BeNil())
 	}
 }
 
 func TestTransferBetweenMemifProxies(t *testing.T) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
 	for i := 0; i < 10; i++ {
 		proxy1, err := newCustomProxy("source.sock", "target.sock", "unix")
-		Expect(err).Should(BeNil())
+		g.Expect(err).Should(BeNil())
 		proxy2, err := newCustomProxy("target.sock", "source.sock", "unix")
-		Expect(err).Should(BeNil())
-		startProxy(proxy1)
-		startProxy(proxy2)
-		connectAndSendMsg("source.sock")
-		connectAndSendMsg("target.sock")
-		stopProxy(proxy1)
-		stopProxy(proxy2)
+		g.Expect(err).Should(BeNil())
+		err = startProxy(proxy1)
+		g.Expect(err).To(BeNil())
+		err = startProxy(proxy2)
+		g.Expect(err).To(BeNil())
+		err = connectAndSendMsg("source.sock")
+		g.Expect(err).To(BeNil())
+		err = connectAndSendMsg("target.sock")
+		g.Expect(err).To(BeNil())
+		err = stopProxy(proxy1)
+		g.Expect(err).To(BeNil())
+		err = stopProxy(proxy2)
+		g.Expect(err).To(BeNil())
 	}
 }
 
 func TestStartProxyIfSocketFileIsExist(t *testing.T) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
 	_, err := os.Create("source.sock")
-	Expect(err).Should(BeNil())
+	g.Expect(err).Should(BeNil())
 	proxy, err := newCustomProxy("source.sock", "target.sock", "unix")
-	Expect(err).Should(BeNil())
-	startProxy(proxy)
-	stopProxy(proxy)
+	g.Expect(err).Should(BeNil())
+	err = startProxy(proxy)
+	g.Expect(err).To(BeNil())
+	err = stopProxy(proxy)
+	g.Expect(err).To(BeNil())
 }
 
-func connectAndSendMsg(sock string) {
+func connectAndSendMsg(sock string) error {
 	addr, err := net.ResolveUnixAddr("unix", sock)
-	Expect(err).To(BeNil())
+	if err != nil {
+		return err
+	}
+
 	var conn *net.UnixConn
 	conn, err = net.DialUnix("unix", nil, addr)
-	Expect(err).To(BeNil())
+	if err != nil {
+		return err
+	}
+
 	_, err = conn.Write([]byte("secret"))
-	Expect(err).To(BeNil())
+	if err != nil {
+		return err
+	}
+
 	err = conn.Close()
 	if err != nil {
 		logrus.Error(err.Error())
+		return err
 	}
-	Expect(err).To(BeNil())
+	return nil
 }
 
-func startProxy(proxy *Proxy) {
-	err := proxy.Start()
-	Expect(err).To(BeNil())
+func startProxy(proxy *Proxy) error {
+	return proxy.Start()
 }
 
-func stopProxy(proxy *Proxy) {
-	err := proxy.Stop()
-	Expect(err).To(BeNil())
+func stopProxy(proxy *Proxy) error {
+	return proxy.Stop()
 }

--- a/dataplane/vppagent/pkg/converter/memif_interface_converter_test.go
+++ b/dataplane/vppagent/pkg/converter/memif_interface_converter_test.go
@@ -60,19 +60,19 @@ var ipAddress = map[ConnectionContextSide][]string{
 	DESTINATION: {dstIp},
 }
 
-func checkInterface(intf *vpp.Interface, side ConnectionContextSide) {
-	Expect(intf.Name).To(Equal(interfaceName))
-	Expect(intf.IpAddresses).To(Equal(ipAddress[side]))
-	Expect(intf.Type).To(Equal(vpp_interfaces.Interface_MEMIF))
+func checkInterface(g *WithT, intf *vpp.Interface, side ConnectionContextSide) {
+	g.Expect(intf.Name).To(Equal(interfaceName))
+	g.Expect(intf.IpAddresses).To(Equal(ipAddress[side]))
+	g.Expect(intf.Type).To(Equal(vpp_interfaces.Interface_MEMIF))
 }
 
-func checkMemif(memif *vpp_interfaces.Interface_Memif, isMaster bool) {
-	Expect(memif.Memif.Master).To(Equal(isMaster))
-	Expect(memif.Memif.SocketFilename).To(Equal(path.Join(baseDir, mechanismName, socketFilename)))
+func checkMemif(g *WithT, memif *vpp_interfaces.Interface_Memif, isMaster bool) {
+	g.Expect(memif.Memif.Master).To(Equal(isMaster))
+	g.Expect(memif.Memif.SocketFilename).To(Equal(path.Join(baseDir, mechanismName, socketFilename)))
 }
 
 func TestSourceSideConverter(t *testing.T) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
 	conversionParameters := &ConnectionConversionParameters{
 		Terminate: true,
 		Side:      SOURCE,
@@ -81,17 +81,17 @@ func TestSourceSideConverter(t *testing.T) {
 	}
 	converter := NewMemifInterfaceConverter(createTestConnection(), conversionParameters)
 	dataRequest, err := converter.ToDataRequest(nil, true)
-	Expect(err).To(BeNil())
+	g.Expect(err).To(BeNil())
 
-	Expect(dataRequest.VppConfig.Interfaces).ToNot(BeEmpty())
-	checkInterface(dataRequest.VppConfig.Interfaces[0], SOURCE)
+	g.Expect(dataRequest.VppConfig.Interfaces).ToNot(BeEmpty())
+	checkInterface(g, dataRequest.VppConfig.Interfaces[0], SOURCE)
 
-	Expect(dataRequest.VppConfig.Interfaces[0].Link.(*vpp_interfaces.Interface_Memif)).ToNot(BeNil())
-	checkMemif(dataRequest.VppConfig.Interfaces[0].Link.(*vpp_interfaces.Interface_Memif), false)
+	g.Expect(dataRequest.VppConfig.Interfaces[0].Link.(*vpp_interfaces.Interface_Memif)).ToNot(BeNil())
+	checkMemif(g, dataRequest.VppConfig.Interfaces[0].Link.(*vpp_interfaces.Interface_Memif), false)
 }
 
 func TestDestinationSideConverter(t *testing.T) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
 	conversionParameters := &ConnectionConversionParameters{
 		Terminate: false,
 		Side:      DESTINATION,
@@ -100,17 +100,17 @@ func TestDestinationSideConverter(t *testing.T) {
 	}
 	converter := NewMemifInterfaceConverter(createTestConnection(), conversionParameters)
 	dataRequest, err := converter.ToDataRequest(nil, true)
-	Expect(err).To(BeNil())
+	g.Expect(err).To(BeNil())
 
-	Expect(dataRequest.VppConfig.Interfaces).ToNot(BeEmpty())
-	checkInterface(dataRequest.VppConfig.Interfaces[0], NEITHER)
+	g.Expect(dataRequest.VppConfig.Interfaces).ToNot(BeEmpty())
+	checkInterface(g, dataRequest.VppConfig.Interfaces[0], NEITHER)
 
-	Expect(dataRequest.VppConfig.Interfaces[0].Link.(*vpp_interfaces.Interface_Memif)).ToNot(BeNil())
-	checkMemif(dataRequest.VppConfig.Interfaces[0].Link.(*vpp_interfaces.Interface_Memif), false)
+	g.Expect(dataRequest.VppConfig.Interfaces[0].Link.(*vpp_interfaces.Interface_Memif)).ToNot(BeNil())
+	checkMemif(g, dataRequest.VppConfig.Interfaces[0].Link.(*vpp_interfaces.Interface_Memif), false)
 }
 
 func TestTerminateDestinationSideConverter(t *testing.T) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
 	conversionParameters := &ConnectionConversionParameters{
 		Terminate: true,
 		Side:      DESTINATION,
@@ -119,13 +119,13 @@ func TestTerminateDestinationSideConverter(t *testing.T) {
 	}
 	converter := NewMemifInterfaceConverter(createTestConnection(), conversionParameters)
 	dataRequest, err := converter.ToDataRequest(nil, true)
-	Expect(err).To(BeNil())
+	g.Expect(err).To(BeNil())
 
-	Expect(dataRequest.VppConfig.Interfaces).ToNot(BeEmpty())
-	checkInterface(dataRequest.VppConfig.Interfaces[0], DESTINATION)
+	g.Expect(dataRequest.VppConfig.Interfaces).ToNot(BeEmpty())
+	checkInterface(g, dataRequest.VppConfig.Interfaces[0], DESTINATION)
 
-	Expect(dataRequest.VppConfig.Interfaces[0].Link.(*vpp_interfaces.Interface_Memif).Memif).ToNot(BeNil())
-	checkMemif(dataRequest.VppConfig.Interfaces[0].Link.(*vpp_interfaces.Interface_Memif), true)
+	g.Expect(dataRequest.VppConfig.Interfaces[0].Link.(*vpp_interfaces.Interface_Memif).Memif).ToNot(BeNil())
+	checkMemif(g, dataRequest.VppConfig.Interfaces[0].Link.(*vpp_interfaces.Interface_Memif), true)
 
 	os.RemoveAll(baseDir)
 }

--- a/k8s/pkg/prefixcollector/collector_server_test.go
+++ b/k8s/pkg/prefixcollector/collector_server_test.go
@@ -61,9 +61,11 @@ func (d *dummyWatcher) send(t watch.EventType, dr *dummyResource) {
 }
 
 func checkSubnetWatcher(t *testing.T, subnetSequence, expectedSequence []string) {
+	g := NewWithT(t)
+
 	dw := NewDummyWatcher()
 	sw, err := watchSubnet(dw, keyFuncDummy, subnetFuncDummy)
-	Expect(err).To(BeNil())
+	g.Expect(err).To(BeNil())
 
 	for i := 0; i < len(subnetSequence); i++ {
 		dw.send(watch.Added, &dummyResource{fmt.Sprintf("r%d", i), subnetSequence[i]})
@@ -72,7 +74,7 @@ func checkSubnetWatcher(t *testing.T, subnetSequence, expectedSequence []string)
 	for i := 0; i < len(expectedSequence); i++ {
 		select {
 		case e := <-sw.ResultChan():
-			Expect(e.String()).To(Equal(expectedSequence[i]))
+			g.Expect(e.String()).To(Equal(expectedSequence[i]))
 		case <-time.After(1 * time.Second):
 			if expectedSequence[i] != "-" {
 				logrus.Error("Timeout waiting for next subnet")
@@ -83,7 +85,6 @@ func checkSubnetWatcher(t *testing.T, subnetSequence, expectedSequence []string)
 }
 
 func TestSimpleSubnetCollector(t *testing.T) {
-	RegisterTestingT(t)
 	subnetSequence := []string{
 		"10.20.1.0/24",
 		"10.20.2.0/24",
@@ -96,7 +97,6 @@ func TestSimpleSubnetCollector(t *testing.T) {
 }
 
 func TestLastIpsAlreadyInSubnet(t *testing.T) {
-	RegisterTestingT(t)
 	subnetSequence := []string{
 		"10.96.10.10/32",
 		"10.98.2.0/32",
@@ -113,7 +113,6 @@ func TestLastIpsAlreadyInSubnet(t *testing.T) {
 }
 
 func TestIntermediateIpsAlreadyInSubnet(t *testing.T) {
-	RegisterTestingT(t)
 	subnetSequence := []string{
 		"10.96.10.10/32",
 		"10.98.2.0/32",
@@ -130,7 +129,6 @@ func TestIntermediateIpsAlreadyInSubnet(t *testing.T) {
 }
 
 func TestIpv6(t *testing.T) {
-	RegisterTestingT(t)
 	subnetSequence := []string{
 		"100::1:0/112",
 		"100::2:0/112",

--- a/k8s/pkg/tests/ns_cache_test.go
+++ b/k8s/pkg/tests/ns_cache_test.go
@@ -12,20 +12,20 @@ import (
 )
 
 func TestNsCacheConcurrentModification(t *testing.T) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
 
 	c := resource_cache.NewNetworkServiceCache()
 	fakeRegistry := fakeRegistry{}
 
 	stopFunc, err := c.Start(&fakeRegistry)
 
-	Expect(stopFunc).ToNot(BeNil())
-	Expect(err).To(BeNil())
+	g.Expect(stopFunc).ToNot(BeNil())
+	g.Expect(err).To(BeNil())
 
 	c.Add(&v1.NetworkService{ObjectMeta: metav1.ObjectMeta{Name: "ns1"}})
 	stopRead := RepeatAsync(func() {
 		ns := c.Get("ns1")
-		Expect(ns).ShouldNot(BeNil())
+		g.Expect(ns).ShouldNot(BeNil())
 	})
 	defer stopRead()
 

--- a/k8s/pkg/tests/nse_cache_test.go
+++ b/k8s/pkg/tests/nse_cache_test.go
@@ -53,33 +53,33 @@ func (f *fakeRegistry) Delete(nse *v1.NetworkServiceEndpoint) {
 }
 
 func TestK8sRegistryAdd(t *testing.T) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
 
 	fakeRegistry := fakeRegistry{}
 	nseCache := resource_cache.NewNetworkServiceEndpointCache()
 
 	stopFunc, err := nseCache.Start(&fakeRegistry)
 
-	Expect(stopFunc).ToNot(BeNil())
-	Expect(err).To(BeNil())
+	g.Expect(stopFunc).ToNot(BeNil())
+	g.Expect(err).To(BeNil())
 
 	nse := newTestNse("nse1", "ns1")
 	fakeRegistry.Add(nse)
 
 	endpointList := getEndpoints(nseCache, "ns1", 1)
-	Expect(len(endpointList)).To(Equal(1))
-	Expect(endpointList[0].Name).To(Equal("nse1"))
+	g.Expect(len(endpointList)).To(Equal(1))
+	g.Expect(endpointList[0].Name).To(Equal("nse1"))
 }
 
 func TestNseCacheConcurrentModification(t *testing.T) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
 	fakeRegistry := fakeRegistry{}
 	c := resource_cache.NewNetworkServiceEndpointCache()
 
 	stopFunc, err := c.Start(&fakeRegistry)
 	defer stopFunc()
-	Expect(stopFunc).ToNot(BeNil())
-	Expect(err).To(BeNil())
+	g.Expect(stopFunc).ToNot(BeNil())
+	g.Expect(err).To(BeNil())
 
 	c.Add(newTestNse("nse1", "ns1"))
 	c.Add(newTestNse("nse2", "ns2"))
@@ -99,34 +99,34 @@ func TestNseCacheConcurrentModification(t *testing.T) {
 	time.Sleep(time.Second * 5)
 }
 func TestNsmdRegistryAdd(t *testing.T) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
 
 	fakeRegistry := fakeRegistry{}
 	nseCache := resource_cache.NewNetworkServiceEndpointCache()
 
 	stopFunc, err := nseCache.Start(&fakeRegistry)
 
-	Expect(stopFunc).ToNot(BeNil())
-	Expect(err).To(BeNil())
+	g.Expect(stopFunc).ToNot(BeNil())
+	g.Expect(err).To(BeNil())
 
 	nse := newTestNse("nse1", "ns1")
 	nseCache.Add(nse)
 
 	endpointList := getEndpoints(nseCache, "ns1", 1)
-	Expect(len(endpointList)).To(Equal(1))
-	Expect(endpointList[0].Name).To(Equal("nse1"))
+	g.Expect(len(endpointList)).To(Equal(1))
+	g.Expect(endpointList[0].Name).To(Equal("nse1"))
 }
 
 func TestRegistryDelete(t *testing.T) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
 
 	fakeRegistry := fakeRegistry{}
 	nseCache := resource_cache.NewNetworkServiceEndpointCache()
 
 	stopFunc, err := nseCache.Start(&fakeRegistry)
 
-	Expect(stopFunc).ToNot(BeNil())
-	Expect(err).To(BeNil())
+	g.Expect(stopFunc).ToNot(BeNil())
+	g.Expect(err).To(BeNil())
 
 	nse1 := newTestNse("nse1", "ns1")
 	nse2 := newTestNse("nse2", "ns1")
@@ -137,13 +137,13 @@ func TestRegistryDelete(t *testing.T) {
 	fakeRegistry.Add(nse3)
 
 	endpointList1 := getEndpoints(nseCache, "ns1", 2)
-	Expect(len(endpointList1)).To(Equal(2))
+	g.Expect(len(endpointList1)).To(Equal(2))
 	endpointList2 := getEndpoints(nseCache, "ns2", 1)
-	Expect(len(endpointList2)).To(Equal(1))
+	g.Expect(len(endpointList2)).To(Equal(1))
 
 	fakeRegistry.Delete(nse3)
 	endpointList3 := getEndpoints(nseCache, "ns2", 0)
-	Expect(len(endpointList3)).To(Equal(0))
+	g.Expect(len(endpointList3)).To(Equal(0))
 }
 
 func getEndpoints(nseCache *resource_cache.NetworkServiceEndpointCache,

--- a/k8s/pkg/tests/nsm_cache_test.go
+++ b/k8s/pkg/tests/nsm_cache_test.go
@@ -12,33 +12,33 @@ import (
 )
 
 func TestNsmCacheGetNil(t *testing.T) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
 	c := resource_cache.NewNetworkServiceManagerCache()
 
 	stopFunc, err := c.Start(&fakeRegistry{})
 	defer stopFunc()
-	Expect(stopFunc).ToNot(BeNil())
-	Expect(err).To(BeNil())
+	g.Expect(stopFunc).ToNot(BeNil())
+	g.Expect(err).To(BeNil())
 	var expect *v1.NetworkServiceManager = nil
-	Expect(c.Get("Justice")).Should(Equal(expect))
+	g.Expect(c.Get("Justice")).Should(Equal(expect))
 }
 
 func TestNsmCacheConcurrentModification(t *testing.T) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
 	c := resource_cache.NewNetworkServiceManagerCache()
 
 	stopFunc, err := c.Start(&fakeRegistry{})
 	defer stopFunc()
-	Expect(stopFunc).ToNot(BeNil())
-	Expect(err).To(BeNil())
+	g.Expect(stopFunc).ToNot(BeNil())
+	g.Expect(err).To(BeNil())
 
 	c.Add(FakeNsm("nsm-1"))
 	c.Add(FakeNsm("nsm-2"))
 
 	stopRead := RepeatAsync(func() {
 		nsm1 := c.Get("nsm-1")
-		Expect(nsm1).ShouldNot(BeNil())
-		Expect(nsm1.Name).Should(Equal("nsm-1"))
+		g.Expect(nsm1).ShouldNot(BeNil())
+		g.Expect(nsm1.Name).Should(Equal("nsm-1"))
 
 		c.Get("nsm-2")
 
@@ -59,7 +59,7 @@ func TestNsmCacheConcurrentModification(t *testing.T) {
 }
 
 func TestNsmCacheStartWithInit(t *testing.T) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
 	c := resource_cache.NewNetworkServiceManagerCache()
 
 	init := []v1.NetworkServiceManager{
@@ -74,9 +74,9 @@ func TestNsmCacheStartWithInit(t *testing.T) {
 	}
 	stopFunc, err := c.Start(&fakeRegistry{}, init...)
 	defer stopFunc()
-	Expect(stopFunc).ToNot(BeNil())
-	Expect(err).To(BeNil())
+	g.Expect(stopFunc).ToNot(BeNil())
+	g.Expect(err).To(BeNil())
 
-	Expect(c.Get("nsm-1").Name).To(Equal("nsm-1"))
-	Expect(c.Get("nsm-2").Name).To(Equal("nsm-2"))
+	g.Expect(c.Get("nsm-1").Name).To(Equal("nsm-1"))
+	g.Expect(c.Get("nsm-2").Name).To(Equal("nsm-2"))
 }

--- a/k8s/pkg/tests/registry_cache_test.go
+++ b/k8s/pkg/tests/registry_cache_test.go
@@ -18,16 +18,18 @@ import (
 	"testing"
 )
 
-func readNsm(reader io.ReadCloser) v1.NetworkServiceManager {
-	msg, err := ioutil.ReadAll(reader)
-	Expect(err).Should(BeNil())
+func readNsm(reader io.ReadCloser) (v1.NetworkServiceManager, error) {
 	nsm := v1.NetworkServiceManager{}
+	msg, err := ioutil.ReadAll(reader)
+	if err != nil {
+		return nsm, err
+	}
+
 	err = json.Unmarshal(msg, &nsm)
-	Expect(err).Should(BeNil())
-	return nsm
+	return nsm, err
 }
 
-func fakeNsmRest(serverData *sync.Map) *FakeRest {
+func fakeNsmRest(g *WithT, serverData *sync.Map) *FakeRest {
 	result := NewFakeRest(v1.SchemeGroupVersion, scheme.Codecs)
 	result.MockGet("/networkserviceendpoints", func(r *http.Request, resource string) (response *http.Response, e error) {
 		return Ok([]v1.NetworkServiceEndpoint{}), nil
@@ -51,7 +53,8 @@ func fakeNsmRest(serverData *sync.Map) *FakeRest {
 		return Ok([]v1.NetworkService{}), nil
 	})
 	result.MockPost("/namespaces/default/networkservicemanagers", func(r *http.Request, resource string) (response *http.Response, e error) {
-		nsm := readNsm(r.Body)
+		nsm, err := readNsm(r.Body)
+		g.Expect(err).To(BeNil())
 		if val, ok := serverData.Load(nsm.Name); ok {
 			return AlreadyExist(val), nil
 		}
@@ -60,7 +63,8 @@ func fakeNsmRest(serverData *sync.Map) *FakeRest {
 		return Ok(nsm), nil
 	})
 	result.MockPut("/namespaces/default/networkservicemanagers", func(r *http.Request, resource string) (response *http.Response, e error) {
-		nsm := readNsm(r.Body)
+		nsm, err := readNsm(r.Body)
+		g.Expect(err).To(BeNil())
 		if nsm.ResourceVersion == "0" {
 			return BadVersion(nsm), nil
 		}
@@ -74,39 +78,39 @@ func fakeNsmRest(serverData *sync.Map) *FakeRest {
 }
 
 func TestCreateOrUpdateNetworkServiceManager(t *testing.T) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
 	nsm := FakeNsm("fake")
 	nsm.ResourceVersion = "1"
 	serverData := sync.Map{}
 	serverData.Store("fake", nsm)
-	fakeRest := fakeNsmRest(&serverData)
+	fakeRest := fakeNsmRest(g, &serverData)
 	cache := registryserver.NewRegistryCache(versioned.New(fakeRest))
 	err := cache.Start()
-	Expect(err).Should(BeNil())
+	g.Expect(err).Should(BeNil())
 	_, err = cache.CreateOrUpdateNetworkServiceManager(FakeNsm("fake"))
 	defer cache.Stop()
-	Expect(err).Should(BeNil())
+	g.Expect(err).Should(BeNil())
 
 }
 func TestConcurrentCreateOrUpdateNetworkServiceManager(t *testing.T) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
 	serverData := sync.Map{}
 	fakeRest := fakeNsmRest(&serverData)
 	for i := 0; i < 10; i++ {
 		cache := registryserver.NewRegistryCache(versioned.New(fakeRest))
 		err := cache.Start()
-		Expect(err).Should(BeNil())
+		g.Expect(err).Should(BeNil())
 		defer cache.Stop()
 		stopClient1 := RepeatAsync(func() {
 			nsm := FakeNsm("fake")
 			_, err := cache.CreateOrUpdateNetworkServiceManager(nsm)
-			Expect(err).Should(BeNil())
+			g.Expect(err).Should(BeNil())
 		})
 		defer stopClient1()
 		stopClient2 := RepeatAsync(func() {
 			nsm := FakeNsm("fake")
 			_, err := cache.CreateOrUpdateNetworkServiceManager(nsm)
-			Expect(err).Should(BeNil())
+			g.Expect(err).Should(BeNil())
 		})
 		defer stopClient2()
 		time.Sleep(time.Microsecond * 500)
@@ -114,40 +118,40 @@ func TestConcurrentCreateOrUpdateNetworkServiceManager(t *testing.T) {
 }
 
 func TestUpdatingExistingNetworkServiceManager(t *testing.T) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
 	serverData := sync.Map{}
 	fakeRest := fakeNsmRest(&serverData)
 	cache := registryserver.NewRegistryCache(versioned.New(fakeRest))
 	err := cache.Start()
-	Expect(err).Should(BeNil())
+	g.Expect(err).Should(BeNil())
 	defer cache.Stop()
 	nsm := FakeNsm("fake")
 	_, err = cache.CreateOrUpdateNetworkServiceManager(nsm)
-	Expect(err).Should(BeNil())
+	g.Expect(err).Should(BeNil())
 	nsm.Status.URL = "update"
 	_, err = cache.CreateOrUpdateNetworkServiceManager(nsm)
-	Expect(err).Should(BeNil())
+	g.Expect(err).Should(BeNil())
 	val, ok := serverData.Load("fake")
-	Expect(ok).Should(Equal(true))
-	Expect(val.(v1.NetworkServiceManager).Status.URL).Should(Equal("update"))
+	g.Expect(ok).Should(Equal(true))
+	g.Expect(val.(v1.NetworkServiceManager).Status.URL).Should(Equal("update"))
 
 }
 func TestUpdatingNotExistingNetworkServiceManager(t *testing.T) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
 	serverData := sync.Map{}
 	fakeRest := fakeNsmRest(&serverData)
 	cache := registryserver.NewRegistryCache(versioned.New(fakeRest))
 	err := cache.Start()
-	Expect(err).Should(BeNil())
+	g.Expect(err).Should(BeNil())
 	defer cache.Stop()
 	nsm := FakeNsm("fake")
 	nsm.ResourceVersion = "1"
 	serverData.Store(nsm.Name, nsm.DeepCopy())
-	Expect(err).Should(BeNil())
+	g.Expect(err).Should(BeNil())
 	nsm.Status.URL = "update"
 	_, err = cache.CreateOrUpdateNetworkServiceManager(nsm)
-	Expect(err).Should(BeNil())
+	g.Expect(err).Should(BeNil())
 	val, ok := serverData.Load("fake")
-	Expect(ok).Should(Equal(true))
-	Expect(val.(v1.NetworkServiceManager).Status.URL).Should(Equal("update"))
+	g.Expect(ok).Should(Equal(true))
+	g.Expect(val.(v1.NetworkServiceManager).Status.URL).Should(Equal("update"))
 }

--- a/k8s/pkg/tests/registry_cache_test.go
+++ b/k8s/pkg/tests/registry_cache_test.go
@@ -18,7 +18,7 @@ import (
 	"testing"
 )
 
-func readNsm(reader io.ReadCloser) (v1.NetworkServiceManager, error) {
+func readNsm(reader io.Reader) (v1.NetworkServiceManager, error) {
 	nsm := v1.NetworkServiceManager{}
 	msg, err := ioutil.ReadAll(reader)
 	if err != nil {
@@ -95,7 +95,7 @@ func TestCreateOrUpdateNetworkServiceManager(t *testing.T) {
 func TestConcurrentCreateOrUpdateNetworkServiceManager(t *testing.T) {
 	g := NewWithT(t)
 	serverData := sync.Map{}
-	fakeRest := fakeNsmRest(&serverData)
+	fakeRest := fakeNsmRest(g, &serverData)
 	for i := 0; i < 10; i++ {
 		cache := registryserver.NewRegistryCache(versioned.New(fakeRest))
 		err := cache.Start()
@@ -120,7 +120,7 @@ func TestConcurrentCreateOrUpdateNetworkServiceManager(t *testing.T) {
 func TestUpdatingExistingNetworkServiceManager(t *testing.T) {
 	g := NewWithT(t)
 	serverData := sync.Map{}
-	fakeRest := fakeNsmRest(&serverData)
+	fakeRest := fakeNsmRest(g, &serverData)
 	cache := registryserver.NewRegistryCache(versioned.New(fakeRest))
 	err := cache.Start()
 	g.Expect(err).Should(BeNil())
@@ -139,7 +139,7 @@ func TestUpdatingExistingNetworkServiceManager(t *testing.T) {
 func TestUpdatingNotExistingNetworkServiceManager(t *testing.T) {
 	g := NewWithT(t)
 	serverData := sync.Map{}
-	fakeRest := fakeNsmRest(&serverData)
+	fakeRest := fakeNsmRest(g, &serverData)
 	cache := registryserver.NewRegistryCache(versioned.New(fakeRest))
 	err := cache.Start()
 	g.Expect(err).Should(BeNil())

--- a/k8s/pkg/tests/test_utils.go
+++ b/k8s/pkg/tests/test_utils.go
@@ -7,7 +7,6 @@ import (
 	"io/ioutil"
 	"net/http"
 
-	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	v1 "github.com/networkservicemesh/networkservicemesh/k8s/pkg/apis/networkservice/v1alpha1"
@@ -15,7 +14,9 @@ import (
 
 func Body(content interface{}) io.ReadCloser {
 	msg, err := json.Marshal(content)
-	Expect(err).Should(BeNil())
+	if err != nil {
+		panic(err)
+	}
 	return ioutil.NopCloser(bytes.NewReader(msg))
 }
 func Ok(content interface{}) *http.Response {
@@ -46,14 +47,15 @@ func AlreadyExist(content interface{}) *http.Response {
 
 func Status(status int, content interface{}) *http.Response {
 	msg, err := json.Marshal(content)
-	Expect(err).Should(BeNil())
+	if err != nil {
+		panic(err)
+	}
 	return &http.Response{
 		StatusCode: status,
 		Body:       ioutil.NopCloser(bytes.NewReader(msg)),
 	}
 }
 func RepeatAsync(operation func()) (stopFunc func()) {
-	Expect(operation).ShouldNot(BeNil())
 	stopCh := make(chan struct{})
 	stopFunc = func() {
 		close(stopCh)

--- a/test/cloudtest/pkg/tests/all_cluster_fail_test.go
+++ b/test/cloudtest/pkg/tests/all_cluster_fail_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestClusterInstancesFailed(t *testing.T) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
 
 	testConfig := &config.CloudTestConfig{}
 
@@ -21,7 +21,7 @@ func TestClusterInstancesFailed(t *testing.T) {
 
 	tmpDir, err := ioutil.TempDir(os.TempDir(), "cloud-test-temp")
 	defer utils.ClearFolder(tmpDir, false)
-	Expect(err).To(BeNil())
+	g.Expect(err).To(BeNil())
 
 	testConfig.ConfigRoot = tmpDir
 	createProvider(testConfig, "a_provider")
@@ -37,18 +37,18 @@ func TestClusterInstancesFailed(t *testing.T) {
 	testConfig.Reporting.JUnitReportFile = JunitReport
 
 	report, err := commands.PerformTesting(testConfig, &testValidationFactory{}, &commands.Arguments{})
-	Expect(err.Error()).To(Equal("there is failed tests 3"))
+	g.Expect(err.Error()).To(Equal("there is failed tests 3"))
 
-	Expect(report).NotTo(BeNil())
+	g.Expect(report).NotTo(BeNil())
 
-	Expect(len(report.Suites)).To(Equal(2))
-	Expect(report.Suites[0].Failures).To(Equal(1))
-	Expect(report.Suites[0].Tests).To(Equal(3))
-	Expect(len(report.Suites[0].TestCases)).To(Equal(3))
+	g.Expect(len(report.Suites)).To(Equal(2))
+	g.Expect(report.Suites[0].Failures).To(Equal(1))
+	g.Expect(report.Suites[0].Tests).To(Equal(3))
+	g.Expect(len(report.Suites[0].TestCases)).To(Equal(3))
 
-	Expect(report.Suites[1].Failures).To(Equal(2))
-	Expect(report.Suites[1].Tests).To(Equal(5))
-	Expect(len(report.Suites[1].TestCases)).To(Equal(5))
+	g.Expect(report.Suites[1].Failures).To(Equal(2))
+	g.Expect(report.Suites[1].Tests).To(Equal(5))
+	g.Expect(len(report.Suites[1].TestCases)).To(Equal(5))
 
 	// Do assertions
 }

--- a/test/cloudtest/pkg/tests/cloud_config_test.go
+++ b/test/cloudtest/pkg/tests/cloud_config_test.go
@@ -11,16 +11,16 @@ import (
 )
 
 func TestClusterConfiguration(t *testing.T) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
 
 	var testConfig config.CloudTestConfig
 
 	file1, err := ioutil.ReadFile("./config1.yaml")
-	Expect(err).To(BeNil())
+	g.Expect(err).To(BeNil())
 
 	err = yaml.Unmarshal(file1, &testConfig)
-	Expect(err).To(BeNil())
-	Expect(len(testConfig.Providers)).To(Equal(3))
-	Expect(testConfig.Reporting.JUnitReportFile).To(Equal("./.tests/junit.xml"))
+	g.Expect(err).To(BeNil())
+	g.Expect(len(testConfig.Providers)).To(Equal(3))
+	g.Expect(testConfig.Reporting.JUnitReportFile).To(Equal("./.tests/junit.xml"))
 
 }

--- a/test/cloudtest/pkg/tests/sample/sample_interdomain_test.go
+++ b/test/cloudtest/pkg/tests/sample/sample_interdomain_test.go
@@ -11,21 +11,21 @@ import (
 )
 
 func TestInterDomainPass(t *testing.T) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
 
 	logrus.Infof("Passed test")
 }
 
 func TestInterdomainCheck(t *testing.T) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
 
-	Expect(len(os.Getenv("CFG1")) != 0).To(Equal(true))
-	Expect(len(os.Getenv("CFG1")) != 0).To(Equal(true))
+	g.Expect(len(os.Getenv("CFG1")) != 0).To(Equal(true))
+	g.Expect(len(os.Getenv("CFG1")) != 0).To(Equal(true))
 }
 func TestInterdomainFail(t *testing.T) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
 
 	logrus.Infof("Failed test")
 
-	Expect("fail").To(Equal("success"))
+	g.Expect("fail").To(Equal("success"))
 }

--- a/test/cloudtest/pkg/tests/sample/sample_tagged_test.go
+++ b/test/cloudtest/pkg/tests/sample/sample_tagged_test.go
@@ -11,21 +11,21 @@ import (
 )
 
 func TestPassTag(t *testing.T) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
 
 	logrus.Infof("Passed test")
 }
 
 func TestFailTag(t *testing.T) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
 
 	logrus.Infof("Failed test")
 
-	Expect("fail").To(Equal("success"))
+	g.Expect("fail").To(Equal("success"))
 }
 
 func TestTimeoutTag(t *testing.T) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
 
 	logrus.Infof("test timeout for 5 seconds")
 	<-time.After(5 * time.Second)

--- a/test/cloudtest/pkg/tests/sample/sample_test.go
+++ b/test/cloudtest/pkg/tests/sample/sample_test.go
@@ -9,22 +9,18 @@ import (
 )
 
 func TestPass(t *testing.T) {
-	RegisterTestingT(t)
-
 	logrus.Infof("Passed test")
 }
 
 func TestFail(t *testing.T) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
 
 	logrus.Infof("Failed test")
 
-	Expect("fail").To(Equal("success"))
+	g.Expect("fail").To(Equal("success"))
 }
 
 func TestTimeout(t *testing.T) {
-	RegisterTestingT(t)
-
 	logrus.Infof("test timeout for 5 seconds")
 	<-time.After(5 * time.Second)
 }

--- a/test/cloudtest/pkg/tests/shell_provider_test.go
+++ b/test/cloudtest/pkg/tests/shell_provider_test.go
@@ -45,7 +45,7 @@ func (*testValidationFactory) CreateValidator(config *config.ClusterProviderConf
 }
 
 func TestShellProvider(t *testing.T) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
 
 	testConfig := &config.CloudTestConfig{}
 
@@ -53,7 +53,7 @@ func TestShellProvider(t *testing.T) {
 
 	tmpDir, err := ioutil.TempDir(os.TempDir(), "cloud-test-temp")
 	defer utils.ClearFolder(tmpDir, false)
-	Expect(err).To(BeNil())
+	g.Expect(err).To(BeNil())
 
 	testConfig.ConfigRoot = tmpDir
 	createProvider(testConfig, "a_provider")
@@ -75,14 +75,14 @@ func TestShellProvider(t *testing.T) {
 	testConfig.Reporting.JUnitReportFile = JunitReport
 
 	report, err := commands.PerformTesting(testConfig, &testValidationFactory{}, &commands.Arguments{})
-	Expect(err.Error()).To(Equal("there is failed tests 4"))
+	g.Expect(err.Error()).To(Equal("there is failed tests 4"))
 
-	Expect(report).NotTo(BeNil())
+	g.Expect(report).NotTo(BeNil())
 
-	Expect(len(report.Suites)).To(Equal(2))
-	Expect(report.Suites[0].Failures).To(Equal(2))
-	Expect(report.Suites[0].Tests).To(Equal(6))
-	Expect(len(report.Suites[0].TestCases)).To(Equal(6))
+	g.Expect(len(report.Suites)).To(Equal(2))
+	g.Expect(report.Suites[0].Failures).To(Equal(2))
+	g.Expect(report.Suites[0].Tests).To(Equal(6))
+	g.Expect(len(report.Suites[0].TestCases)).To(Equal(6))
 
 	// Do assertions
 }
@@ -109,7 +109,7 @@ func createProvider(testConfig *config.CloudTestConfig, name string) *config.Clu
 }
 
 func TestInvalidProvider(t *testing.T) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
 
 	testConfig := &config.CloudTestConfig{}
 
@@ -117,7 +117,7 @@ func TestInvalidProvider(t *testing.T) {
 
 	tmpDir, err := ioutil.TempDir(os.TempDir(), "cloud-test-temp")
 	defer utils.ClearFolder(tmpDir, false)
-	Expect(err).To(BeNil())
+	g.Expect(err).To(BeNil())
 
 	testConfig.ConfigRoot = tmpDir
 	createProvider(testConfig, "a_provider")
@@ -131,14 +131,14 @@ func TestInvalidProvider(t *testing.T) {
 
 	report, err := commands.PerformTesting(testConfig, &testValidationFactory{}, &commands.Arguments{})
 	logrus.Error(err.Error())
-	Expect(err.Error()).To(Equal("Failed to create cluster instance. Error invalid start script"))
+	g.Expect(err.Error()).To(Equal("Failed to create cluster instance. Error invalid start script"))
 
-	Expect(report).To(BeNil())
+	g.Expect(report).To(BeNil())
 	// Do assertions
 }
 
 func TestRequireEnvVars(t *testing.T) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
 
 	testConfig := &config.CloudTestConfig{}
 
@@ -146,7 +146,7 @@ func TestRequireEnvVars(t *testing.T) {
 
 	tmpDir, err := ioutil.TempDir(os.TempDir(), "cloud-test-temp")
 	defer utils.ClearFolder(tmpDir, false)
-	Expect(err).To(BeNil())
+	g.Expect(err).To(BeNil())
 
 	testConfig.ConfigRoot = tmpDir
 
@@ -164,15 +164,15 @@ func TestRequireEnvVars(t *testing.T) {
 
 	report, err := commands.PerformTesting(testConfig, &testValidationFactory{}, &commands.Arguments{})
 	logrus.Error(err.Error())
-	Expect(err.Error()).To(Equal(
+	g.Expect(err.Error()).To(Equal(
 		"Failed to create cluster instance. Error environment variable are not specified  Required variables: [KUBECONFIG QWE]"))
 
-	Expect(report).To(BeNil())
+	g.Expect(report).To(BeNil())
 	// Do assertions
 }
 
 func TestRequireEnvVars_DEPS(t *testing.T) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
 
 	testConfig := &config.CloudTestConfig{}
 
@@ -180,7 +180,7 @@ func TestRequireEnvVars_DEPS(t *testing.T) {
 
 	tmpDir, err := ioutil.TempDir(os.TempDir(), "cloud-test-temp")
 	defer utils.ClearFolder(tmpDir, false)
-	Expect(err).To(BeNil())
+	g.Expect(err).To(BeNil())
 
 	testConfig.ConfigRoot = tmpDir
 
@@ -213,14 +213,14 @@ func TestRequireEnvVars_DEPS(t *testing.T) {
 	})
 
 	report, err := commands.PerformTesting(testConfig, &testValidationFactory{}, &commands.Arguments{})
-	Expect(err.Error()).To(Equal("there is failed tests 2"))
+	g.Expect(err.Error()).To(Equal("there is failed tests 2"))
 
-	Expect(report).ToNot(BeNil())
+	g.Expect(report).ToNot(BeNil())
 	// Do assertions
 }
 
 func TestShellProviderShellTest(t *testing.T) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
 
 	testConfig := &config.CloudTestConfig{}
 
@@ -228,7 +228,7 @@ func TestShellProviderShellTest(t *testing.T) {
 
 	tmpDir, err := ioutil.TempDir(os.TempDir(), "cloud-test-temp")
 	defer utils.ClearFolder(tmpDir, false)
-	Expect(err).To(BeNil())
+	g.Expect(err).To(BeNil())
 
 	testConfig.ConfigRoot = tmpDir
 	createProvider(testConfig, "a_provider")
@@ -265,20 +265,20 @@ func TestShellProviderShellTest(t *testing.T) {
 	testConfig.Reporting.JUnitReportFile = JunitReport
 
 	report, err := commands.PerformTesting(testConfig, &testValidationFactory{}, &commands.Arguments{})
-	Expect(err.Error()).To(Equal("there is failed tests 4"))
+	g.Expect(err.Error()).To(Equal("there is failed tests 4"))
 
-	Expect(report).NotTo(BeNil())
+	g.Expect(report).NotTo(BeNil())
 
-	Expect(len(report.Suites)).To(Equal(2))
-	Expect(report.Suites[0].Failures).To(Equal(2))
-	Expect(report.Suites[0].Tests).To(Equal(5))
-	Expect(len(report.Suites[0].TestCases)).To(Equal(5))
+	g.Expect(len(report.Suites)).To(Equal(2))
+	g.Expect(report.Suites[0].Failures).To(Equal(2))
+	g.Expect(report.Suites[0].Tests).To(Equal(5))
+	g.Expect(len(report.Suites[0].TestCases)).To(Equal(5))
 
 	// Do assertions
 }
 
 func TestUsedClusterCancel(t *testing.T) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
 
 	testConfig := &config.CloudTestConfig{}
 
@@ -286,7 +286,7 @@ func TestUsedClusterCancel(t *testing.T) {
 
 	tmpDir, err := ioutil.TempDir(os.TempDir(), "cloud-test-temp")
 	defer utils.ClearFolder(tmpDir, false)
-	Expect(err).To(BeNil())
+	g.Expect(err).To(BeNil())
 
 	testConfig.ConfigRoot = tmpDir
 	createProvider(testConfig, "a_provider")
@@ -311,20 +311,20 @@ func TestUsedClusterCancel(t *testing.T) {
 	testConfig.Reporting.JUnitReportFile = JunitReport
 
 	report, err := commands.PerformTesting(testConfig, &testValidationFactory{}, &commands.Arguments{})
-	Expect(err.Error()).To(Equal("there is failed tests 2"))
+	g.Expect(err.Error()).To(Equal("there is failed tests 2"))
 
-	Expect(report).NotTo(BeNil())
+	g.Expect(report).NotTo(BeNil())
 
-	Expect(len(report.Suites)).To(Equal(2))
-	Expect(report.Suites[0].Failures).To(Equal(1))
-	Expect(report.Suites[0].Tests).To(Equal(3))
-	Expect(len(report.Suites[0].TestCases)).To(Equal(3))
+	g.Expect(len(report.Suites)).To(Equal(2))
+	g.Expect(report.Suites[0].Failures).To(Equal(1))
+	g.Expect(report.Suites[0].Tests).To(Equal(3))
+	g.Expect(len(report.Suites[0].TestCases)).To(Equal(3))
 
 	// Do assertions
 }
 
 func TestMultiClusterTest(t *testing.T) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
 
 	testConfig := &config.CloudTestConfig{}
 
@@ -332,7 +332,7 @@ func TestMultiClusterTest(t *testing.T) {
 
 	tmpDir, err := ioutil.TempDir(os.TempDir(), "cloud-test-temp")
 	defer utils.ClearFolder(tmpDir, false)
-	Expect(err).To(BeNil())
+	g.Expect(err).To(BeNil())
 
 	testConfig.ConfigRoot = tmpDir
 	p1 := createProvider(testConfig, "a_provider")
@@ -374,16 +374,16 @@ func TestMultiClusterTest(t *testing.T) {
 	testConfig.Reporting.JUnitReportFile = JunitReport
 
 	report, err := commands.PerformTesting(testConfig, &testValidationFactory{}, &commands.Arguments{})
-	Expect(err.Error()).To(Equal("there is failed tests 3"))
+	g.Expect(err.Error()).To(Equal("there is failed tests 3"))
 
-	Expect(report).NotTo(BeNil())
+	g.Expect(report).NotTo(BeNil())
 
-	Expect(len(report.Suites)).To(Equal(4))
-	Expect(report.Suites[0].Failures).To(Equal(2))
-	Expect(report.Suites[0].Tests).To(Equal(6))
-	Expect(report.Suites[1].Tests).To(Equal(0))
-	Expect(report.Suites[2].Tests).To(Equal(3))
-	Expect(report.Suites[3].Tests).To(Equal(0))
+	g.Expect(len(report.Suites)).To(Equal(4))
+	g.Expect(report.Suites[0].Failures).To(Equal(2))
+	g.Expect(report.Suites[0].Tests).To(Equal(6))
+	g.Expect(report.Suites[1].Tests).To(Equal(0))
+	g.Expect(report.Suites[2].Tests).To(Equal(3))
+	g.Expect(report.Suites[3].Tests).To(Equal(0))
 
 	// Do assertions
 }

--- a/test/cloudtest/pkg/tests/shell_utils_test.go
+++ b/test/cloudtest/pkg/tests/shell_utils_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestVariableSubstitutions(t *testing.T) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
 
 	env := map[string]string{
 		"KUBECONFIG": "~/.kube/config",
@@ -25,45 +25,43 @@ func TestVariableSubstitutions(t *testing.T) {
 	}
 
 	var1, err := utils.SubstituteVariable("qwe ${KUBECONFIG} $(uuid) BBB", env, args)
-	Expect(err).To(BeNil())
-	Expect(var1).To(Equal("qwe ~/.kube/config uu-uu BBB"))
+	g.Expect(err).To(BeNil())
+	g.Expect(var1).To(Equal("qwe ~/.kube/config uu-uu BBB"))
 
 }
 
 func TestParseCommandLine1(t *testing.T) {
-	RegisterTestingT(t)
-
 	t.Run("simple", func(t *testing.T) {
-		RegisterTestingT(t)
-		Expect(utils.ParseCommandLine("a b c")).To(Equal([]string{"a", "b", "c"}))
+		g := NewWithT(t)
+		g.Expect(utils.ParseCommandLine("a b c")).To(Equal([]string{"a", "b", "c"}))
 	})
 
 	t.Run("spaces", func(t *testing.T) {
-		RegisterTestingT(t)
-		Expect(utils.ParseCommandLine("a\\ b c")).To(Equal([]string{"a b", "c"}))
+		g := NewWithT(t)
+		g.Expect(utils.ParseCommandLine("a\\ b c")).To(Equal([]string{"a b", "c"}))
 	})
 
 	t.Run("strings", func(t *testing.T) {
-		RegisterTestingT(t)
-		Expect(utils.ParseCommandLine("a \"b    \" c")).To(Equal([]string{"a", "b    ", "c"}))
+		g := NewWithT(t)
+		g.Expect(utils.ParseCommandLine("a \"b    \" c")).To(Equal([]string{"a", "b    ", "c"}))
 	})
 
 	t.Run("empty_arg", func(t *testing.T) {
-		RegisterTestingT(t)
-		Expect(utils.ParseCommandLine("a 	-N \"\"")).To(Equal([]string{"a", "-N", ""}))
+		g := NewWithT(t)
+		g.Expect(utils.ParseCommandLine("a 	-N \"\"")).To(Equal([]string{"a", "-N", ""}))
 	})
 }
 
 func TestParseCommandLine2(t *testing.T) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
 
 	cmdLine := utils.ParseCommandLine("go test ./test/integration -test.timeout 300s -count 1 --run \"^(TestNSMHealLocalDieNSMD)$\" --tags \"basic recover usecase\" --test.v")
-	Expect(len(cmdLine)).To(Equal(12))
+	g.Expect(len(cmdLine)).To(Equal(12))
 }
 func TestParseCommandLine3(t *testing.T) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
 
 	cmdLine := utils.ParseCommandLine("go test ./test/integration -test.timeout 300s -count 1 --run \"^(TestNSMHealLocalDieNSMD)$\\\\z\" --tags \"basic recover usecase\" --test.v")
-	Expect(len(cmdLine)).To(Equal(12))
-	Expect(cmdLine[8]).To(Equal("^(TestNSMHealLocalDieNSMD)$\\z"))
+	g.Expect(len(cmdLine)).To(Equal(12))
+	g.Expect(cmdLine[8]).To(Equal("^(TestNSMHealLocalDieNSMD)$\\z"))
 }

--- a/test/integration/basic_dataplane_image_version_test.go
+++ b/test/integration/basic_dataplane_image_version_test.go
@@ -5,28 +5,27 @@ package nsmd_integration_tests
 import (
 	"testing"
 
-	"github.com/onsi/gomega"
-
 	"github.com/networkservicemesh/networkservicemesh/test/kubetest"
+	. "github.com/onsi/gomega"
 )
 
 func TestDataplaneVersion(t *testing.T) {
-	gomega.RegisterTestingT(t)
+	g := NewWithT(t)
 
 	if testing.Short() {
 		t.Skip("Skip, please run without -short")
 		return
 	}
-	k8s, err := kubetest.NewK8s(true)
+	k8s, err := kubetest.NewK8s(g, true)
 	defer k8s.Cleanup()
 
-	gomega.Expect(err).To(gomega.BeNil())
+	g.Expect(err).To(BeNil())
 
 	nodes, err := kubetest.SetupNodes(k8s, 1, defaultTimeout)
-	gomega.Expect(err).To(gomega.BeNil())
+	g.Expect(err).To(BeNil())
 	defer kubetest.ShowLogs(k8s, t)
 
-	gomega.Expect(len(nodes) > 0).Should(gomega.BeTrue())
+	g.Expect(len(nodes) > 0).Should(BeTrue())
 	dataplane := nodes[0].Dataplane
 	k8s.PrintImageVersion(dataplane)
 

--- a/test/integration/basic_dataplane_image_version_test.go
+++ b/test/integration/basic_dataplane_image_version_test.go
@@ -5,8 +5,9 @@ package nsmd_integration_tests
 import (
 	"testing"
 
-	"github.com/networkservicemesh/networkservicemesh/test/kubetest"
 	. "github.com/onsi/gomega"
+
+	"github.com/networkservicemesh/networkservicemesh/test/kubetest"
 )
 
 func TestDataplaneVersion(t *testing.T) {

--- a/test/integration/basic_dataplane_standalone_test.go
+++ b/test/integration/basic_dataplane_standalone_test.go
@@ -78,6 +78,8 @@ func TestDataplaneCrossConnectUpdate(t *testing.T) {
 		return
 	}
 
+	wt = NewWithT(t)
+
 	fixture := createFixture(t, defaultTimeout)
 	defer fixture.cleanup()
 

--- a/test/integration/basic_dataplane_standalone_test.go
+++ b/test/integration/basic_dataplane_standalone_test.go
@@ -38,13 +38,15 @@ const (
 	dstIpMasked = dstIp + "/30"
 )
 
-func TestDataplaneCrossConnectBasic(t *testing.T) {
-	RegisterTestingT(t)
+var wt *WithT
 
+func TestDataplaneCrossConnectBasic(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skip, please run without -short")
 		return
 	}
+
+	wt = NewWithT(t)
 
 	fixture := createFixture(t, defaultTimeout)
 	defer fixture.cleanup()
@@ -54,12 +56,12 @@ func TestDataplaneCrossConnectBasic(t *testing.T) {
 }
 
 func TestDataplaneCrossConnectMultiple(t *testing.T) {
-	RegisterTestingT(t)
-
 	if testing.Short() {
 		t.Skip("Skip, please run without -short")
 		return
 	}
+
+	wt = NewWithT(t)
 
 	fixture := createFixture(t, defaultTimeout)
 	defer fixture.cleanup()
@@ -71,8 +73,6 @@ func TestDataplaneCrossConnectMultiple(t *testing.T) {
 }
 
 func TestDataplaneCrossConnectUpdate(t *testing.T) {
-	RegisterTestingT(t)
-
 	if testing.Short() {
 		t.Skip("Skip, please run without -short")
 		return
@@ -92,12 +92,12 @@ func TestDataplaneCrossConnectUpdate(t *testing.T) {
 }
 
 func TestDataplaneCrossConnectReconnect(t *testing.T) {
-	RegisterTestingT(t)
-
 	if testing.Short() {
 		t.Skip("Skip, please run without -short")
 		return
 	}
+
+	wt = NewWithT(t)
 
 	fixture := createFixture(t, defaultTimeout)
 	defer fixture.cleanup()
@@ -140,12 +140,12 @@ func createFixture(test *testing.T, timeout time.Duration) *standaloneDataplaneF
 		test:    test,
 	}
 
-	k8s, err := kubetest.NewK8s(true)
-	Expect(err).To(BeNil())
+	k8s, err := kubetest.NewK8s(wt, true)
+	wt.Expect(err).To(BeNil())
 
 	// prepare node
 	nodes := k8s.GetNodesWait(1, timeout)
-	Expect(len(nodes) >= 1).To(Equal(true), "At least one kubernetes node is required for this test")
+	wt.Expect(len(nodes) >= 1).To(Equal(true), "At least one kubernetes node is required for this test")
 
 	fixture.k8s = k8s
 	fixture.node = &nodes[0]
@@ -167,17 +167,17 @@ func createFixture(test *testing.T, timeout time.Duration) *standaloneDataplaneF
 
 func (fixture *standaloneDataplaneFixture) forwardDataplanePort(port int) {
 	fwd, err := fixture.k8s.NewPortForwarder(fixture.dataplanePod, port)
-	Expect(err).To(BeNil())
+	wt.Expect(err).To(BeNil())
 
 	err = fwd.Start()
-	Expect(err).To(BeNil())
+	wt.Expect(err).To(BeNil())
 	logrus.Infof("Forwarded port: pod=%s, remote=%d local=%d\n", fixture.dataplanePod.Name, port, fwd.ListenPort)
 	fixture.forwarding = fwd
 }
 
 func (fixture *standaloneDataplaneFixture) connectDataplane() {
 	dataplaneConn, err := tools.DialTimeout(localPort(dataplaneSocketType, fixture.forwarding.ListenPort), 5*time.Second)
-	Expect(err).To(BeNil())
+	wt.Expect(err).To(BeNil())
 	fixture.dataplaneClient = dataplaneapi.NewDataplaneClient(dataplaneConn)
 }
 
@@ -189,7 +189,7 @@ func (fixture *standaloneDataplaneFixture) requestCrossConnect(id, srcMech, dstM
 func (fixture *standaloneDataplaneFixture) request(req *crossconnect.CrossConnect) *crossconnect.CrossConnect {
 	ctx, _ := context.WithTimeout(context.Background(), fixture.timeout)
 	conn, err := fixture.dataplaneClient.Request(ctx, req)
-	Expect(err).To(BeNil())
+	wt.Expect(err).To(BeNil())
 	return conn
 }
 
@@ -221,7 +221,7 @@ func (fixture *standaloneDataplaneFixture) createConnection(id, mech, iface, src
 		},
 	}
 	err := mechanism.IsValid()
-	Expect(err).To(BeNil())
+	wt.Expect(err).To(BeNil())
 
 	return &connection.Connection{
 		Id:             id,
@@ -239,11 +239,11 @@ func (fixture *standaloneDataplaneFixture) createConnection(id, mech, iface, src
 func (fixture *standaloneDataplaneFixture) getNetNS(pod *v1.Pod) string {
 	container := pod.Spec.Containers[0].Name
 	link, _, err := fixture.k8s.Exec(pod, container, "readlink", "/proc/self/ns/net")
-	Expect(err).To(BeNil())
+	wt.Expect(err).To(BeNil())
 
 	pattern := regexp.MustCompile("net:\\[(.*)\\]")
 	matches := pattern.FindStringSubmatch(link)
-	Expect(len(matches) >= 1).To(BeTrue())
+	wt.Expect(len(matches) >= 1).To(BeTrue())
 
 	return matches[1]
 }
@@ -257,30 +257,26 @@ func (fixture *standaloneDataplaneFixture) requestDefaultKernelConnection() *cro
 }
 
 func (fixture *standaloneDataplaneFixture) verifyKernelConnection(xcon *crossconnect.CrossConnect) {
-	failures := InterceptGomegaFailures(func() {
-		srcIface := getIface(xcon.GetLocalSource())
-		dstIface := getIface(xcon.GetLocalDestination())
-		srcIp := unmaskIp(xcon.GetLocalSource().Context.IpContext.SrcIpAddr)
-		dstIp := unmaskIp(xcon.GetLocalDestination().Context.IpContext.DstIpAddr)
+	srcIface := getIface(xcon.GetLocalSource())
+	dstIface := getIface(xcon.GetLocalDestination())
+	srcIp := unmaskIp(xcon.GetLocalSource().Context.IpContext.SrcIpAddr)
+	dstIp := unmaskIp(xcon.GetLocalDestination().Context.IpContext.DstIpAddr)
 
-		out, _, err := fixture.k8s.Exec(fixture.sourcePod, fixture.sourcePod.Spec.Containers[0].Name, "ifconfig", srcIface)
-		Expect(err).To(BeNil())
-		Expect(strings.Contains(out, fmt.Sprintf("inet addr:%s", srcIp))).To(BeTrue())
+	out, _, err := fixture.k8s.Exec(fixture.sourcePod, fixture.sourcePod.Spec.Containers[0].Name, "ifconfig", srcIface)
+	wt.Expect(err).To(BeNil())
+	wt.Expect(strings.Contains(out, fmt.Sprintf("inet addr:%s", srcIp))).To(BeTrue())
 
-		logrus.Infof("Source interface:\n%s", out)
+	logrus.Infof("Source interface:\n%s", out)
 
-		out, _, err = fixture.k8s.Exec(fixture.destPod, fixture.destPod.Spec.Containers[0].Name, "ifconfig", dstIface)
-		Expect(err).To(BeNil())
-		Expect(strings.Contains(out, fmt.Sprintf("inet addr:%s", dstIp))).To(BeTrue())
+	out, _, err = fixture.k8s.Exec(fixture.destPod, fixture.destPod.Spec.Containers[0].Name, "ifconfig", dstIface)
+	wt.Expect(err).To(BeNil())
+	wt.Expect(strings.Contains(out, fmt.Sprintf("inet addr:%s", dstIp))).To(BeTrue())
 
-		logrus.Infof("Destination interface:\n%s", out)
+	logrus.Infof("Destination interface:\n%s", out)
 
-		out, _, err = fixture.k8s.Exec(fixture.sourcePod, fixture.sourcePod.Spec.Containers[0].Name, "ping", dstIp, "-c", "1")
-		Expect(err).To(BeNil())
-		Expect(strings.Contains(out, "0% packet loss")).To(BeTrue())
-	})
-
-	fixture.handleFailures(failures)
+	out, _, err = fixture.k8s.Exec(fixture.sourcePod, fixture.sourcePod.Spec.Containers[0].Name, "ping", dstIp, "-c", "1")
+	wt.Expect(err).To(BeNil())
+	wt.Expect(strings.Contains(out, "0% packet loss")).To(BeTrue())
 }
 
 func (fixture *standaloneDataplaneFixture) handleFailures(failures []string) {
@@ -302,30 +298,26 @@ func (fixture *standaloneDataplaneFixture) printLogs(pod *v1.Pod) {
 }
 
 func (fixture *standaloneDataplaneFixture) verifyKernelConnectionClosed(xcon *crossconnect.CrossConnect) {
-	failures := InterceptGomegaFailures(func() {
-		srcIface := getIface(xcon.GetLocalSource())
-		dstIface := getIface(xcon.GetLocalDestination())
+	srcIface := getIface(xcon.GetLocalSource())
+	dstIface := getIface(xcon.GetLocalDestination())
 
-		out, _, err := fixture.k8s.Exec(fixture.sourcePod, fixture.sourcePod.Spec.Containers[0].Name, "ip", "a")
-		Expect(err).To(BeNil())
-		Expect(strings.Contains(out, srcIface)).To(BeFalse())
+	out, _, err := fixture.k8s.Exec(fixture.sourcePod, fixture.sourcePod.Spec.Containers[0].Name, "ip", "a")
+	wt.Expect(err).To(BeNil())
+	wt.Expect(strings.Contains(out, srcIface)).To(BeFalse())
 
-		logrus.Infof("Source interfaces:\n%s", out)
+	logrus.Infof("Source interfaces:\n%s", out)
 
-		out, _, err = fixture.k8s.Exec(fixture.destPod, fixture.destPod.Spec.Containers[0].Name, "ip", "a")
-		Expect(err).To(BeNil())
-		Expect(strings.Contains(out, dstIface)).To(BeFalse())
+	out, _, err = fixture.k8s.Exec(fixture.destPod, fixture.destPod.Spec.Containers[0].Name, "ip", "a")
+	wt.Expect(err).To(BeNil())
+	wt.Expect(strings.Contains(out, dstIface)).To(BeFalse())
 
-		logrus.Infof("Destination interfaces:\n%s", out)
-	})
-
-	fixture.handleFailures(failures)
+	logrus.Infof("Destination interfaces:\n%s", out)
 }
 
 func (fixture *standaloneDataplaneFixture) closeConnection(conn *crossconnect.CrossConnect) {
 	ctx, _ := context.WithTimeout(context.Background(), fixture.timeout)
 	_, err := fixture.dataplaneClient.Close(ctx, conn)
-	Expect(err).To(BeNil())
+	wt.Expect(err).To(BeNil())
 }
 
 func unmaskIp(maskedIp string) string {

--- a/test/integration/basic_delete_dirty_nse_test.go
+++ b/test/integration/basic_delete_dirty_nse_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestDeleteDirtyNSE(t *testing.T) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
 
 	if testing.Short() {
 		t.Skip("Skip, please run without -short")
@@ -22,12 +22,12 @@ func TestDeleteDirtyNSE(t *testing.T) {
 
 	logrus.Print("Running delete dirty NSE test")
 
-	k8s, err := kubetest.NewK8s(true)
-	Expect(err).To(BeNil())
+	k8s, err := kubetest.NewK8s(g, true)
+	g.Expect(err).To(BeNil())
 	defer k8s.Cleanup()
 
 	nodesConf, err := kubetest.SetupNodesConfig(k8s, 1, defaultTimeout, []*pods.NSMgrPodConfig{}, k8s.GetK8sNamespace())
-	Expect(err).To(BeNil())
+	g.Expect(err).To(BeNil())
 	defer kubetest.ShowLogs(k8s, t)
 
 	nsePod := kubetest.DeployDirtyICMP(k8s, nodesConf[0].Node, "dirty-icmp-responder-nse", defaultTimeout)
@@ -40,7 +40,7 @@ func TestDeleteDirtyNSE(t *testing.T) {
 }
 
 func TestDeleteDirtyNSEWithClient(t *testing.T) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
 
 	if testing.Short() {
 		t.Skip("Skip, please run without -short")
@@ -49,12 +49,12 @@ func TestDeleteDirtyNSEWithClient(t *testing.T) {
 
 	logrus.Print("Running delete dirty NSE with client test")
 
-	k8s, err := kubetest.NewK8s(true)
-	Expect(err).To(BeNil())
+	k8s, err := kubetest.NewK8s(g, true)
+	g.Expect(err).To(BeNil())
 	defer k8s.Cleanup()
 
 	nodesConf, err := kubetest.SetupNodesConfig(k8s, 1, defaultTimeout, []*pods.NSMgrPodConfig{}, k8s.GetK8sNamespace())
-	Expect(err).To(BeNil())
+	g.Expect(err).To(BeNil())
 	defer kubetest.ShowLogs(k8s, t)
 
 	nsePod := kubetest.DeployDirtyICMP(k8s, nodesConf[0].Node, "dirty-icmp-responder-nse", defaultTimeout)

--- a/test/integration/basic_excluded_prefixes_test.go
+++ b/test/integration/basic_excluded_prefixes_test.go
@@ -13,16 +13,16 @@ import (
 )
 
 func TestExcludePrefixCheck(t *testing.T) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
 
 	if testing.Short() {
 		t.Skip("Skip, please run without -short")
 		return
 	}
 
-	k8s, err := kubetest.NewK8s(true)
+	k8s, err := kubetest.NewK8s(g, true)
 	defer k8s.Cleanup()
-	Expect(err).To(BeNil())
+	g.Expect(err).To(BeNil())
 
 	nodesCount := 1
 
@@ -45,14 +45,14 @@ func TestExcludePrefixCheck(t *testing.T) {
 			Namespace:          k8s.GetK8sNamespace(),
 		},
 	}, k8s.GetK8sNamespace())
-	Expect(err).To(BeNil())
+	g.Expect(err).To(BeNil())
 
 	defer kubetest.ShowLogs(k8s, t)
 
 	icmp := kubetest.DeployICMP(k8s, nodes[0].Node, "icmp-responder-nse-1", defaultTimeout)
 
 	clientset, err := k8s.GetClientSet()
-	Expect(err).To(BeNil())
+	g.Expect(err).To(BeNil())
 
 	nsc, err := clientset.CoreV1().Pods(k8s.GetK8sNamespace()).Create(pods.NSCPod("nsc", nodes[0].Node,
 		map[string]string{
@@ -63,7 +63,7 @@ func TestExcludePrefixCheck(t *testing.T) {
 
 	defer k8s.DeletePods(nsc)
 
-	Expect(err).To(BeNil())
+	g.Expect(err).To(BeNil())
 	k8s.WaitLogsContains(icmp, "", "IPAM: The available address pool is empty, probably intersected by excludedPrefix", defaultTimeout)
 
 }

--- a/test/integration/basic_exec_test.go
+++ b/test/integration/basic_exec_test.go
@@ -13,16 +13,16 @@ import (
 )
 
 func TestExec(t *testing.T) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
 
 	if testing.Short() {
 		t.Skip("Skip, please run without -short")
 		return
 	}
 
-	k8s, err := kubetest.NewK8sWithoutRoles(false)
+	k8s, err := kubetest.NewK8sWithoutRoles(g, false)
 	defer k8s.Cleanup()
-	Expect(err).To(BeNil())
+	g.Expect(err).To(BeNil())
 	defer kubetest.ShowLogs(k8s, t)
 
 	k8s.Prepare("alpine-pod")
@@ -30,8 +30,8 @@ func TestExec(t *testing.T) {
 	alpinePod := k8s.CreatePod(pods.AlpinePod("alpine-pod", nil))
 
 	ipResponse, errResponse, error := k8s.Exec(alpinePod, alpinePod.Spec.Containers[0].Name, "ip", "addr")
-	Expect(error).To(BeNil())
-	Expect(errResponse).To(Equal(""))
+	g.Expect(error).To(BeNil())
+	g.Expect(errResponse).To(Equal(""))
 	logrus.Printf("NSC IP status:%s", ipResponse)
 	logrus.Printf("End of test")
 	k8s.DeletePods(alpinePod)

--- a/test/integration/basic_k8s_version_test.go
+++ b/test/integration/basic_k8s_version_test.go
@@ -12,18 +12,18 @@ import (
 )
 
 func TestKubernetesAreOk(t *testing.T) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
 
 	if testing.Short() {
 		t.Skip("Skip, please run without -short")
 		return
 	}
 
-	k8s, err := kubetest.NewK8sWithoutRoles(false)
+	k8s, err := kubetest.NewK8sWithoutRoles(g, false)
 	defer k8s.Cleanup()
-	Expect(err).To(BeNil())
+	g.Expect(err).To(BeNil())
 	defer kubetest.ShowLogs(k8s, t)
 	v := k8s.GetVersion()
-	Expect(strings.Contains(v, "1.")).To(Equal(true))
+	g.Expect(strings.Contains(v, "1.")).To(Equal(true))
 
 }

--- a/test/integration/basic_memif_test.go
+++ b/test/integration/basic_memif_test.go
@@ -11,23 +11,23 @@ import (
 )
 
 func TestSimpleMemifConnection(t *testing.T) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
 
 	if testing.Short() {
 		t.Skip("Skip, please run without -short")
 		return
 	}
 
-	k8s, err := kubetest.NewK8s(true)
+	k8s, err := kubetest.NewK8s(g, true)
 	defer k8s.Cleanup()
 
-	Expect(err).To(BeNil())
+	g.Expect(err).To(BeNil())
 
 	nodes, err := kubetest.SetupNodes(k8s, 1, defaultTimeout)
-	Expect(err).To(BeNil())
+	g.Expect(err).To(BeNil())
 	defer kubetest.ShowLogs(k8s, t)
 
 	kubetest.DeployVppAgentICMP(k8s, nodes[0].Node, "icmp-responder", defaultTimeout)
 	vppagentNsc := kubetest.DeployVppAgentNSC(k8s, nodes[0].Node, "vppagent-nsc", defaultTimeout)
-	Expect(true, kubetest.IsVppAgentNsePinged(k8s, vppagentNsc))
+	g.Expect(true, kubetest.IsVppAgentNsePinged(k8s, vppagentNsc))
 }

--- a/test/integration/basic_monitor_crossconnect_metrics_test.go
+++ b/test/integration/basic_monitor_crossconnect_metrics_test.go
@@ -17,13 +17,13 @@ import (
 )
 
 func TestSimpleMetrics(t *testing.T) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
 	if testing.Short() {
 		t.Skip("Skip, please run without -short")
 		return
 	}
-	k8s, err := kubetest.NewK8s(true)
-	Expect(err).To(BeNil())
+	k8s, err := kubetest.NewK8s(g, true)
+	g.Expect(err).To(BeNil())
 
 	defer k8s.Cleanup()
 
@@ -40,7 +40,7 @@ func TestSimpleMetrics(t *testing.T) {
 		},
 	}, k8s.GetK8sNamespace())
 	k8s.WaitLogsContains(nodes[0].Dataplane, nodes[0].Dataplane.Spec.Containers[0].Name, "Metrics collector: creating notificaiton client", time.Minute)
-	Expect(err).To(BeNil())
+	g.Expect(err).To(BeNil())
 	kubetest.DeployICMP(k8s, nodes[nodesCount-1].Node, "icmp-responder-nse-1", defaultTimeout)
 	defer kubetest.ShowLogs(k8s, t)
 
@@ -52,14 +52,14 @@ func TestSimpleMetrics(t *testing.T) {
 
 	response, _, err := k8s.Exec(nsc, nsc.Spec.Containers[0].Name, "ping", "172.16.1.2", "-A", "-c", "4")
 	logrus.Infof("response = %v", response)
-	Expect(err).To(BeNil())
+	g.Expect(err).To(BeNil())
 	<-time.After(requestPeriod * 5)
 	k8s.DeletePods(nsc)
 	select {
 	case metrics := <-metricsCh:
-		Expect(isMetricsEmpty(metrics)).Should(Equal(false))
-		Expect(metrics["rx_error_packets"]).Should(Equal("0"))
-		Expect(metrics["tx_error_packets"]).Should(Equal("0"))
+		g.Expect(isMetricsEmpty(metrics)).Should(Equal(false))
+		g.Expect(metrics["rx_error_packets"]).Should(Equal("0"))
+		g.Expect(metrics["tx_error_packets"]).Should(Equal("0"))
 		return
 	case <-time.After(defaultTimeout):
 		t.Fatalf("Fail to get metrics during %v", defaultTimeout)

--- a/test/integration/basic_monitor_crossconnect_test.go
+++ b/test/integration/basic_monitor_crossconnect_test.go
@@ -13,21 +13,21 @@ import (
 )
 
 func TestSingleCrossConnect(t *testing.T) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
 
 	if testing.Short() {
 		t.Skip("Skip, please run without -short")
 		return
 	}
 
-	k8s, err := kubetest.NewK8s(true)
+	k8s, err := kubetest.NewK8s(g, true)
 	defer k8s.Cleanup()
-	Expect(err).To(BeNil())
+	g.Expect(err).To(BeNil())
 
 	nodesCount := 2
 
 	nodes, err := kubetest.SetupNodes(k8s, nodesCount, defaultTimeout)
-	Expect(err).To(BeNil())
+	g.Expect(err).To(BeNil())
 	defer kubetest.ShowLogs(k8s, t)
 	kubetest.DeployICMP(k8s, nodes[nodesCount-1].Node, "icmp-responder-nse-1", defaultTimeout)
 	kubetest.DeployNSC(k8s, nodes[0].Node, "nsc-1", defaultTimeout)
@@ -65,21 +65,21 @@ func TestSingleCrossConnect(t *testing.T) {
 }
 
 func TestSingleCrossConnectMonitorBeforeXcons(t *testing.T) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
 
 	if testing.Short() {
 		t.Skip("Skip, please run without -short")
 		return
 	}
 
-	k8s, err := kubetest.NewK8s(true)
+	k8s, err := kubetest.NewK8s(g, true)
 	defer k8s.Cleanup()
-	Expect(err).To(BeNil())
+	g.Expect(err).To(BeNil())
 
 	nodesCount := 2
 
 	nodes, err := kubetest.SetupNodes(k8s, nodesCount, defaultTimeout)
-	Expect(err).To(BeNil())
+	g.Expect(err).To(BeNil())
 	defer kubetest.ShowLogs(k8s, t)
 
 	// monitor client for node0
@@ -94,28 +94,28 @@ func TestSingleCrossConnectMonitorBeforeXcons(t *testing.T) {
 	kubetest.DeployNSC(k8s, nodes[0].Node, "nsc-1", defaultTimeout)
 
 	_, err = kubetest.CollectXcons(eventCh0, 1, fastTimeout)
-	Expect(err).To(BeNil())
+	g.Expect(err).To(BeNil())
 
 	_, err = kubetest.CollectXcons(eventCh1, 1, fastTimeout)
-	Expect(err).To(BeNil())
+	g.Expect(err).To(BeNil())
 }
 
 func TestSeveralCrossConnects(t *testing.T) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
 
 	if testing.Short() {
 		t.Skip("Skip, please run without -short")
 		return
 	}
 
-	k8s, err := kubetest.NewK8s(true)
+	k8s, err := kubetest.NewK8s(g, true)
 	defer k8s.Cleanup()
-	Expect(err).To(BeNil())
+	g.Expect(err).To(BeNil())
 
 	nodesCount := 2
 
 	nodes, err := kubetest.SetupNodes(k8s, nodesCount, defaultTimeout)
-	Expect(err).To(BeNil())
+	g.Expect(err).To(BeNil())
 	defer kubetest.ShowLogs(k8s, t)
 	kubetest.DeployICMP(k8s, nodes[nodesCount-1].Node, "icmp-responder-nse-1", defaultTimeout)
 	kubetest.DeployNSC(k8s, nodes[0].Node, "nsc-1", defaultTimeout)
@@ -130,28 +130,28 @@ func TestSeveralCrossConnects(t *testing.T) {
 	defer closeFunc1()
 
 	_, err = kubetest.CollectXcons(eventCh0, 2, fastTimeout)
-	Expect(err).To(BeNil())
+	g.Expect(err).To(BeNil())
 
 	_, err = kubetest.CollectXcons(eventCh1, 2, fastTimeout)
-	Expect(err).To(BeNil())
+	g.Expect(err).To(BeNil())
 }
 
 func TestCrossConnectMonitorRestart(t *testing.T) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
 
 	if testing.Short() {
 		t.Skip("Skip, please run without -short")
 		return
 	}
 
-	k8s, err := kubetest.NewK8s(true)
+	k8s, err := kubetest.NewK8s(g, true)
 	defer k8s.Cleanup()
-	Expect(err).To(BeNil())
+	g.Expect(err).To(BeNil())
 
 	nodesCount := 2
 
 	nodes, err := kubetest.SetupNodes(k8s, nodesCount, defaultTimeout)
-	Expect(err).To(BeNil())
+	g.Expect(err).To(BeNil())
 	kubetest.DeployICMP(k8s, nodes[nodesCount-1].Node, "icmp-responder-nse-1", defaultTimeout)
 	kubetest.DeployNSC(k8s, nodes[0].Node, "nsc-1", defaultTimeout)
 	kubetest.DeployNSC(k8s, nodes[0].Node, "nsc-2", defaultTimeout)
@@ -160,7 +160,7 @@ func TestCrossConnectMonitorRestart(t *testing.T) {
 	eventCh0, closeFunc0 := kubetest.XconProxyMonitor(k8s, nodes[0], "0")
 
 	_, err = kubetest.CollectXcons(eventCh0, 2, fastTimeout)
-	Expect(err).To(BeNil())
+	g.Expect(err).To(BeNil())
 	closeFunc0()
 
 	logrus.Info("Restarting monitor")
@@ -169,5 +169,5 @@ func TestCrossConnectMonitorRestart(t *testing.T) {
 	defer closeFunc1()
 
 	_, err = kubetest.CollectXcons(eventCh1, 2, fastTimeout)
-	Expect(err).To(BeNil())
+	g.Expect(err).To(BeNil())
 }

--- a/test/integration/basic_namespace_test.go
+++ b/test/integration/basic_namespace_test.go
@@ -12,16 +12,16 @@ import (
 )
 
 func Test_createNSMNamespace(t *testing.T) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
 
-	k8s, err := kubetest.NewK8s(true)
+	k8s, err := kubetest.NewK8s(g, true)
 	defer k8s.Cleanup()
 	defer kubetest.ShowLogs(k8s, t)
 
 	namespaceName := k8s.GetK8sNamespace()
 	namespace, err := k8s.GetNamespace(namespaceName)
 
-	Expect(err).To(BeNil())
-	Expect(namespace.Status.Phase).To(Equal(v1.NamespaceActive))
+	g.Expect(err).To(BeNil())
+	g.Expect(namespace.Status.Phase).To(Equal(v1.NamespaceActive))
 
 }

--- a/test/integration/basic_nsc_deploy_test.go
+++ b/test/integration/basic_nsc_deploy_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestDeployPodIntoInvalidEnv(t *testing.T) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
 
 	if testing.Short() {
 		t.Skip("Skip, please run without -short")
@@ -22,21 +22,21 @@ func TestDeployPodIntoInvalidEnv(t *testing.T) {
 
 	logrus.Print("Running NSMD Deploy test")
 
-	k8s, err := kubetest.NewK8s(true)
+	k8s, err := kubetest.NewK8s(g, true)
 	defer k8s.Cleanup()
-	Expect(err).To(BeNil())
+	g.Expect(err).To(BeNil())
 	defer kubetest.ShowLogs(k8s, t)
 
 	nodes := k8s.GetNodesWait(1, defaultTimeout)
 
 	if len(nodes) < 1 {
 		logrus.Printf("At least two Kubernetes nodes are required for this test")
-		Expect(len(nodes)).To(Equal(1))
+		g.Expect(len(nodes)).To(Equal(1))
 		return
 	}
 
 	nsmdPodNode1, err := k8s.CreatePodsRaw(fastTimeout, false, pods.NSCPod("nsc-1", &nodes[0], map[string]string{}))
-	Expect(len(nsmdPodNode1)).To(Equal(1))
+	g.Expect(len(nsmdPodNode1)).To(Equal(1))
 
 	k8s.DeletePods(nsmdPodNode1...)
 

--- a/test/integration/basic_nsm_monitor_deploy_test.go
+++ b/test/integration/basic_nsm_monitor_deploy_test.go
@@ -6,40 +6,26 @@ import (
 	"testing"
 
 	. "github.com/onsi/gomega"
-	"github.com/sirupsen/logrus"
-
 	"github.com/networkservicemesh/networkservicemesh/test/kubetest"
 )
 
 func TestDeployNSMMonitor(t *testing.T) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
 
-	k8s, err := kubetest.NewK8s(true)
+	k8s, err := kubetest.NewK8s(g, true)
 	defer k8s.Cleanup()
 	defer kubetest.ShowLogs(k8s, t)
-	Expect(err).To(BeNil())
+	g.Expect(err).To(BeNil())
 
 	nodes_setup, err := kubetest.SetupNodes(k8s, 2, defaultTimeout)
-	Expect(err).To(BeNil())
+	g.Expect(err).To(BeNil())
 
 	// Run ICMP on latest node
 	_ = kubetest.DeployICMP(k8s, nodes_setup[1].Node, "icmp-responder-nse-1", defaultTimeout)
 
 	nscPodNode := kubetest.DeployNSCMonitor(k8s, nodes_setup[0].Node, "nsc-1", defaultTimeout)
-	var nscInfo *kubetest.NSCCheckInfo
-
-	failures := InterceptGomegaFailures(func() {
-		nscInfo = kubetest.CheckNSC(k8s, nscPodNode)
-	})
+	kubetest.CheckNSC(k8s, nscPodNode)
 
 	k8s.WaitLogsContains(nscPodNode, "nsm-monitor", "", defaultTimeout)
 	// Do dumping of container state to dig into what is happened.
-	if len(failures) > 0 {
-		logrus.Errorf("Failures: %v", failures)
-
-		nscInfo.PrintLogs()
-
-		t.Fail()
-	}
-
 }

--- a/test/integration/basic_nsm_monitor_deploy_test.go
+++ b/test/integration/basic_nsm_monitor_deploy_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	. "github.com/onsi/gomega"
+
 	"github.com/networkservicemesh/networkservicemesh/test/kubetest"
 )
 

--- a/test/integration/basic_nsm_restart_restore_nse_test.go
+++ b/test/integration/basic_nsm_restart_restore_nse_test.go
@@ -14,42 +14,42 @@ import (
 )
 
 func TestNSMgrRestartRestoreNSE(t *testing.T) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
 
 	if testing.Short() {
 		t.Skip("Skip, please run without -short")
 		return
 	}
 
-	k8s, err := kubetest.NewK8s(true)
-	Expect(err).To(BeNil())
+	k8s, err := kubetest.NewK8s(g, true)
+	g.Expect(err).To(BeNil())
 	defer k8s.Cleanup()
 	defer kubetest.ShowLogs(k8s, t)
 
 	nodesConf, err := kubetest.SetupNodes(k8s, 1, defaultTimeout)
-	Expect(err).To(BeNil())
+	g.Expect(err).To(BeNil())
 
 	nsMgrName := nodesConf[0].Nsmd.GetName()
 
-	nse1, name1, err := deployNSEPod(k8s, nodesConf[0].Node, "icmp-responder-nse-1")
-	Expect(err).To(BeNil())
+	nse1, name1, err := deployNSEPod(g, k8s, nodesConf[0].Node, "icmp-responder-nse-1")
+	g.Expect(err).To(BeNil())
 	logrus.Infof("NSE created: %v", name1)
 
-	_, name2, err := deployNSEPod(k8s, nodesConf[0].Node, "icmp-responder-nse-2")
-	Expect(err).To(BeNil())
+	_, name2, err := deployNSEPod(g, k8s, nodesConf[0].Node, "icmp-responder-nse-2")
+	g.Expect(err).To(BeNil())
 	logrus.Infof("NSE created: %v", name2)
 
-	_, name3, err := deployNSEPod(k8s, nodesConf[0].Node, "icmp-responder-nse-3")
-	Expect(err).To(BeNil())
+	_, name3, err := deployNSEPod(g, k8s, nodesConf[0].Node, "icmp-responder-nse-3")
+	g.Expect(err).To(BeNil())
 	logrus.Infof("NSE created: %v", name3)
 
 	k8s.DeletePods(nodesConf[0].Nsmd)
 
 	err = k8s.DeleteNetworkServices("icmp-responder")
-	Expect(err).To(BeNil())
+	g.Expect(err).To(BeNil())
 
 	err = k8s.DeleteNSEs(name1, name2)
-	Expect(err).To(BeNil())
+	g.Expect(err).To(BeNil())
 	logrus.Infof("NSEs deleted: %v, %v", name1, name2)
 
 	k8s.DeletePods(nse1)
@@ -60,26 +60,23 @@ func TestNSMgrRestartRestoreNSE(t *testing.T) {
 		},
 		Namespace: k8s.GetK8sNamespace(),
 	}))
-	Expect(nsMgrPod).NotTo(BeNil())
+	g.Expect(nsMgrPod).NotTo(BeNil())
 
-	failures := InterceptGomegaFailures(func() {
-		_ = k8s.WaitLogsContainsRegex(nsMgrPod, "nsmd", "NSM gRPC API Server: .* is operational", defaultTimeout)
+	_ = k8s.WaitLogsContainsRegex(nsMgrPod, "nsmd", "NSM gRPC API Server: .* is operational", defaultTimeout)
 
-		networkServices, err := k8s.GetNetworkServices()
-		Expect(err).To(BeNil())
-		Expect(networkServices).To(HaveLen(1))
-		Expect(networkServices[0].GetName()).To(Equal("icmp-responder"))
+	networkServices, err := k8s.GetNetworkServices()
+	g.Expect(err).To(BeNil())
+	g.Expect(networkServices).To(HaveLen(1))
+	g.Expect(networkServices[0].GetName()).To(Equal("icmp-responder"))
 
-		nses, err := k8s.GetNSEs()
-		Expect(err).To(BeNil())
-		Expect(nses).To(HaveLen(2))
-		Expect(nses[0].GetName()).To(Or(Equal(name2), Equal(name3)))
-		Expect(nses[1].GetName()).To(Or(Equal(name2), Equal(name3)))
-	})
-	kubetest.PrintErrors(failures, k8s, nodesConf, nil, t)
+	nses, err := k8s.GetNSEs()
+	g.Expect(err).To(BeNil())
+	g.Expect(nses).To(HaveLen(2))
+	g.Expect(nses[0].GetName()).To(Or(Equal(name2), Equal(name3)))
+	g.Expect(nses[1].GetName()).To(Or(Equal(name2), Equal(name3)))
 }
 
-func deployNSEPod(k8s *kubetest.K8s, node *v1.Node, name string) (*v1.Pod, string, error) {
+func deployNSEPod(g *WithT, k8s *kubetest.K8s, node *v1.Node, name string) (*v1.Pod, string, error) {
 	nsesBefore, err := k8s.GetNSEs()
 	if err != nil {
 		return nil, "", err
@@ -91,7 +88,7 @@ func deployNSEPod(k8s *kubetest.K8s, node *v1.Node, name string) (*v1.Pod, strin
 	}
 
 	pod := kubetest.DeployICMP(k8s, node, name, defaultTimeout)
-	Expect(pod.GetName()).To(Equal(name))
+	g.Expect(pod.GetName()).To(Equal(name))
 
 	kubetest.ExpectNSEsCountToBe(k8s, len(nsesBefore), len(nsesBefore)+1)
 

--- a/test/integration/basic_nsmd_deploy_test.go
+++ b/test/integration/basic_nsmd_deploy_test.go
@@ -25,7 +25,7 @@ func TestNSMgrDataplaneDeployLiveCheck(t *testing.T) {
 }
 
 func testNSMgrDataplaneDeploy(t *testing.T, nsmdPodFactory func(string, *v1.Node, string) *v1.Pod, dataplanePodFactory func(string, *v1.Node, string) *v1.Pod) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
 
 	if testing.Short() {
 		t.Skip("Skip, please run without -short")
@@ -34,10 +34,10 @@ func testNSMgrDataplaneDeploy(t *testing.T, nsmdPodFactory func(string, *v1.Node
 
 	logrus.Print("Running NSMgr Deploy test")
 
-	k8s, err := kubetest.NewK8s(true)
+	k8s, err := kubetest.NewK8s(g, true)
 	defer k8s.Cleanup()
 
-	Expect(err).To(BeNil())
+	g.Expect(err).To(BeNil())
 	defer kubetest.ShowLogs(k8s, t)
 
 	nodes := k8s.GetNodesWait(1, defaultTimeout)
@@ -47,7 +47,7 @@ func testNSMgrDataplaneDeploy(t *testing.T, nsmdPodFactory func(string, *v1.Node
 	corePod := nsmdPodFactory(nsmdName, &nodes[0], k8s.GetK8sNamespace())
 	dataplanePod := dataplanePodFactory(dataplaneName, &nodes[0], k8s.GetForwardingPlane())
 	corePods, err := k8s.CreatePodsRaw(defaultTimeout, true, corePod, dataplanePod)
-	Expect(err).To(BeNil())
+	g.Expect(err).To(BeNil())
 
 	k8s.WaitLogsContains(corePods[1], "", "Sending MonitorMechanisms update", defaultTimeout)
 	_ = k8s.WaitLogsContainsRegex(corePods[0], "nsmd", "NSM gRPC API Server: .* is operational", defaultTimeout)
@@ -62,5 +62,5 @@ func testNSMgrDataplaneDeploy(t *testing.T, nsmdPodFactory func(string, *v1.Node
 			count += 1
 		}
 	}
-	Expect(count).To(Equal(int(0)))
+	g.Expect(count).To(Equal(int(0)))
 }

--- a/test/integration/basic_nsmd_deploy_time_test.go
+++ b/test/integration/basic_nsmd_deploy_time_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestNSMDDeploy(t *testing.T) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
 
 	if testing.Short() {
 		t.Skip("Skip, please run without -short")
@@ -22,19 +22,19 @@ func TestNSMDDeploy(t *testing.T) {
 
 	logrus.Print("Running NSMgr Deploy test")
 
-	k8s, err := kubetest.NewK8s(true)
+	k8s, err := kubetest.NewK8s(g, true)
 	defer k8s.Cleanup()
 	defer kubetest.ShowLogs(k8s, t)
-	Expect(err).To(BeNil())
+	g.Expect(err).To(BeNil())
 
 	st := time.Now()
 	_, err = kubetest.SetupNodes(k8s, 1, defaultTimeout)
-	Expect(err).To(BeNil())
+	g.Expect(err).To(BeNil())
 	deploy := time.Now()
 	k8s.Cleanup()
 	destroy := time.Now()
 	logrus.Infof("Pods Start time: %v", deploy.Sub(st))
-	Expect(deploy.Sub(st) < time.Second*15).To(Equal(true))
+	g.Expect(deploy.Sub(st) < time.Second*15).To(Equal(true))
 	logrus.Infof("Pods Cleanup time: %v", destroy.Sub(deploy))
-	Expect(destroy.Sub(deploy) < time.Second*25).To(Equal(true))
+	g.Expect(destroy.Sub(deploy) < time.Second*25).To(Equal(true))
 }

--- a/test/integration/basic_nsmd_k8s_test.go
+++ b/test/integration/basic_nsmd_k8s_test.go
@@ -22,24 +22,24 @@ import (
 )
 
 func TestNSMDDRegistryNSE(t *testing.T) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
 
 	if testing.Short() {
 		t.Skip("Skip, please run without -short")
 		return
 	}
 
-	k8s, err := kubetest.NewK8s(true)
+	k8s, err := kubetest.NewK8s(g, true)
 	defer k8s.Cleanup()
 	defer kubetest.ShowLogs(k8s, t)
-	Expect(err).To(BeNil())
+	g.Expect(err).To(BeNil())
 
 	nsmd := k8s.CreatePod(pods.NSMgrPod("nsmgr-1", nil, k8s.GetK8sNamespace()))
 
 	k8s.WaitLogsContains(nsmd, "nsmd", "NSMD: Restore of NSE/Clients Complete...", defaultTimeout)
 
 	fwd, err := k8s.NewPortForwarder(nsmd, 5000)
-	Expect(err).To(BeNil())
+	g.Expect(err).To(BeNil())
 	defer fwd.Stop()
 
 	// We need to wait unti it is started
@@ -56,20 +56,20 @@ func TestNSMDDRegistryNSE(t *testing.T) {
 	serviceRegistry := nsmd2.NewServiceRegistryAt(fmt.Sprintf("localhost:%d", fwd.ListenPort))
 
 	discovery, err := serviceRegistry.DiscoveryClient()
-	Expect(err).To(BeNil())
+	g.Expect(err).To(BeNil())
 	req := &registry.FindNetworkServiceRequest{
 		NetworkServiceName: "my_service",
 	}
 	response, err := discovery.FindNetworkService(context.Background(), req)
-	Expect(response).To(BeNil())
+	g.Expect(response).To(BeNil())
 	logrus.Print(err.Error())
 
-	Expect(err.Error()).To(Equal("rpc error: code = Unknown desc = no NetworkService with name: my_service"))
+	g.Expect(err.Error()).To(Equal("rpc error: code = Unknown desc = no NetworkService with name: my_service"))
 
 	// Lets register few hundred NSEs and check how it works.
 
 	registryClient, err := serviceRegistry.NseRegistryClient()
-	Expect(err).To(BeNil())
+	g.Expect(err).To(BeNil())
 
 	nses := []string{}
 	nme := "my-network-service"
@@ -87,14 +87,14 @@ func TestNSMDDRegistryNSE(t *testing.T) {
 		},
 	}
 	resp, err := registryClient.RegisterNSE(context.Background(), reg)
-	Expect(err).To(BeNil())
+	g.Expect(err).To(BeNil())
 	logrus.Printf("Register time: time: %v %v", time.Since(t1), resp)
 
 	t2 := time.Now()
 	response, err = discovery.FindNetworkService(context.Background(), &registry.FindNetworkServiceRequest{
 		NetworkServiceName: nme,
 	})
-	Expect(err).To(BeNil())
+	g.Expect(err).To(BeNil())
 	logrus.Printf("Find time: time: %v %d", time.Since(t2), len(response.NetworkServiceEndpoints))
 
 	for _, lnse := range response.NetworkServiceEndpoints {
@@ -115,11 +115,11 @@ func TestNSMDDRegistryNSE(t *testing.T) {
 			NetworkServiceName: nme,
 		})
 		logrus.Printf("Find time: time: %v %d", time.Since(t2), len(response.NetworkServiceEndpoints))
-		Expect(err).To(BeNil())
+		g.Expect(err).To(BeNil())
 		if err != nil {
 			logrus.Printf("Bad")
 		}
-		Expect(err2).To(BeNil())
+		g.Expect(err2).To(BeNil())
 	}
 
 	logs, err = k8s.GetLogs(nsmd, "nsmd-k8s")
@@ -128,21 +128,21 @@ func TestNSMDDRegistryNSE(t *testing.T) {
 }
 
 func TestUpdateNSM(t *testing.T) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
 
 	if testing.Short() {
 		t.Skip("Skip, please run without -short")
 		return
 	}
 
-	k8s, err := kubetest.NewK8s(true)
+	k8s, err := kubetest.NewK8s(g, true)
 	defer k8s.Cleanup()
-	Expect(err).To(BeNil())
+	g.Expect(err).To(BeNil())
 
 	nsmd := k8s.CreatePod(pods.NSMgrPod("nsmgr-1", nil, k8s.GetK8sNamespace()))
 
 	fwd, err := k8s.NewPortForwarder(nsmd, 5000)
-	Expect(err).To(BeNil())
+	g.Expect(err).To(BeNil())
 	defer fwd.Stop()
 
 	// We need to wait until it is started
@@ -158,78 +158,62 @@ func TestUpdateNSM(t *testing.T) {
 	serviceRegistry := nsmd2.NewServiceRegistryAt(fmt.Sprintf("localhost:%d", fwd.ListenPort))
 
 	discovery, err := serviceRegistry.DiscoveryClient()
-	Expect(err).To(BeNil())
+	g.Expect(err).To(BeNil())
 
 	nseRegistryClient, err := serviceRegistry.NseRegistryClient()
-	Expect(err).To(BeNil())
+	g.Expect(err).To(BeNil())
 
 	nsmRegistryClient, err := serviceRegistry.NsmRegistryClient()
-	Expect(err).To(BeNil())
+	g.Expect(err).To(BeNil())
 
 	networkService := "icmp-responder"
 	nsmName := "master"
 	url1 := "1.1.1.1:1"
 	url2 := "2.2.2.2:2"
-	failures := InterceptGomegaFailures(func() {
-		response, err := nsmRegistryClient.RegisterNSM(context.Background(), &registry.NetworkServiceManager{
-			Name: nsmName,
-			Url:  url1,
-		})
-		logrus.Info(response)
-		Expect(err).To(BeNil())
 
-		nseResp, err := nseRegistryClient.RegisterNSE(context.Background(), &registry.NSERegistration{
-			NetworkService: &registry.NetworkService{
-				Name:    networkService,
-				Payload: "tcp",
-			},
-			NetworkserviceEndpoint: &registry.NetworkServiceEndpoint{
-				NetworkServiceName: networkService,
-			},
-		})
-		Expect(err).To(BeNil())
-		logrus.Info(nseResp)
-		Expect(getNsmUrl(discovery)).To(Equal(url1))
-
-		updNsm, err := nsmRegistryClient.RegisterNSM(context.Background(), &registry.NetworkServiceManager{
-			Name: nsmName,
-			Url:  url2,
-		})
-		Expect(err).To(BeNil())
-		Expect(updNsm.GetUrl()).To(Equal(url2))
-		Expect(getNsmUrl(discovery)).To(Equal(url2))
+	response, err := nsmRegistryClient.RegisterNSM(context.Background(), &registry.NetworkServiceManager{
+		Name: nsmName,
+		Url:  url1,
 	})
+	logrus.Info(response)
+	g.Expect(err).To(BeNil())
 
-	if len(failures) > 0 {
-		logrus.Errorf("Failures: %v", failures)
+	nseResp, err := nseRegistryClient.RegisterNSE(context.Background(), &registry.NSERegistration{
+		NetworkService: &registry.NetworkService{
+			Name:    networkService,
+			Payload: "tcp",
+		},
+		NetworkserviceEndpoint: &registry.NetworkServiceEndpoint{
+			NetworkServiceName: networkService,
+		},
+	})
+	g.Expect(err).To(BeNil())
+	logrus.Info(nseResp)
+	g.Expect(getNsmUrl(g, discovery)).To(Equal(url1))
 
-		nsmdLogs, _ := k8s.GetLogs(nsmd, "nsmd")
-		logrus.Errorf("===================== NSMD output since test is failing %v\n=====================", nsmdLogs)
-
-		nsmdk8sLogs, _ := k8s.GetLogs(nsmd, "nsmd-k8s")
-		logrus.Errorf("===================== NSMD K8S output since test is failing %v\n=====================", nsmdk8sLogs)
-
-		nsmdpLogs, _ := k8s.GetLogs(nsmd, "nsmdp")
-		logrus.Errorf("===================== NSMDP output since test is failing %v\n=====================", nsmdpLogs)
-
-		t.Fail()
-	}
+	updNsm, err := nsmRegistryClient.RegisterNSM(context.Background(), &registry.NetworkServiceManager{
+		Name: nsmName,
+		Url:  url2,
+	})
+	g.Expect(err).To(BeNil())
+	g.Expect(updNsm.GetUrl()).To(Equal(url2))
+	g.Expect(getNsmUrl(g, discovery)).To(Equal(url2))
 }
 
 func TestGetEndpoints(t *testing.T) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
 
 	if testing.Short() {
 		t.Skip("Skip, please run without -short")
 		return
 	}
 
-	k8s, err := kubetest.NewK8s(true)
+	k8s, err := kubetest.NewK8s(g, true)
 	defer k8s.Cleanup()
-	Expect(err).To(BeNil())
+	g.Expect(err).To(BeNil())
 
 	nsmd, err := kubetest.SetupNodes(k8s, 1, defaultTimeout)
-	Expect(err).To(BeNil())
+	g.Expect(err).To(BeNil())
 
 	k8s.WaitLogsContains(nsmd[0].Nsmd, "nsmd", "NSMD: Restore of NSE/Clients Complete...", defaultTimeout)
 
@@ -241,8 +225,8 @@ func TestGetEndpoints(t *testing.T) {
 	responseNsm, err := nsmRegistryClient.RegisterNSM(context.Background(), &registry.NetworkServiceManager{
 		Url: url,
 	})
-	Expect(err).To(BeNil())
-	Expect(responseNsm.Url).To(Equal(url))
+	g.Expect(err).To(BeNil())
+	g.Expect(responseNsm.Url).To(Equal(url))
 	letters := []string{"a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k"}
 
 	for i := 0; i < len(letters); i++ {
@@ -256,12 +240,12 @@ func TestGetEndpoints(t *testing.T) {
 				NetworkServiceName: nsName,
 			},
 		})
-		Expect(err).To(BeNil())
+		g.Expect(err).To(BeNil())
 	}
 
 	nseList, err := nsmRegistryClient.GetEndpoints(context.Background(), &empty.Empty{})
-	Expect(err).To(BeNil())
-	Expect(len(nseList.NetworkServiceEndpoints)).To(Equal(len(letters)))
+	g.Expect(err).To(BeNil())
+	g.Expect(len(nseList.NetworkServiceEndpoints)).To(Equal(len(letters)))
 
 	_, err = nseRegistryClient.RegisterNSE(context.Background(), &registry.NSERegistration{
 		NetworkService: &registry.NetworkService{
@@ -272,24 +256,24 @@ func TestGetEndpoints(t *testing.T) {
 			EndpointName: nseList.NetworkServiceEndpoints[0].EndpointName,
 		},
 	})
-	Expect(err).NotTo(BeNil())
-	Expect(err.Error()).To(ContainSubstring("already exists"))
+	g.Expect(err).NotTo(BeNil())
+	g.Expect(err.Error()).To(ContainSubstring("already exists"))
 }
 
 func TestDuplicateEndpoint(t *testing.T) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
 
 	if testing.Short() {
 		t.Skip("Skip, please run without -short")
 		return
 	}
 
-	k8s, err := kubetest.NewK8s(true)
+	k8s, err := kubetest.NewK8s(g, true)
 	defer k8s.Cleanup()
-	Expect(err).To(BeNil())
+	g.Expect(err).To(BeNil())
 
 	nsmd, err := kubetest.SetupNodes(k8s, 1, defaultTimeout)
-	Expect(err).To(BeNil())
+	g.Expect(err).To(BeNil())
 
 	// We need to wait unti it is started
 	k8s.WaitLogsContains(nsmd[0].Nsmd, "nsmd-k8s", "nsmd-k8s initialized and waiting for connection", defaultTimeout)
@@ -304,8 +288,8 @@ func TestDuplicateEndpoint(t *testing.T) {
 	responseNsm, err := nsmRegistryClient.RegisterNSM(context.Background(), &registry.NetworkServiceManager{
 		Url: url,
 	})
-	Expect(err).To(BeNil())
-	Expect(responseNsm.Url).To(Equal(url))
+	g.Expect(err).To(BeNil())
+	g.Expect(responseNsm.Url).To(Equal(url))
 
 	nsName := "icmp-responder"
 	_, err = nseRegistryClient.RegisterNSE(context.Background(), &registry.NSERegistration{
@@ -317,11 +301,11 @@ func TestDuplicateEndpoint(t *testing.T) {
 			EndpointName: nsName,
 		},
 	})
-	Expect(err).To(BeNil())
+	g.Expect(err).To(BeNil())
 
 	nseList, err := nsmRegistryClient.GetEndpoints(context.Background(), &empty.Empty{})
-	Expect(err).To(BeNil())
-	Expect(len(nseList.NetworkServiceEndpoints)).To(Equal(1))
+	g.Expect(err).To(BeNil())
+	g.Expect(len(nseList.NetworkServiceEndpoints)).To(Equal(1))
 
 	_, err = nseRegistryClient.RegisterNSE(context.Background(), &registry.NSERegistration{
 		NetworkService: &registry.NetworkService{
@@ -332,17 +316,17 @@ func TestDuplicateEndpoint(t *testing.T) {
 			EndpointName: nsName,
 		},
 	})
-	Expect(err).NotTo(BeNil())
-	Expect(err.Error()).To(ContainSubstring("already exists"))
+	g.Expect(err).NotTo(BeNil())
+	g.Expect(err.Error()).To(ContainSubstring("already exists"))
 }
 
-func getNsmUrl(discovery registry.NetworkServiceDiscoveryClient) string {
+func getNsmUrl(g *WithT, discovery registry.NetworkServiceDiscoveryClient) string {
 	logrus.Infof("Finding NSE...")
 	response, err := discovery.FindNetworkService(context.Background(), &registry.FindNetworkServiceRequest{
 		NetworkServiceName: "icmp-responder",
 	})
-	Expect(err).To(BeNil())
-	Expect(len(response.GetNetworkServiceEndpoints()) >= 1).To(Equal(true))
+	g.Expect(err).To(BeNil())
+	g.Expect(len(response.GetNetworkServiceEndpoints()) >= 1).To(Equal(true))
 
 	endpoint := response.GetNetworkServiceEndpoints()[0]
 	logrus.Infof("Endpoint: %v", endpoint)
@@ -350,19 +334,19 @@ func getNsmUrl(discovery registry.NetworkServiceDiscoveryClient) string {
 }
 
 func TestClusterInfo(t *testing.T) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
 
 	if testing.Short() {
 		t.Skip("Skip, please run without -short")
 		return
 	}
 
-	k8s, err := kubetest.NewK8s(true)
+	k8s, err := kubetest.NewK8s(g, true)
 	defer k8s.Cleanup()
-	Expect(err).To(BeNil())
+	g.Expect(err).To(BeNil())
 
 	clientset, err := k8s.GetClientSet()
-	Expect(err).To(BeNil())
+	g.Expect(err).To(BeNil())
 	cm, err := clientset.CoreV1().ConfigMaps("kube-system").Get("kubeadm-config", metav1.GetOptions{})
 
 	if cm == nil || err != nil {
@@ -372,12 +356,12 @@ func TestClusterInfo(t *testing.T) {
 
 	k8s.Prepare("nsmgr")
 	nsmd, err := kubetest.SetupNodes(k8s, 1, defaultTimeout)
-	Expect(err).To(BeNil())
+	g.Expect(err).To(BeNil())
 
 	k8s.WaitLogsContains(nsmd[0].Nsmd, "nsmd", "NSMD: Restore of NSE/Clients Complete...", defaultTimeout)
 
 	fwd, err := k8s.NewPortForwarder(nsmd[0].Nsmd, 5000)
-	Expect(err).To(BeNil())
+	g.Expect(err).To(BeNil())
 	defer fwd.Stop()
 
 	e := fwd.Start()
@@ -387,18 +371,18 @@ func TestClusterInfo(t *testing.T) {
 
 	serviceRegistry := nsmd2.NewServiceRegistryAt(fmt.Sprintf("localhost:%d", fwd.ListenPort))
 	clusterInfo, err := serviceRegistry.ClusterInfoClient()
-	Expect(err).To(BeNil())
+	g.Expect(err).To(BeNil())
 
 	config, err := clusterInfo.GetClusterConfiguration(context.Background(), &empty.Empty{})
-	Expect(err).To(BeNil())
-	Expect(config.PodSubnet).ToNot(BeNil())
-	Expect(config.ServiceSubnet).ToNot(BeNil())
+	g.Expect(err).To(BeNil())
+	g.Expect(config.PodSubnet).ToNot(BeNil())
+	g.Expect(config.ServiceSubnet).ToNot(BeNil())
 
 	_, _, err = net.ParseCIDR(config.PodSubnet)
-	Expect(err).To(BeNil())
+	g.Expect(err).To(BeNil())
 
 	_, _, err = net.ParseCIDR(config.ServiceSubnet)
-	Expect(err).To(BeNil())
+	g.Expect(err).To(BeNil())
 }
 
 func createSingleNsmgr(k8s *kubetest.K8s, name string) *v1.Pod {
@@ -413,29 +397,29 @@ func createSingleNsmgr(k8s *kubetest.K8s, name string) *v1.Pod {
 }
 
 func TestLostUpdate(t *testing.T) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
 
 	if testing.Short() {
 		t.Skip("Skip, please run without -short")
 		return
 	}
 
-	k8s, err := kubetest.NewK8s(true)
+	k8s, err := kubetest.NewK8s(g, true)
 	defer k8s.Cleanup()
-	Expect(err).To(BeNil())
+	g.Expect(err).To(BeNil())
 
 	nsmgr1 := createSingleNsmgr(k8s, "nsmgr-1")
 
 	sr1, closeFunc := kubetest.ServiceRegistryAt(k8s, nsmgr1)
 
 	nsmRegistryClient, err := sr1.NsmRegistryClient()
-	Expect(err).To(BeNil())
+	g.Expect(err).To(BeNil())
 
 	discovery, err := sr1.DiscoveryClient()
-	Expect(err).To(BeNil())
+	g.Expect(err).To(BeNil())
 
 	nseRegistryClient, err := sr1.NseRegistryClient()
-	Expect(err).To(BeNil())
+	g.Expect(err).To(BeNil())
 
 	networkService := "icmp-responder"
 	nsmName := "master"
@@ -445,7 +429,7 @@ func TestLostUpdate(t *testing.T) {
 		Url:  url1,
 	})
 	logrus.Info(response)
-	Expect(err).To(BeNil())
+	g.Expect(err).To(BeNil())
 
 	nseResp, err := nseRegistryClient.RegisterNSE(context.Background(), &registry.NSERegistration{
 		NetworkService: &registry.NetworkService{
@@ -456,9 +440,9 @@ func TestLostUpdate(t *testing.T) {
 			NetworkServiceName: networkService,
 		},
 	})
-	Expect(err).To(BeNil())
+	g.Expect(err).To(BeNil())
 	logrus.Info(nseResp)
-	Expect(getNsmUrl(discovery)).To(Equal(url1))
+	g.Expect(getNsmUrl(g, discovery)).To(Equal(url1))
 	closeFunc()
 	k8s.DeletePods(nsmgr1)
 
@@ -468,10 +452,10 @@ func TestLostUpdate(t *testing.T) {
 	defer closeFunc2()
 
 	discovery2, err := sr2.DiscoveryClient()
-	Expect(err).To(BeNil())
+	g.Expect(err).To(BeNil())
 
 	nseRegistryClient2, err := sr2.NseRegistryClient()
-	Expect(err).To(BeNil())
+	g.Expect(err).To(BeNil())
 
 	nseResp, err = nseRegistryClient2.RegisterNSE(context.Background(), &registry.NSERegistration{
 		NetworkService: &registry.NetworkService{
@@ -482,22 +466,22 @@ func TestLostUpdate(t *testing.T) {
 			NetworkServiceName: networkService,
 		},
 	})
-	Expect(err).To(BeNil())
+	g.Expect(err).To(BeNil())
 	logrus.Info(nseResp)
-	Expect(getNsmUrl(discovery2)).ToNot(Equal(url1))
+	g.Expect(getNsmUrl(g, discovery2)).ToNot(Equal(url1))
 }
 
 func TestRegistryConcurrentModification(t *testing.T) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
 
 	if testing.Short() {
 		t.Skip("Skip, please run without -short")
 		return
 	}
 
-	k8s, err := kubetest.NewK8s(true)
+	k8s, err := kubetest.NewK8s(g, true)
 	defer k8s.Cleanup()
-	Expect(err).To(BeNil())
+	g.Expect(err).To(BeNil())
 
 	nsmgr1 := createSingleNsmgr(k8s, "nsmgr-1")
 
@@ -505,7 +489,7 @@ func TestRegistryConcurrentModification(t *testing.T) {
 	defer closeFunc()
 
 	nsmRegistryClient, err := sr1.NsmRegistryClient()
-	Expect(err).To(BeNil())
+	g.Expect(err).To(BeNil())
 
 	n := 30
 	errorCh := make(chan error)
@@ -533,7 +517,7 @@ func TestRegistryConcurrentModification(t *testing.T) {
 			k8s.CleanupCRDs()
 			logrus.Info("CleanupCRDs")
 		case err := <-errorCh:
-			Expect(err).To(BeNil())
+			g.Expect(err).To(BeNil())
 			return
 		}
 	}

--- a/test/integration/basic_nsmdp_test.go
+++ b/test/integration/basic_nsmdp_test.go
@@ -13,41 +13,41 @@ import (
 )
 
 func TestNSMDDP(t *testing.T) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
 
 	if testing.Short() {
 		t.Skip("Skip, please run without -short")
 		return
 	}
 
-	k8s, err := kubetest.NewK8s(true)
+	k8s, err := kubetest.NewK8s(g, true)
 	defer k8s.Cleanup()
 
-	Expect(err).To(BeNil())
+	g.Expect(err).To(BeNil())
 	defer kubetest.ShowLogs(k8s, t)
 	nodes, err := kubetest.SetupNodes(k8s, 1, defaultTimeout)
-	Expect(err).To(BeNil())
+	g.Expect(err).To(BeNil())
 	icmpPod := kubetest.DeployICMP(k8s, nodes[0].Node, "icmp-responder-nse-1", defaultTimeout)
 
 	nsmdName := nodes[0].Nsmd.Name
 	k8s.DeletePods(nodes[0].Nsmd, icmpPod)
 	nodes[0].Nsmd = k8s.CreatePod(pods.NSMgrPod(nsmdName, nodes[0].Node, k8s.GetK8sNamespace())) // Recovery NSEs
 	icmpPod = kubetest.DeployICMP(k8s, nodes[0].Node, "icmp-responder-nse-2", defaultTimeout)
-	Expect(icmpPod).ToNot(BeNil())
+	g.Expect(icmpPod).ToNot(BeNil())
 }
 
 func TestNSMDRecoverNSE(t *testing.T) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
 
 	if testing.Short() {
 		t.Skip("Skip, please run without -short")
 		return
 	}
 
-	k8s, err := kubetest.NewK8s(true)
+	k8s, err := kubetest.NewK8s(g, true)
 	defer k8s.Cleanup()
 
-	Expect(err).To(BeNil())
+	g.Expect(err).To(BeNil())
 
 	nodes, err := kubetest.SetupNodesConfig(k8s, 1, defaultTimeout, []*pods.NSMgrPodConfig{
 		&pods.NSMgrPodConfig{
@@ -58,7 +58,7 @@ func TestNSMDRecoverNSE(t *testing.T) {
 			DataplaneVariables: kubetest.DefaultDataplaneVariables(k8s.GetForwardingPlane()),
 		},
 	}, k8s.GetK8sNamespace())
-	Expect(err).To(BeNil())
+	g.Expect(err).To(BeNil())
 	icmpPod := kubetest.DeployICMP(k8s, nodes[0].Node, "icmp-responder-nse-1", defaultTimeout)
 
 	nsmdName := nodes[0].Nsmd.Name
@@ -69,5 +69,5 @@ func TestNSMDRecoverNSE(t *testing.T) {
 		Namespace: k8s.GetK8sNamespace(),
 	})) // Recovery NSEs
 	icmpPod = kubetest.DeployICMP(k8s, nodes[0].Node, "icmp-responder-nse-2", defaultTimeout)
-	Expect(icmpPod).ToNot(BeNil())
+	g.Expect(icmpPod).ToNot(BeNil())
 }

--- a/test/integration/recover_death_handling_test.go
+++ b/test/integration/recover_death_handling_test.go
@@ -15,8 +15,6 @@ import (
 )
 
 func TestNSCDiesSingleNode(t *testing.T) {
-	RegisterTestingT(t)
-
 	if testing.Short() {
 		t.Skip("Skip, please run without -short")
 		return
@@ -26,8 +24,6 @@ func TestNSCDiesSingleNode(t *testing.T) {
 }
 
 func TestNSEDiesSingleNode(t *testing.T) {
-	RegisterTestingT(t)
-
 	if testing.Short() {
 		t.Skip("Skip, please run without -short")
 		return
@@ -37,8 +33,6 @@ func TestNSEDiesSingleNode(t *testing.T) {
 }
 
 func TestNSCDiesMultiNode(t *testing.T) {
-	RegisterTestingT(t)
-
 	if testing.Short() {
 		t.Skip("Skip, please run without -short")
 		return
@@ -46,8 +40,6 @@ func TestNSCDiesMultiNode(t *testing.T) {
 	testDie(t, true, 2)
 }
 func TestNSEDiesMultiNode(t *testing.T) {
-	RegisterTestingT(t)
-
 	if testing.Short() {
 		t.Skip("Skip, please run without -short")
 		return
@@ -56,34 +48,36 @@ func TestNSEDiesMultiNode(t *testing.T) {
 }
 
 func testDie(t *testing.T, killSrc bool, nodesCount int) {
-	Expect(nodesCount > 0).Should(BeTrue())
+	g := NewWithT(t)
 
-	k8s, err := kubetest.NewK8s(true)
+	g.Expect(nodesCount > 0).Should(BeTrue())
+
+	k8s, err := kubetest.NewK8s(g, true)
 
 	defer k8s.Cleanup()
-	Expect(err).To(BeNil())
+	g.Expect(err).To(BeNil())
 
 	nodes, err := kubetest.SetupNodesConfig(k8s, nodesCount, defaultTimeout, kubetest.NoHealNSMgrPodConfig(k8s), k8s.GetK8sNamespace())
 
 	defer kubetest.ShowLogs(k8s, t)
-	Expect(err).To(BeNil())
+	g.Expect(err).To(BeNil())
 
 	icmp := kubetest.DeployICMP(k8s, nodes[nodesCount-1].Node, "icmp-responder-nse-1", defaultTimeout)
 	nsc := kubetest.DeployNSC(k8s, nodes[0].Node, "nsc-1", defaultTimeout)
 
 	ipResponse, errOut, err := k8s.Exec(nsc, nsc.Spec.Containers[0].Name, "ip", "addr")
-	Expect(err).To(BeNil())
-	Expect(errOut).To(Equal(""))
-	Expect(strings.Contains(ipResponse, "nsm")).To(Equal(true))
+	g.Expect(err).To(BeNil())
+	g.Expect(errOut).To(Equal(""))
+	g.Expect(strings.Contains(ipResponse, "nsm")).To(Equal(true))
 
 	ipResponse, errOut, err = k8s.Exec(icmp, icmp.Spec.Containers[0].Name, "ip", "addr")
-	Expect(err).To(BeNil())
-	Expect(errOut).To(Equal(""))
-	Expect(strings.Contains(ipResponse, "nsm")).To(Equal(true))
+	g.Expect(err).To(BeNil())
+	g.Expect(errOut).To(Equal(""))
+	g.Expect(strings.Contains(ipResponse, "nsm")).To(Equal(true))
 
 	pingResponse, errOut, err := k8s.Exec(nsc, nsc.Spec.Containers[0].Name, "ping", "172.16.1.2", "-A", "-c", "5")
-	Expect(err).To(BeNil())
-	Expect(strings.Contains(pingResponse, "5 packets transmitted, 5 packets received, 0% packet loss")).To(Equal(true))
+	g.Expect(err).To(BeNil())
+	g.Expect(strings.Contains(pingResponse, "5 packets transmitted, 5 packets received, 0% packet loss")).To(Equal(true))
 	logrus.Printf("NSC Ping is success:%s", pingResponse)
 
 	var podToKill *v1.Pod
@@ -106,6 +100,6 @@ func testDie(t *testing.T, killSrc bool, nodesCount int) {
 			break
 		}
 	}
-	Expect(success).To(Equal(true))
+	g.Expect(success).To(Equal(true))
 
 }

--- a/test/integration/recover_nse_dataplane_heal_test.go
+++ b/test/integration/recover_nse_dataplane_heal_test.go
@@ -15,61 +15,63 @@ import (
 )
 
 func TestDataplaneHealLocal(t *testing.T) {
-	RegisterTestingT(t)
-
 	if testing.Short() {
 		t.Skip("Skip, please run without -short")
 		return
 	}
 
-	testDataplaneHeal(t, 0, 1, kubetest.DefaultTestingPodFixture())
+	g := NewWithT(t)
+
+	testDataplaneHeal(t, 0, 1, kubetest.DefaultTestingPodFixture(g))
 }
 
 func TestDataplaneHealLocalMemif(t *testing.T) {
-	RegisterTestingT(t)
-
 	if testing.Short() {
 		t.Skip("Skip, please run without -short")
 		return
 	}
 
-	testDataplaneHeal(t, 0, 1, kubetest.VppAgentTestingPodFixture())
+	g := NewWithT(t)
+
+	testDataplaneHeal(t, 0, 1, kubetest.VppAgentTestingPodFixture(g))
 }
 
 func TestDataplaneHealMultiNodesLocal(t *testing.T) {
-	RegisterTestingT(t)
-
 	if testing.Short() {
 		t.Skip("Skip, please run without -short")
 		return
 	}
 
-	testDataplaneHeal(t, 0, 2, kubetest.HealTestingPodFixture())
+	g := NewWithT(t)
+
+	testDataplaneHeal(t, 0, 2, kubetest.HealTestingPodFixture(g))
 }
 func TestDataplaneHealMultiNodesRemote(t *testing.T) {
-	RegisterTestingT(t)
-
 	if testing.Short() {
 		t.Skip("Skip, please run without -short")
 		return
 	}
 
-	testDataplaneHeal(t, 1, 2, kubetest.HealTestingPodFixture())
+	g := NewWithT(t)
+
+	testDataplaneHeal(t, 1, 2, kubetest.HealTestingPodFixture(g))
 }
 
 /**
 If passed 1 both will be on same node, if not on different.
 */
 func testDataplaneHeal(t *testing.T, killDataplaneIndex, nodesCount int, fixture kubetest.TestingPodFixture) {
-	Expect(nodesCount > 0).Should(BeTrue())
-	Expect(killDataplaneIndex >= 0 && killDataplaneIndex < nodesCount).Should(BeTrue())
-	k8s, err := kubetest.NewK8s(true)
+	g := NewWithT(t)
+
+	g.Expect(nodesCount > 0).Should(BeTrue())
+	g.Expect(killDataplaneIndex >= 0 && killDataplaneIndex < nodesCount).Should(BeTrue())
+	k8s, err := kubetest.NewK8s(g, true)
 	defer k8s.Cleanup()
-	Expect(err).To(BeNil())
+	g.Expect(err).To(BeNil())
 
 	// Deploy open tracing to see what happening.
 	nodes_setup, err := kubetest.SetupNodes(k8s, nodesCount, defaultTimeout)
-	Expect(err).To(BeNil())
+	g.Expect(err).To(BeNil())
 	defer kubetest.ShowLogs(k8s, t)
 	// Run ICMP on latest node
 	fixture.DeployNse(k8s, nodes_setup[nodesCount-1].Node, "icmp-responder-nse-1", defaultTimeout)

--- a/test/integration/recover_nse_heal_test.go
+++ b/test/integration/recover_nse_heal_test.go
@@ -13,63 +13,63 @@ import (
 )
 
 func TestNSEHealLocal(t *testing.T) {
-	RegisterTestingT(t)
-
 	if testing.Short() {
 		t.Skip("Skip, please run without -short")
 		return
 	}
 
+	g := NewWithT(t)
+
 	testNSEHeal(t, 1, map[string]int{
 		"icmp-responder-nse-1": 0,
 		"icmp-responder-nse-2": 0,
-	}, kubetest.HealTestingPodFixture())
+	}, kubetest.HealTestingPodFixture(g))
 }
 
 func TestNSEHealLocalToRemote(t *testing.T) {
-	RegisterTestingT(t)
-
 	if testing.Short() {
 		t.Skip("Skip, please run without -short")
 		return
 	}
+
+	g := NewWithT(t)
 
 	testNSEHeal(t, 2, map[string]int{
 		"icmp-responder-nse-1": 0,
 		"icmp-responder-nse-2": 1,
-	}, kubetest.HealTestingPodFixture())
+	}, kubetest.HealTestingPodFixture(g))
 }
 
 func TestNSEHealRemoteToLocal(t *testing.T) {
-	RegisterTestingT(t)
-
 	if testing.Short() {
 		t.Skip("Skip, please run without -short")
 		return
 	}
+
+	g := NewWithT(t)
 
 	testNSEHeal(t, 2, map[string]int{
 		"icmp-responder-nse-1": 1,
 		"icmp-responder-nse-2": 0,
-	}, kubetest.HealTestingPodFixture())
+	}, kubetest.HealTestingPodFixture(g))
 }
 
 func TestNSEHealRemote(t *testing.T) {
-	RegisterTestingT(t)
-
 	if testing.Short() {
 		t.Skip("Skip, please run without -short")
 		return
 	}
 
+	g := NewWithT(t)
+
 	testNSEHeal(t, 2, map[string]int{
 		"icmp-responder-nse-1": 1,
 		"icmp-responder-nse-2": 1,
-	}, kubetest.HealTestingPodFixture())
+	}, kubetest.HealTestingPodFixture(g))
 }
 
 func TestNSEHealLocalMemif(t *testing.T) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
 
 	if testing.Short() {
 		t.Skip("Skip, please run without -short")
@@ -79,21 +79,22 @@ func TestNSEHealLocalMemif(t *testing.T) {
 	testNSEHeal(t, 1, map[string]int{
 		"icmp-responder-nse-1": 0,
 		"icmp-responder-nse-2": 0,
-	}, kubetest.VppAgentTestingPodFixture())
+	}, kubetest.VppAgentTestingPodFixture(g))
 }
 
 /**
 If passed 1 both will be on same node, if not on different.
 */
-func testNSEHeal(t *testing.T, nodesCount int, affinity map[string]int,
-	fixture kubetest.TestingPodFixture) {
-	k8s, err := kubetest.NewK8s(true)
+func testNSEHeal(t *testing.T, nodesCount int, affinity map[string]int, fixture kubetest.TestingPodFixture) {
+	g := NewWithT(t)
+
+	k8s, err := kubetest.NewK8s(g, true)
 	defer k8s.Cleanup()
-	Expect(err).To(BeNil())
+	g.Expect(err).To(BeNil())
 
 	// Deploy open tracing to see what happening.
 	nodesSetup, err := kubetest.SetupNodes(k8s, nodesCount, defaultTimeout)
-	Expect(err).To(BeNil())
+	g.Expect(err).To(BeNil())
 	defer kubetest.ShowLogs(k8s, t)
 
 	// Run ICMP
@@ -116,7 +117,7 @@ func testNSEHeal(t *testing.T, nodesCount int, affinity map[string]int,
 
 	if len(nodesSetup) > 1 {
 		l2, err := k8s.GetLogs(nodesSetup[1].Nsmd, "nsmd")
-		Expect(err).To(BeNil())
+		g.Expect(err).To(BeNil())
 		if strings.Contains(l2, "Dataplane request failed:") {
 			logrus.Infof("Dataplane first attempt was failed: %v", l2)
 		}

--- a/test/integration/recover_nse_nsm_heal_test.go
+++ b/test/integration/recover_nse_nsm_heal_test.go
@@ -18,34 +18,30 @@ import (
 )
 
 func TestNSMHealLocalDieNSMD(t *testing.T) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
 
 	if testing.Short() {
 		t.Skip("Skip, please run without -short")
 		return
 	}
 
-	k8s, err := kubetest.NewK8s(true)
+	k8s, err := kubetest.NewK8s(g, true)
 	defer k8s.Cleanup()
 
-	Expect(err).To(BeNil())
+	g.Expect(err).To(BeNil())
 	defer kubetest.ShowLogs(k8s, t)
 
 	// Deploy open tracing to see what happening.
 	nodes_setup, err := kubetest.SetupNodes(k8s, 2, defaultTimeout)
-	Expect(err).To(BeNil())
+	g.Expect(err).To(BeNil())
 
 	// Run ICMP on latest node
 	icmpPod := kubetest.DeployICMP(k8s, nodes_setup[1].Node, "icmp-responder-nse-1", defaultTimeout)
-	Expect(icmpPod).ToNot(BeNil())
+	g.Expect(icmpPod).ToNot(BeNil())
 
 	nscPodNode := kubetest.DeployNSC(k8s, nodes_setup[0].Node, "nsc-1", defaultTimeout)
-	var nscInfo *kubetest.NSCCheckInfo
-	failures := InterceptGomegaFailures(func() {
-		nscInfo = kubetest.CheckNSC(k8s, nscPodNode)
-	})
-	// Do dumping of container state to dig into what is happened.
-	kubetest.PrintErrors(failures, k8s, nodes_setup, nscInfo, t)
+
+	kubetest.CheckNSC(k8s, nscPodNode)
 
 	logrus.Infof("Delete Local NSMD")
 	k8s.DeletePods(nodes_setup[0].Nsmd)
@@ -60,19 +56,14 @@ func TestNSMHealLocalDieNSMD(t *testing.T) {
 	nodes_setup[0].Nsmd = k8s.CreatePod(pods.NSMgrPodWithConfig(nsmdName, nodes_setup[0].Node, &pods.NSMgrPodConfig{Namespace: k8s.GetK8sNamespace()})) // Recovery NSEs
 	logrus.Printf("Started new NSMD: %v on node %s", time.Since(startTime), nodes_setup[0].Node.Name)
 
-	failures = InterceptGomegaFailures(func() {
-		logrus.Infof("Waiting for connection recovery...")
-		k8s.WaitLogsContains(nodes_setup[0].Nsmd, "nsmd", "Heal: Connection recovered:", defaultTimeout)
-		logrus.Infof("Waiting for connection recovery Done...")
+	logrus.Infof("Waiting for connection recovery...")
+	k8s.WaitLogsContains(nodes_setup[0].Nsmd, "nsmd", "Heal: Connection recovered:", defaultTimeout)
+	logrus.Infof("Waiting for connection recovery Done...")
 
-		nscInfo = kubetest.HealNscChecker(k8s, nscPodNode)
-	})
-	kubetest.PrintErrors(failures, k8s, nodes_setup, nscInfo, t)
+	kubetest.HealNscChecker(k8s, nscPodNode)
 }
 
 func TestNSMHealLocalDieNSMDOneNode(t *testing.T) {
-	RegisterTestingT(t)
-
 	if testing.Short() {
 		t.Skip("Skip, please run without -short")
 		return
@@ -81,8 +72,6 @@ func TestNSMHealLocalDieNSMDOneNode(t *testing.T) {
 }
 
 func TestNSMHealLocalDieNSMDOneNodeMemif(t *testing.T) {
-	RegisterTestingT(t)
-
 	if testing.Short() {
 		t.Skip("Skip, please run without -short")
 		return
@@ -91,8 +80,6 @@ func TestNSMHealLocalDieNSMDOneNodeMemif(t *testing.T) {
 }
 
 func TestNSMHealLocalDieNSMDOneNodeCleanedEndpoints(t *testing.T) {
-	RegisterTestingT(t)
-
 	if testing.Short() {
 		t.Skip("Skip, please run without -short")
 		return
@@ -101,26 +88,23 @@ func TestNSMHealLocalDieNSMDOneNodeCleanedEndpoints(t *testing.T) {
 }
 
 func testNSMHealLocalDieNSMDOneNode(t *testing.T, deployNsc, deployNse kubetest.PodSupplier, nscCheck kubetest.NscChecker, cleanupEndpointsCRDs bool) {
-	k8s, err := kubetest.NewK8s(true)
+	g := NewWithT(t)
+
+	k8s, err := kubetest.NewK8s(g, true)
 	defer k8s.Cleanup()
 
-	Expect(err).To(BeNil())
+	g.Expect(err).To(BeNil())
 	kubetest.ShowLogs(k8s, t)
 	// Deploy open tracing to see what happening.
 	nodes_setup, err := kubetest.SetupNodes(k8s, 1, defaultTimeout)
-	Expect(err).To(BeNil())
+	g.Expect(err).To(BeNil())
 
 	// Run ICMP on latest node
 	icmpPod := deployNse(k8s, nodes_setup[0].Node, "icmp-responder-nse-1", defaultTimeout)
-	Expect(icmpPod).ToNot(BeNil())
+	g.Expect(icmpPod).ToNot(BeNil())
 
 	nscPodNode := deployNsc(k8s, nodes_setup[0].Node, "nsc-1", defaultTimeout)
-	var nscInfo *kubetest.NSCCheckInfo
-	failures := InterceptGomegaFailures(func() {
-		nscInfo = nscCheck(k8s, nscPodNode)
-	})
-	// Do dumping of container state to dig into what is happened.
-	kubetest.PrintErrors(failures, k8s, nodes_setup, nscInfo, t)
+	nscCheck(k8s, nscPodNode)
 
 	logrus.Infof("Delete Local NSMD")
 	k8s.DeletePods(nodes_setup[0].Nsmd)
@@ -137,19 +121,14 @@ func testNSMHealLocalDieNSMDOneNode(t *testing.T, deployNsc, deployNse kubetest.
 	nodes_setup[0].Nsmd = k8s.CreatePod(pods.NSMgrPodWithConfig(nsmdName, nodes_setup[0].Node, &pods.NSMgrPodConfig{Namespace: k8s.GetK8sNamespace()})) // Recovery NSEs
 	logrus.Printf("Started new NSMD: %v on node %s", time.Since(startTime), nodes_setup[0].Node.Name)
 
-	failures = InterceptGomegaFailures(func() {
-		logrus.Infof("Waiting for connection recovery...")
-		k8s.WaitLogsContains(nodes_setup[0].Nsmd, "nsmd", "Heal: Connection recovered:", defaultTimeout)
-		logrus.Infof("Waiting for connection recovery Done...")
+	logrus.Infof("Waiting for connection recovery...")
+	k8s.WaitLogsContains(nodes_setup[0].Nsmd, "nsmd", "Heal: Connection recovered:", defaultTimeout)
+	logrus.Infof("Waiting for connection recovery Done...")
 
-		nscInfo = nscCheck(k8s, nscPodNode)
-	})
-	kubetest.PrintErrors(failures, k8s, nodes_setup, nscInfo, t)
+	nscCheck(k8s, nscPodNode)
 }
 
 func TestNSMHealLocalDieNSMDOneNodeFakeEndpoint(t *testing.T) {
-	RegisterTestingT(t)
-
 	if testing.Short() {
 		t.Skip("Skip, please run without -short")
 		return
@@ -158,33 +137,30 @@ func TestNSMHealLocalDieNSMDOneNodeFakeEndpoint(t *testing.T) {
 }
 
 func testNSMHealLocalDieNSMDTwoNodes(t *testing.T, deployNsc, deployNse kubetest.PodSupplier, nscCheck kubetest.NscChecker) {
-	k8s, err := kubetest.NewK8s(true)
+	g := NewWithT(t)
+
+	k8s, err := kubetest.NewK8s(g, true)
 	defer k8s.Cleanup()
 
-	Expect(err).To(BeNil())
+	g.Expect(err).To(BeNil())
 
 	nodes_setup, err := kubetest.SetupNodes(k8s, 2, defaultTimeout)
-	Expect(err).To(BeNil())
+	g.Expect(err).To(BeNil())
 
 	// Run ICMP on latest node
 	icmpPod := deployNse(k8s, nodes_setup[0].Node, "icmp-responder-nse-1", defaultTimeout)
-	Expect(icmpPod).ToNot(BeNil())
+	g.Expect(icmpPod).ToNot(BeNil())
 
 	nscPodNode := deployNsc(k8s, nodes_setup[0].Node, "nsc-1", defaultTimeout)
-	var nscInfo *kubetest.NSCCheckInfo
-	failures := InterceptGomegaFailures(func() {
-		nscInfo = nscCheck(k8s, nscPodNode)
-	})
-	// Do dumping of container state to dig into what is happened.
-	kubetest.PrintErrors(failures, k8s, nodes_setup, nscInfo, t)
+	nscCheck(k8s, nscPodNode)
 
 	// Remember nse name
 	_, nsm1RegistryClient, fwd1Close := kubetest.PrepareRegistryClients(k8s, nodes_setup[0].Nsmd)
 	nseList, err := nsm1RegistryClient.GetEndpoints(context.Background(), &empty.Empty{})
 	fwd1Close()
 
-	Expect(err).To(BeNil())
-	Expect(len(nseList.NetworkServiceEndpoints)).To(Equal(1))
+	g.Expect(err).To(BeNil())
+	g.Expect(len(nseList.NetworkServiceEndpoints)).To(Equal(1))
 	nseName := nseList.NetworkServiceEndpoints[0].EndpointName
 
 	logrus.Info(nseName)
@@ -209,22 +185,19 @@ func testNSMHealLocalDieNSMDTwoNodes(t *testing.T, deployNsc, deployNse kubetest
 			EndpointName:       nseName,
 		},
 	})
-	Expect(err).To(BeNil())
+	g.Expect(err).To(BeNil())
 	nseList2, err := nsm2RegistryClient.GetEndpoints(context.Background(), &empty.Empty{})
-	Expect(err).To(BeNil())
-	Expect(len(nseList2.NetworkServiceEndpoints)).To(Equal(1))
+	g.Expect(err).To(BeNil())
+	g.Expect(len(nseList2.NetworkServiceEndpoints)).To(Equal(1))
 
 	logrus.Infof("Starting recovered NSMD...")
 	startTime := time.Now()
 	nodes_setup[0].Nsmd = k8s.CreatePod(pods.NSMgrPodWithConfig(nsmdName, nodes_setup[0].Node, &pods.NSMgrPodConfig{Namespace: k8s.GetK8sNamespace()})) // Recovery NSEs
 	logrus.Printf("Started new NSMD: %v on node %s", time.Since(startTime), nodes_setup[0].Node.Name)
 
-	failures = InterceptGomegaFailures(func() {
-		logrus.Infof("Waiting for connection recovery...")
-		k8s.WaitLogsContains(nodes_setup[0].Nsmd, "nsmd", "Heal: Connection recovered:", defaultTimeout)
-		logrus.Infof("Waiting for connection recovery Done...")
+	logrus.Infof("Waiting for connection recovery...")
+	k8s.WaitLogsContains(nodes_setup[0].Nsmd, "nsmd", "Heal: Connection recovered:", defaultTimeout)
+	logrus.Infof("Waiting for connection recovery Done...")
 
-		nscInfo = nscCheck(k8s, nscPodNode)
-	})
-	kubetest.PrintErrors(failures, k8s, nodes_setup, nscInfo, t)
+	nscCheck(k8s, nscPodNode)
 }

--- a/test/integration/recover_update_local_connection_test.go
+++ b/test/integration/recover_update_local_connection_test.go
@@ -13,18 +13,19 @@ import (
 )
 
 func TestUpdateConnectionOnNSEChange(t *testing.T) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
+
 	if testing.Short() {
 		t.Skip("Skip, please run without -short")
 		return
 	}
 
-	k8s, err := kubetest.NewK8s(true)
-	Expect(err).To(BeNil())
+	k8s, err := kubetest.NewK8s(g, true)
+	g.Expect(err).To(BeNil())
 	defer k8s.Cleanup()
 
 	nodesConf, err := kubetest.SetupNodes(k8s, 2, defaultTimeout)
-	Expect(err).To(BeNil())
+	g.Expect(err).To(BeNil())
 	defer kubetest.ShowLogs(k8s, t)
 
 	nse1 := kubetest.DeployICMP(k8s, nodesConf[0].Node, "icmp-responder-nse-1", defaultTimeout)
@@ -35,8 +36,8 @@ func TestUpdateConnectionOnNSEChange(t *testing.T) {
 	<-time.After(5 * time.Second) // we need to be sure that NSC is updated only with the initial connection
 
 	l, err := k8s.GetLogs(nsc, "monitoring-nsc")
-	Expect(err).To(BeNil())
-	Expect(l).NotTo(ContainSubstring("Connection updated"))
+	g.Expect(err).To(BeNil())
+	g.Expect(l).NotTo(ContainSubstring("Connection updated"))
 
 	kubetest.DeployICMP(k8s, nodesConf[1].Node, "icmp-responder-nse-2", defaultTimeout)
 	k8s.DeletePods(nse1)
@@ -49,19 +50,19 @@ func TestUpdateConnectionOnNSEChange(t *testing.T) {
 }
 
 func TestUpdateConnectionOnNSEUpdate(t *testing.T) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
 
 	if testing.Short() {
 		t.Skip("Skip, please run without -short")
 		return
 	}
 
-	k8s, err := kubetest.NewK8s(true)
-	Expect(err).To(BeNil())
+	k8s, err := kubetest.NewK8s(g, true)
+	g.Expect(err).To(BeNil())
 	defer k8s.Cleanup()
 
 	nodesConf, err := kubetest.SetupNodes(k8s, 1, defaultTimeout)
-	Expect(err).To(BeNil())
+	g.Expect(err).To(BeNil())
 	defer kubetest.ShowLogs(k8s, t)
 
 	kubetest.DeployUpdatingNSE(k8s, nodesConf[0].Node, "icmp-responder-nse", defaultTimeout)

--- a/test/integration/recover_xcon_monitor_test.go
+++ b/test/integration/recover_xcon_monitor_test.go
@@ -13,22 +13,22 @@ import (
 )
 
 func TestXconMonitorSingleNodeHealFailed(t *testing.T) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
 
-	k8s, err := kubetest.NewK8s(true)
+	k8s, err := kubetest.NewK8s(g, true)
 	defer k8s.Cleanup()
-	Expect(err).To(BeNil())
+	g.Expect(err).To(BeNil())
 
 	nodesConf, err := kubetest.SetupNodes(k8s, 1, defaultTimeout)
-	Expect(err).To(BeNil())
+	g.Expect(err).To(BeNil())
 
 	defer kubetest.ShowLogs(k8s, t)
 
 	icmpPod := kubetest.DeployICMP(k8s, nodesConf[0].Node, "icmp-0", defaultTimeout)
-	Expect(icmpPod).ToNot(BeNil())
+	g.Expect(icmpPod).ToNot(BeNil())
 
 	nscPodNode := kubetest.DeployNSC(k8s, nodesConf[0].Node, "nsc-0", defaultTimeout)
-	Expect(nscPodNode).ToNot(BeNil())
+	g.Expect(nscPodNode).ToNot(BeNil())
 
 	eventCh, closeFunc := kubetest.XconProxyMonitor(k8s, nodesConf[0], "0")
 	defer closeFunc()
@@ -60,22 +60,22 @@ func TestXconMonitorSingleNodeHealFailed(t *testing.T) {
 }
 
 func TestXconMonitorSingleNodeHealSuccess(t *testing.T) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
 
-	k8s, err := kubetest.NewK8s(true)
+	k8s, err := kubetest.NewK8s(g, true)
 	defer k8s.Cleanup()
-	Expect(err).To(BeNil())
+	g.Expect(err).To(BeNil())
 
 	nodesConf, err := kubetest.SetupNodes(k8s, 1, defaultTimeout)
-	Expect(err).To(BeNil())
+	g.Expect(err).To(BeNil())
 
 	defer kubetest.ShowLogs(k8s, t)
 
 	icmp0 := kubetest.DeployICMP(k8s, nodesConf[0].Node, "icmp-0", defaultTimeout)
-	Expect(icmp0).ToNot(BeNil())
+	g.Expect(icmp0).ToNot(BeNil())
 
 	nsc := kubetest.DeployNSC(k8s, nodesConf[0].Node, "nsc-0", defaultTimeout)
-	Expect(nsc).ToNot(BeNil())
+	g.Expect(nsc).ToNot(BeNil())
 
 	eventCh, closeFunc := kubetest.XconProxyMonitor(k8s, nodesConf[0], "0")
 	defer closeFunc()
@@ -83,7 +83,7 @@ func TestXconMonitorSingleNodeHealSuccess(t *testing.T) {
 	expectedFunc, waitFunc := kubetest.NewEventChecker(t, eventCh)
 
 	icmp1 := kubetest.DeployICMP(k8s, nodesConf[0].Node, "icmp-1", defaultTimeout)
-	Expect(icmp1).ToNot(BeNil())
+	g.Expect(icmp1).ToNot(BeNil())
 
 	k8s.DeletePods(icmp0)
 
@@ -111,22 +111,22 @@ func TestXconMonitorSingleNodeHealSuccess(t *testing.T) {
 }
 
 func TestXconMonitorMultiNodeHealFail(t *testing.T) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
 
-	k8s, err := kubetest.NewK8s(true)
+	k8s, err := kubetest.NewK8s(g, true)
 	defer k8s.Cleanup()
-	Expect(err).To(BeNil())
+	g.Expect(err).To(BeNil())
 
 	nodesConf, err := kubetest.SetupNodes(k8s, 2, defaultTimeout)
-	Expect(err).To(BeNil())
+	g.Expect(err).To(BeNil())
 
 	defer kubetest.ShowLogs(k8s, t)
 
 	icmp := kubetest.DeployICMP(k8s, nodesConf[1].Node, "icmp-0", defaultTimeout)
-	Expect(icmp).ToNot(BeNil())
+	g.Expect(icmp).ToNot(BeNil())
 
 	nsc := kubetest.DeployNSC(k8s, nodesConf[0].Node, "nsc-0", defaultTimeout)
-	Expect(nsc).ToNot(BeNil())
+	g.Expect(nsc).ToNot(BeNil())
 
 	// monitor client for node0
 	eventCh0, closeFunc0 := kubetest.XconProxyMonitor(k8s, nodesConf[0], "0")
@@ -191,22 +191,22 @@ func TestXconMonitorMultiNodeHealFail(t *testing.T) {
 }
 
 func TestXconMonitorMultiNodeHealSuccess(t *testing.T) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
 
-	k8s, err := kubetest.NewK8s(true)
+	k8s, err := kubetest.NewK8s(g, true)
 	defer k8s.Cleanup()
-	Expect(err).To(BeNil())
+	g.Expect(err).To(BeNil())
 
 	nodesConf, err := kubetest.SetupNodes(k8s, 2, defaultTimeout)
-	Expect(err).To(BeNil())
+	g.Expect(err).To(BeNil())
 
 	defer kubetest.ShowLogs(k8s, t)
 
 	icmp0 := kubetest.DeployICMP(k8s, nodesConf[1].Node, "icmp-0", defaultTimeout)
-	Expect(icmp0).ToNot(BeNil())
+	g.Expect(icmp0).ToNot(BeNil())
 
 	nsc := kubetest.DeployNSC(k8s, nodesConf[0].Node, "nsc-0", defaultTimeout)
-	Expect(nsc).ToNot(BeNil())
+	g.Expect(nsc).ToNot(BeNil())
 
 	// monitor client for node0
 	eventCh0, closeFunc0 := kubetest.XconProxyMonitor(k8s, nodesConf[0], "0")
@@ -223,7 +223,7 @@ func TestXconMonitorMultiNodeHealSuccess(t *testing.T) {
 	expectedFunc1, waitFunc1 := kubetest.NewEventChecker(t, eventCh1)
 
 	icmp1 := kubetest.DeployICMP(k8s, nodesConf[1].Node, "icmp-1", defaultTimeout)
-	Expect(icmp1).ToNot(BeNil())
+	g.Expect(icmp1).ToNot(BeNil())
 	k8s.DeletePods(icmp0)
 
 	// expected events for node0
@@ -273,22 +273,22 @@ func TestXconMonitorMultiNodeHealSuccess(t *testing.T) {
 }
 
 func TestXconMonitorNsmgrRestart(t *testing.T) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
 
-	k8s, err := kubetest.NewK8s(true)
+	k8s, err := kubetest.NewK8s(g, true)
 	defer k8s.Cleanup()
-	Expect(err).To(BeNil())
+	g.Expect(err).To(BeNil())
 
 	nodesConf, err := kubetest.SetupNodes(k8s, 1, defaultTimeout)
-	Expect(err).To(BeNil())
+	g.Expect(err).To(BeNil())
 
 	defer kubetest.ShowLogs(k8s, t)
 
 	icmp0 := kubetest.DeployICMP(k8s, nodesConf[0].Node, "icmp-0", defaultTimeout)
-	Expect(icmp0).ToNot(BeNil())
+	g.Expect(icmp0).ToNot(BeNil())
 
 	nsc := kubetest.DeployNSC(k8s, nodesConf[0].Node, "nsc-0", defaultTimeout)
-	Expect(nsc).ToNot(BeNil())
+	g.Expect(nsc).ToNot(BeNil())
 
 	eventCh, closeFunc := kubetest.XconProxyMonitor(k8s, nodesConf[0], "0")
 	expectFunc, waitFunc := kubetest.NewEventChecker(t, eventCh)

--- a/test/integration/usecase_deploy_wrong_nsc_test.go
+++ b/test/integration/usecase_deploy_wrong_nsc_test.go
@@ -3,34 +3,33 @@
 package nsmd_integration_tests
 
 import (
-	"strings"
-	"testing"
-
-	"github.com/onsi/gomega"
-
 	"github.com/networkservicemesh/networkservicemesh/test/kubetest"
 	"github.com/networkservicemesh/networkservicemesh/test/kubetest/pods"
+	"strings"
+
+	. "github.com/onsi/gomega"
+	"testing"
 )
 
 func TestDeployWrongNsc(t *testing.T) {
-	gomega.RegisterTestingT(t)
+	g := NewWithT(t)
 
 	if testing.Short() {
 		t.Skip("Skip, please run without -short")
 		return
 	}
 
-	k8s, err := kubetest.NewK8s(true)
+	k8s, err := kubetest.NewK8s(g, true)
 	defer k8s.Cleanup()
 
-	gomega.Expect(err).To(gomega.BeNil())
+	g.Expect(err).To(BeNil())
 
 	nodes, err := kubetest.SetupNodes(k8s, 1, defaultTimeout)
-	gomega.Expect(err).To(gomega.BeNil())
+	g.Expect(err).To(BeNil())
 	defer kubetest.ShowLogs(k8s, t)
 
 	awc, awDeployment, awService := kubetest.DeployAdmissionWebhook(k8s, "nsm-admission-webhook", "networkservicemesh/admission-webhook", k8s.GetK8sNamespace(), defaultTimeout)
 	defer kubetest.DeleteAdmissionWebhook(k8s, "nsm-admission-webhook-certs", awc, awDeployment, awService, k8s.GetK8sNamespace())
 	_, err = k8s.CreatePodsRaw(defaultTimeout, false, pods.WrongNSCPodWebhook("wrong-nsc-client-pod", nodes[0].Node))
-	gomega.Expect(strings.Contains(err.Error(), "do not use init-container and nsm annotation")).Should(gomega.BeTrue())
+	g.Expect(strings.Contains(err.Error(), "do not use init-container and nsm annotation")).Should(BeTrue())
 }

--- a/test/integration/usecase_deploy_wrong_nsc_test.go
+++ b/test/integration/usecase_deploy_wrong_nsc_test.go
@@ -3,12 +3,14 @@
 package nsmd_integration_tests
 
 import (
-	"github.com/networkservicemesh/networkservicemesh/test/kubetest"
-	"github.com/networkservicemesh/networkservicemesh/test/kubetest/pods"
 	"strings"
 
-	. "github.com/onsi/gomega"
+	"github.com/networkservicemesh/networkservicemesh/test/kubetest"
+	"github.com/networkservicemesh/networkservicemesh/test/kubetest/pods"
+
 	"testing"
+
+	. "github.com/onsi/gomega"
 )
 
 func TestDeployWrongNsc(t *testing.T) {

--- a/test/integration/usecase_deployment_order_test.go
+++ b/test/integration/usecase_deployment_order_test.go
@@ -149,17 +149,17 @@ func TestDeploymentOrderService4ClientWebhook2Endpoint(t *testing.T) {
 }
 
 func testDeploymentOrder(t *testing.T, order []Deployment) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
 
 	if testing.Short() {
 		t.Skip("Skip, please run without -short")
 		return
 	}
 
-	k8s, err := kubetest.NewK8s(true)
+	k8s, err := kubetest.NewK8s(g, true)
 	defer k8s.Cleanup()
 
-	Expect(err).To(BeNil())
+	g.Expect(err).To(BeNil())
 
 	for _, deploy := range order {
 		if deploy == DeployClientWebhook {
@@ -170,7 +170,7 @@ func testDeploymentOrder(t *testing.T, order []Deployment) {
 	}
 
 	_, err = kubetest.SetupNodes(k8s, 1, defaultTimeout)
-	Expect(err).To(BeNil())
+	g.Expect(err).To(BeNil())
 
 	var nseCount uint64
 	var nscPods []*v1.Pod
@@ -187,15 +187,15 @@ func testDeploymentOrder(t *testing.T, order []Deployment) {
 			switch deploy {
 			case DeployService:
 				nscrd, err := crds.NewNSCRD(k8s.GetK8sNamespace())
-				Expect(err).To(BeNil())
+				g.Expect(err).To(BeNil())
 				nsIcmpResponder := crds.IcmpResponder(map[string]string{}, map[string]string{"app": "icmp"})
 				logrus.Printf("About to insert: %v", nsIcmpResponder)
 				var result *nsapiv1.NetworkService
 				result, err = nscrd.Create(nsIcmpResponder)
-				Expect(err).To(BeNil())
+				g.Expect(err).To(BeNil())
 				logrus.Printf("CRD applied with result: %v", result)
 				result, err = nscrd.Get(nsIcmpResponder.ObjectMeta.Name)
-				Expect(err).To(BeNil())
+				g.Expect(err).To(BeNil())
 				logrus.Printf("Registered CRD is: %v", result)
 			case DeployEndpoint:
 				kubetest.DeployICMP(k8s, nil, "nse-"+strconv.FormatUint(atomic.AddUint64(&nseCount, 1), 10), defaultTimeout)

--- a/test/integration/usecase_nsc_icmp_configuration_test.go
+++ b/test/integration/usecase_nsc_icmp_configuration_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	. "github.com/onsi/gomega"
-	"github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
 
 	"github.com/networkservicemesh/networkservicemesh/test/kubetest"
@@ -15,8 +14,6 @@ import (
 )
 
 func TestNSCAndICMPLocal(t *testing.T) {
-	RegisterTestingT(t)
-
 	if testing.Short() {
 		t.Skip("Skip, please run without -short")
 		return
@@ -26,8 +23,6 @@ func TestNSCAndICMPLocal(t *testing.T) {
 }
 
 func TestNSCAndICMPRemote(t *testing.T) {
-	RegisterTestingT(t)
-
 	if testing.Short() {
 		t.Skip("Skip, please run without -short")
 		return
@@ -37,8 +32,6 @@ func TestNSCAndICMPRemote(t *testing.T) {
 }
 
 func TestNSCAndICMPWebhookLocal(t *testing.T) {
-	RegisterTestingT(t)
-
 	if testing.Short() {
 		t.Skip("Skip, please run without -short")
 		return
@@ -48,8 +41,6 @@ func TestNSCAndICMPWebhookLocal(t *testing.T) {
 }
 
 func TestNSCAndICMPWebhookRemote(t *testing.T) {
-	RegisterTestingT(t)
-
 	if testing.Short() {
 		t.Skip("Skip, please run without -short")
 		return
@@ -59,8 +50,6 @@ func TestNSCAndICMPWebhookRemote(t *testing.T) {
 }
 
 func TestNSCAndICMPLocalVeth(t *testing.T) {
-	RegisterTestingT(t)
-
 	if testing.Short() {
 		t.Skip("Skip, please run without -short")
 		return
@@ -70,8 +59,6 @@ func TestNSCAndICMPLocalVeth(t *testing.T) {
 }
 
 func TestNSCAndICMPRemoteVeth(t *testing.T) {
-	RegisterTestingT(t)
-
 	if testing.Short() {
 		t.Skip("Skip, please run without -short")
 		return
@@ -81,20 +68,20 @@ func TestNSCAndICMPRemoteVeth(t *testing.T) {
 }
 
 func TestNSCAndICMPNeighbors(t *testing.T) {
-	RegisterTestingT(t)
+	g := NewWithT(t)
 
 	if testing.Short() {
 		t.Skip("Skip, please run without -short")
 		return
 	}
 
-	k8s, err := kubetest.NewK8s(true)
+	k8s, err := kubetest.NewK8s(g, true)
 	defer k8s.Cleanup()
 	defer kubetest.ShowLogs(k8s, t)
-	Expect(err).To(BeNil())
+	g.Expect(err).To(BeNil())
 
 	nodes_setup, err := kubetest.SetupNodes(k8s, 1, defaultTimeout)
-	Expect(err).To(BeNil())
+	g.Expect(err).To(BeNil())
 	_ = kubetest.DeployNeighborNSE(k8s, nodes_setup[0].Node, "icmp-responder-nse-1", defaultTimeout)
 	nsc := kubetest.DeployNSC(k8s, nodes_setup[0].Node, "nsc-1", defaultTimeout)
 
@@ -107,25 +94,27 @@ func TestNSCAndICMPNeighbors(t *testing.T) {
 		arpCommand = []string{"ip", "-6", "neigh", "show"}
 	}
 	pingResponse, errOut, err := k8s.Exec(nsc, nsc.Spec.Containers[0].Name, pingCommand, pingIP, "-A", "-c", "5")
-	Expect(err).To(BeNil())
-	Expect(errOut).To(Equal(""))
-	Expect(strings.Contains(pingResponse, "100% packet loss")).To(Equal(false))
+	g.Expect(err).To(BeNil())
+	g.Expect(errOut).To(Equal(""))
+	g.Expect(strings.Contains(pingResponse, "100% packet loss")).To(Equal(false))
 
 	nsc2 := kubetest.DeployNSC(k8s, nodes_setup[0].Node, "nsc-2", defaultTimeout)
 	arpResponse, errOut, err := k8s.Exec(nsc2, nsc.Spec.Containers[0].Name, arpCommand...)
-	Expect(err).To(BeNil())
-	Expect(errOut).To(Equal(""))
-	Expect(strings.Contains(arpResponse, pingIP)).To(Equal(true))
+	g.Expect(err).To(BeNil())
+	g.Expect(errOut).To(Equal(""))
+	g.Expect(strings.Contains(arpResponse, pingIP)).To(Equal(true))
 }
 
 /**
 If passed 1 both will be on same node, if not on different.
 */
 func testNSCAndICMP(t *testing.T, nodesCount int, useWebhook bool, disableVHost bool) {
-	k8s, err := kubetest.NewK8s(true)
+	g := NewWithT(t)
+
+	k8s, err := kubetest.NewK8s(g, true)
 	defer k8s.Cleanup()
 	defer kubetest.ShowLogs(k8s, t)
-	Expect(err).To(BeNil())
+	g.Expect(err).To(BeNil())
 
 	if useWebhook {
 		awc, awDeployment, awService := kubetest.DeployAdmissionWebhook(k8s, "nsm-admission-webhook", "networkservicemesh/admission-webhook", k8s.GetK8sNamespace(), defaultTimeout)
@@ -145,7 +134,7 @@ func testNSCAndICMP(t *testing.T, nodesCount int, useWebhook bool, disableVHost 
 		config = append(config, cfg)
 	}
 	nodes_setup, err := kubetest.SetupNodesConfig(k8s, nodesCount, defaultTimeout, config, k8s.GetK8sNamespace())
-	Expect(err).To(BeNil())
+	g.Expect(err).To(BeNil())
 
 	// Run ICMP on latest node
 	_ = kubetest.DeployICMP(k8s, nodes_setup[nodesCount-1].Node, "icmp-responder-nse-1", defaultTimeout)
@@ -156,17 +145,6 @@ func testNSCAndICMP(t *testing.T, nodesCount int, useWebhook bool, disableVHost 
 	} else {
 		nscPodNode = kubetest.DeployNSC(k8s, nodes_setup[0].Node, "nsc-1", defaultTimeout)
 	}
-	var nscInfo *kubetest.NSCCheckInfo
 
-	failures := InterceptGomegaFailures(func() {
-		nscInfo = kubetest.CheckNSC(k8s, nscPodNode)
-	})
-	// Do dumping of container state to dig into what is happened.
-	if len(failures) > 0 {
-		logrus.Errorf("Failures: %v", failures)
-
-		nscInfo.PrintLogs()
-
-		t.Fail()
-	}
+	kubetest.CheckNSC(k8s, nscPodNode)
 }

--- a/test/kubetest/crds/networkservice.go
+++ b/test/kubetest/crds/networkservice.go
@@ -18,7 +18,6 @@ package crds
 import (
 	"os"
 
-	. "github.com/onsi/gomega"
 	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -73,7 +72,9 @@ func NewNSCRD(namespace string) (*NSCRD, error) {
 	}
 
 	config, err := clientcmd.BuildConfigFromFlags("", path)
-	Expect(err).To(BeNil())
+	if err != nil {
+		return nil, err
+	}
 
 	nsmNamespace := namespace
 	client := NSCRD{
@@ -82,8 +83,9 @@ func NewNSCRD(namespace string) (*NSCRD, error) {
 		config:    config,
 	}
 	client.clientset, err = nscrd.NewForConfig(config)
-
-	Expect(err).To(BeNil())
+	if err != nil {
+		return nil, err
+	}
 
 	return &client, nil
 }

--- a/test/kubetest/ip.go
+++ b/test/kubetest/ip.go
@@ -61,8 +61,8 @@ func getNSCLocalRemoteIPs(k8s *K8s, nscPodNode *v1.Pod) [2]string {
 	} else {
 		ipResponse, errOut, err = k8s.Exec(nscPodNode, nscPodNode.Spec.Containers[0].Name, "ip", "-6", "addr", "show", "nsm0", "scope", "global")
 	}
-	Expect(err).To(BeNil())
-	Expect(errOut).To(Equal(""))
+	k8s.g.Expect(err).To(BeNil())
+	k8s.g.Expect(errOut).To(Equal(""))
 	result := splitIP(ipResponse, k8s.UseIPv6())
 	return result
 }

--- a/test/kubetest/k8s.go
+++ b/test/kubetest/k8s.go
@@ -267,7 +267,7 @@ type K8s struct {
 	apiServerHost      string
 	useIPv6            bool
 	forwardingPlane    string
-	g				   *WithT
+	g                  *WithT
 }
 
 // NewK8s - Creates a new K8s Clientset with roles for the default config
@@ -293,7 +293,7 @@ func NewK8sWithoutRoles(g *WithT, prepare bool) (*K8s, error) {
 
 	client := K8s{
 		pods: []*v1.Pod{},
-		g: g,
+		g:    g,
 	}
 	client.setForwardingPlane()
 	client.config = config

--- a/test/kubetest/k8s.go
+++ b/test/kubetest/k8s.go
@@ -267,16 +267,19 @@ type K8s struct {
 	apiServerHost      string
 	useIPv6            bool
 	forwardingPlane    string
+	g				   *WithT
 }
 
-func NewK8s(prepare bool) (*K8s, error) {
+// NewK8s - Creates a new K8s Clientset with roles for the default config
+func NewK8s(g *WithT, prepare bool) (*K8s, error) {
 
-	client, err := NewK8sWithoutRoles(prepare)
+	client, err := NewK8sWithoutRoles(g, prepare)
 	client.roles, _ = client.CreateRoles("admin", "view", "binding")
 	return client, err
 }
 
-func NewK8sWithoutRoles(prepare bool) (*K8s, error) {
+// NewK8sWithoutRoles - Creates a new K8s Clientset for the default config
+func NewK8sWithoutRoles(g *WithT, prepare bool) (*K8s, error) {
 
 	path := os.Getenv("KUBECONFIG")
 	if len(path) == 0 {
@@ -284,22 +287,29 @@ func NewK8sWithoutRoles(prepare bool) (*K8s, error) {
 	}
 
 	config, err := clientcmd.BuildConfigFromFlags("", path)
-	Expect(err).To(BeNil())
+	if err != nil {
+		return nil, err
+	}
 
 	client := K8s{
 		pods: []*v1.Pod{},
+		g: g,
 	}
 	client.setForwardingPlane()
 	client.config = config
 	client.clientset, err = kubernetes.NewForConfig(config)
-	Expect(err).To(BeNil())
+	if err != nil {
+		return nil, err
+	}
 
 	client.apiServerHost = config.Host
 	client.initNamespace()
 	client.setIPVersion()
 
 	client.versionedClientSet, err = versioned.NewForConfig(config)
-	Expect(err).To(BeNil())
+	if err != nil {
+		return nil, err
+	}
 
 	if prepare {
 		start := time.Now()
@@ -358,7 +368,7 @@ func (k8s *K8s) initNamespace() {
 	if err != nil {
 		k8s.checkAPIServerAvailable()
 	}
-	Expect(err).To(BeNil())
+	k8s.g.Expect(err).To(BeNil())
 }
 
 // Delete POD with completion check
@@ -409,7 +419,7 @@ func (k8s *K8s) deletePodsForce(pods ...*v1.Pod) error {
 // GetVersion returns the k8s version
 func (k8s *K8s) GetVersion() string {
 	version, err := k8s.clientset.Discovery().ServerVersion()
-	Expect(err).To(BeNil())
+	k8s.g.Expect(err).To(BeNil())
 	return fmt.Sprintf("%s", version)
 }
 
@@ -419,14 +429,14 @@ func (k8s *K8s) GetNodes() []v1.Node {
 	if err != nil {
 		k8s.checkAPIServerAvailable()
 	}
-	Expect(err).To(BeNil())
+	k8s.g.Expect(err).To(BeNil())
 	return nodes.Items
 }
 
 // ListPods lists the pods
 func (k8s *K8s) ListPods() []v1.Pod {
 	podList, err := k8s.clientset.CoreV1().Pods(k8s.namespace).List(metaV1.ListOptions{})
-	Expect(err).To(BeNil())
+	k8s.g.Expect(err).To(BeNil())
 	return podList.Items
 }
 
@@ -473,10 +483,10 @@ func (k8s *K8s) DescribePod(pod *v1.Pod) {
 // PrintImageVersion Prints image version pf pod.
 func (k8s *K8s) PrintImageVersion(pod *v1.Pod) {
 	logs, err := k8s.GetLogs(pod, pod.Spec.Containers[0].Name)
-	Expect(err).Should(BeNil())
+	k8s.g.Expect(err).Should(BeNil())
 	versionSubStr := "Version: "
 	index := strings.Index(logs, versionSubStr)
-	Expect(index == -1).ShouldNot(BeTrue())
+	k8s.g.Expect(index == -1).ShouldNot(BeTrue())
 	index += len(versionSubStr)
 	builder := strings.Builder{}
 	for ; index < len(logs); index++ {
@@ -484,10 +494,10 @@ func (k8s *K8s) PrintImageVersion(pod *v1.Pod) {
 			break
 		}
 		err = builder.WriteByte(logs[index])
-		Expect(err).Should(BeNil())
+		k8s.g.Expect(err).Should(BeNil())
 	}
 	version := builder.String()
-	Expect(strings.TrimSpace(version)).ShouldNot(Equal(""))
+	k8s.g.Expect(strings.TrimSpace(version)).ShouldNot(Equal(""))
 	logrus.Infof("Version of %v is %v", pod.Name, version)
 }
 
@@ -576,7 +586,7 @@ func (k8s *K8s) CreatePodsRaw(timeout time.Duration, failTest bool, templates ..
 	// Make sure unit test is failed
 	var err error = nil
 	if failTest {
-		Expect(len(errs)).To(Equal(0))
+		k8s.g.Expect(len(errs)).To(Equal(0))
 	} else {
 		// Lets construct error
 		err = fmt.Errorf("Errors %v", errs)
@@ -603,7 +613,7 @@ func (k8s *K8s) CreatePod(template *v1.Pod) *v1.Pod {
 // DeletePods delete pods
 func (k8s *K8s) DeletePods(pods ...*v1.Pod) {
 	err := k8s.deletePods(pods...)
-	Expect(err).To(BeNil())
+	k8s.g.Expect(err).To(BeNil())
 
 	for _, pod := range pods {
 		for idx, pod0 := range k8s.pods {
@@ -617,7 +627,7 @@ func (k8s *K8s) DeletePods(pods ...*v1.Pod) {
 // DeletePodsForce delete pods forcefully
 func (k8s *K8s) DeletePodsForce(pods ...*v1.Pod) {
 	err := k8s.deletePodsForce(pods...)
-	Expect(err).To(BeNil())
+	k8s.g.Expect(err).To(BeNil())
 
 	for _, pod := range pods {
 		for idx, pod0 := range k8s.pods {
@@ -740,7 +750,7 @@ func (k8s *K8s) waitLogsMatch(ctx context.Context, pod *v1.Pod, container string
 			}
 		case <-ctx.Done():
 			logrus.Errorf("%v Last logs: %v", description, builder.String())
-			Expect(false).To(BeTrue())
+			k8s.g.Expect(false).To(BeTrue())
 			return
 		}
 	}
@@ -749,7 +759,7 @@ func (k8s *K8s) waitLogsMatch(ctx context.Context, pod *v1.Pod, container string
 // UpdatePod updates a pod
 func (k8s *K8s) UpdatePod(pod *v1.Pod) *v1.Pod {
 	pod, error := k8s.clientset.CoreV1().Pods(pod.Namespace).Get(pod.Name, metaV1.GetOptions{})
-	Expect(error).To(BeNil())
+	k8s.g.Expect(error).To(BeNil())
 	return pod
 }
 
@@ -792,7 +802,7 @@ func (k8s *K8s) GetNodesWait(requiredNumber int, timeout time.Duration) []v1.Nod
 		}
 		since := time.Since(st)
 		if since > timeout {
-			Expect(len(nodes)).To(Equal(requiredNumber))
+			k8s.g.Expect(len(nodes)).To(Equal(requiredNumber))
 		}
 		if since > timeout/10 && !warnPrinted {
 			logrus.Warnf("Waiting for %d nodes to arrive, currently have: %d", requiredNumber, len(nodes))

--- a/test/kubetest/monitor_utils.go
+++ b/test/kubetest/monitor_utils.go
@@ -33,12 +33,12 @@ type EventDescription struct {
 // CrossConnectClientAt returns channel of CrossConnectEvents from passed nsmgr pod
 func CrossConnectClientAt(k8s *K8s, pod *v1.Pod) (<-chan *crossconnect.CrossConnectEvent, func()) {
 	fwd, err := k8s.NewPortForwarder(pod, 6001)
-	Expect(err).To(BeNil())
+	k8s.g.Expect(err).To(BeNil())
 
 	err = fwd.Start()
-	Expect(err).To(BeNil())
+	k8s.g.Expect(err).To(BeNil())
 
-	client, closeClient, cancel := CreateCrossConnectClient(fmt.Sprintf("localhost:%d", fwd.ListenPort))
+	client, closeClient, cancel := CreateCrossConnectClient(k8s, fmt.Sprintf("localhost:%d", fwd.ListenPort))
 
 	stopCh := make(chan struct{})
 
@@ -201,12 +201,12 @@ func getEventCh(mc MonitorClient, cf context.CancelFunc, stopCh <-chan struct{})
 }
 
 // CreateCrossConnectClient returns CrossConnectMonitorClient to passed address
-func CreateCrossConnectClient(address string) (MonitorClient, func(), context.CancelFunc) {
+func CreateCrossConnectClient(k8s *K8s, address string) (MonitorClient, func(), context.CancelFunc) {
 	var err error
 	logrus.Infof("Starting CrossConnections Monitor on %s", address)
 	conn, err := tools.DialTCP(address)
 	if err != nil {
-		Expect(err).To(BeNil())
+		k8s.g.Expect(err).To(BeNil())
 		return nil, nil, nil
 	}
 
@@ -214,7 +214,7 @@ func CreateCrossConnectClient(address string) (MonitorClient, func(), context.Ca
 	ctx, cancel := context.WithCancel(context.Background())
 	stream, err := monitorClient.MonitorCrossConnects(ctx, &empty.Empty{})
 	if err != nil {
-		Expect(err).To(BeNil())
+		k8s.g.Expect(err).To(BeNil())
 		cancel()
 		return nil, nil, nil
 	}

--- a/test/kubetest/testing_pod_fixture.go
+++ b/test/kubetest/testing_pod_fixture.go
@@ -1,10 +1,9 @@
 package kubetest
 
 import (
-	"time"
-
-	"github.com/onsi/gomega"
+	. "github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
+	"time"
 )
 
 // TestingPodFixture - Tool for help testing pods
@@ -15,25 +14,25 @@ type TestingPodFixture interface {
 }
 
 // VppAgentTestingPodFixture - Creates vpp agent specific testing tool
-func VppAgentTestingPodFixture() TestingPodFixture {
-	return NewCustomTestingPodFixture(DeployVppAgentNSC, DeployVppAgentICMP, CheckVppAgentNSC)
+func VppAgentTestingPodFixture(g *WithT) TestingPodFixture {
+	return NewCustomTestingPodFixture(g, DeployVppAgentNSC, DeployVppAgentICMP, CheckVppAgentNSC)
 }
 
 // DefaultTestingPodFixture - Creates default testing tool
-func DefaultTestingPodFixture() TestingPodFixture {
-	return NewCustomTestingPodFixture(DeployNSC, DeployICMP, CheckNSC)
+func DefaultTestingPodFixture(g *WithT) TestingPodFixture {
+	return NewCustomTestingPodFixture(g, DeployNSC, DeployICMP, CheckNSC)
 }
 
 // HealTestingPodFixture - Creates a testing tool specific for healing
-func HealTestingPodFixture() TestingPodFixture {
-	return NewCustomTestingPodFixture(DeployNSC, DeployICMP, HealNscChecker)
+func HealTestingPodFixture(g *WithT) TestingPodFixture {
+	return NewCustomTestingPodFixture(g, DeployNSC, DeployICMP, HealNscChecker)
 }
 
 // NewCustomTestingPodFixture - Creates a custom testing tool
-func NewCustomTestingPodFixture(deployNscFunc, deployNseFunc PodSupplier, checkNscFunc NscChecker) TestingPodFixture {
-	gomega.Expect(deployNscFunc).ShouldNot(gomega.BeNil())
-	gomega.Expect(deployNseFunc).ShouldNot(gomega.BeNil())
-	gomega.Expect(checkNscFunc).ShouldNot(gomega.BeNil())
+func NewCustomTestingPodFixture(g *WithT, deployNscFunc, deployNseFunc PodSupplier, checkNscFunc NscChecker) TestingPodFixture {
+	g.Expect(deployNscFunc).ShouldNot(BeNil())
+	g.Expect(deployNseFunc).ShouldNot(BeNil())
+	g.Expect(checkNscFunc).ShouldNot(BeNil())
 	return &testingPodFixtureImpl{
 		deployNscFunc: deployNscFunc,
 		deployNseFunc: deployNseFunc,

--- a/test/kubetest/testing_pod_fixture.go
+++ b/test/kubetest/testing_pod_fixture.go
@@ -1,9 +1,10 @@
 package kubetest
 
 import (
+	"time"
+
 	. "github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
-	"time"
 )
 
 // TestingPodFixture - Tool for help testing pods

--- a/test/kubetest/utils.go
+++ b/test/kubetest/utils.go
@@ -63,7 +63,7 @@ func SetupNodes(k8s *K8s, nodesCount int, timeout time.Duration) ([]*NodeConf, e
 // SetupNodesConfig - Setup NSMgr and Dataplane for particular number of nodes in cluster
 func SetupNodesConfig(k8s *K8s, nodesCount int, timeout time.Duration, conf []*pods.NSMgrPodConfig, namespace string) ([]*NodeConf, error) {
 	nodes := k8s.GetNodesWait(nodesCount, timeout)
-	Expect(len(nodes) >= nodesCount).To(Equal(true),
+	k8s.g.Expect(len(nodes) >= nodesCount).To(Equal(true),
 		"At least one Kubernetes node is required for this test")
 
 	var wg sync.WaitGroup
@@ -136,18 +136,14 @@ func deployNSMgrAndDataplane(k8s *K8s, corePods []*v1.Pod, timeout time.Duration
 	nsmd = corePods[0]
 	dataplane = corePods[1]
 
-	Expect(nsmd.Name).To(Equal(corePods[0].Name))
-	Expect(dataplane.Name).To(Equal(corePods[1].Name))
+	k8s.g.Expect(nsmd.Name).To(Equal(corePods[0].Name))
+	k8s.g.Expect(dataplane.Name).To(Equal(corePods[1].Name))
 
-	failures := InterceptGomegaFailures(func() {
-		k8s.WaitLogsContains(dataplane, "", "Sending MonitorMechanisms update", timeout)
-		_ = k8s.WaitLogsContainsRegex(nsmd, "nsmd", "NSM gRPC API Server: .* is operational", timeout)
-		k8s.WaitLogsContains(nsmd, "nsmdp", "nsmdp: successfully started", timeout)
-		k8s.WaitLogsContains(nsmd, "nsmd-k8s", "nsmd-k8s initialized and waiting for connection", timeout)
-	})
-	if len(failures) > 0 {
-		showLogs(k8s, nil)
-	}
+	k8s.WaitLogsContains(dataplane, "", "Sending MonitorMechanisms update", timeout)
+	_ = k8s.WaitLogsContainsRegex(nsmd, "nsmd", "NSM gRPC API Server: .* is operational", timeout)
+	k8s.WaitLogsContains(nsmd, "nsmdp", "nsmdp: successfully started", timeout)
+	k8s.WaitLogsContains(nsmd, "nsmd-k8s", "nsmd-k8s initialized and waiting for connection", timeout)
+
 	err = nil
 	return
 }
@@ -289,7 +285,7 @@ func deployICMP(k8s *K8s, nodeName, name string, timeout time.Duration, template
 
 	logrus.Infof("Starting ICMP Responder NSE on node: %s", nodeName)
 	icmp := k8s.CreatePod(template)
-	Expect(icmp.Name).To(Equal(name))
+	k8s.g.Expect(icmp.Name).To(Equal(name))
 
 	k8s.WaitLogsContains(icmp, "", "NSE: channel has been successfully advertised, waiting for connection from NSM...", timeout)
 
@@ -302,7 +298,7 @@ func deployDirtyNSE(k8s *K8s, nodeName, name string, timeout time.Duration, temp
 
 	logrus.Infof("Starting dirty NSE on node: %s", nodeName)
 	dirty := k8s.CreatePod(template)
-	Expect(dirty.Name).To(Equal(name))
+	k8s.g.Expect(dirty.Name).To(Equal(name))
 
 	k8s.WaitLogsContains(dirty, "", "NSE: channel has been successfully advertised, waiting for connection from NSM...", timeout)
 
@@ -312,13 +308,13 @@ func deployDirtyNSE(k8s *K8s, nodeName, name string, timeout time.Duration, temp
 
 func deployNSC(k8s *K8s, nodeName, name, container string, timeout time.Duration, template *v1.Pod) *v1.Pod {
 	startTime := time.Now()
-	Expect(template).ShouldNot(BeNil())
+	k8s.g.Expect(template).ShouldNot(BeNil())
 
 	logrus.Infof("Starting NSC %s on node: %s", name, nodeName)
 
 	nsc := k8s.CreatePod(template)
 
-	Expect(nsc.Name).To(Equal(name))
+	k8s.g.Expect(nsc.Name).To(Equal(name))
 	k8s.WaitLogsContains(nsc, container, "nsm client: initialization is completed successfully", timeout)
 
 	logrus.Printf("NSC started done: %v", time.Since(startTime))
@@ -334,7 +330,7 @@ func DeployAdmissionWebhook(k8s *K8s, name, image, namespace string, timeout tim
 	awService := CreateAdmissionWebhookService(k8s, name, namespace)
 
 	admissionWebhookPod := waitWebhookPod(k8s, awDeployment.Name, timeout)
-	Expect(admissionWebhookPod).ShouldNot(BeNil())
+	k8s.g.Expect(admissionWebhookPod).ShouldNot(BeNil())
 	k8s.WaitLogsContains(admissionWebhookPod, admissionWebhookPod.Spec.Containers[0].Name, "Server started", timeout)
 	return awc, awDeployment, awService
 }
@@ -344,16 +340,16 @@ func DeleteAdmissionWebhook(k8s *K8s, secretName string,
 	awc *arv1beta1.MutatingWebhookConfiguration, awDeployment *appsv1.Deployment, awService *v1.Service, namespace string) {
 
 	err := k8s.DeleteService(awService, namespace)
-	Expect(err).To(BeNil())
+	k8s.g.Expect(err).To(BeNil())
 
 	err = k8s.DeleteDeployment(awDeployment, namespace)
-	Expect(err).To(BeNil())
+	k8s.g.Expect(err).To(BeNil())
 
 	err = k8s.DeleteMutatingWebhookConfiguration(awc)
-	Expect(err).To(BeNil())
+	k8s.g.Expect(err).To(BeNil())
 
 	err = k8s.DeleteSecret(secretName, namespace)
-	Expect(err).To(BeNil())
+	k8s.g.Expect(err).To(BeNil())
 }
 
 // CreateAdmissionWebhookSecret - Create admission webhook secret
@@ -364,7 +360,7 @@ func CreateAdmissionWebhookSecret(k8s *K8s, name, namespace string) (*v1.Secret,
 		Usages:     []x509.ExtKeyUsage{x509.ExtKeyUsageAny},
 	}
 	caCert, caKey, err := pkiutil.NewCertificateAuthority(caCertSpec)
-	Expect(err).To(BeNil())
+	k8s.g.Expect(err).To(BeNil())
 
 	certSpec := &cert.Config{
 		CommonName: name + "-svc",
@@ -377,7 +373,7 @@ func CreateAdmissionWebhookSecret(k8s *K8s, name, namespace string) (*v1.Secret,
 		Usages: []x509.ExtKeyUsage{x509.ExtKeyUsageAny},
 	}
 	cer, key, err := pkiutil.NewCertAndKey(caCert, caKey, certSpec)
-	Expect(err).To(BeNil())
+	k8s.g.Expect(err).To(BeNil())
 
 	block := &pem.Block{
 		Type:  "RSA PRIVATE KEY",
@@ -407,7 +403,7 @@ func CreateAdmissionWebhookSecret(k8s *K8s, name, namespace string) (*v1.Secret,
 	}
 
 	awSecret, err := k8s.CreateSecret(secret, namespace)
-	Expect(err).To(BeNil())
+	k8s.g.Expect(err).To(BeNil())
 
 	block = &pem.Block{
 		Type:  "CERTIFICATE",
@@ -460,7 +456,7 @@ func CreateMutatingWebhookConfiguration(k8s *K8s, certPem []byte, name, namespac
 		},
 	}
 	awc, err := k8s.CreateMutatingWebhookConfiguration(mutatingWebhookConf)
-	Expect(err).To(BeNil())
+	k8s.g.Expect(err).To(BeNil())
 
 	return awc
 }
@@ -470,7 +466,7 @@ func CreateAdmissionWebhookDeployment(k8s *K8s, name, image, namespace string) *
 	deployment := pods.AdmissionWebhookDeployment(name, image)
 
 	awDeployment, err := k8s.CreateDeployment(deployment, namespace)
-	Expect(err).To(BeNil())
+	k8s.g.Expect(err).To(BeNil())
 
 	return awDeployment
 }
@@ -500,7 +496,7 @@ func CreateAdmissionWebhookService(k8s *K8s, name, namespace string) *v1.Service
 		},
 	}
 	awService, err := k8s.CreateService(service, namespace)
-	Expect(err).To(BeNil())
+	k8s.g.Expect(err).To(BeNil())
 
 	return awService
 }
@@ -535,7 +531,7 @@ func waitWebhookPod(k8s *K8s, name string, timeout time.Duration) *v1.Pod {
 				p := &list[i]
 				if strings.Contains(p.Name, name) {
 					result, err := blockUntilPodReady(k8s.clientset, timeout, p)
-					Expect(err).Should(BeNil())
+					k8s.g.Expect(err).Should(BeNil())
 					return result
 				}
 			}
@@ -562,10 +558,10 @@ func checkNSCConfig(k8s *K8s, nscPodNode *v1.Pod, checkIP, pingIP string) *NSCCh
 	} else {
 		info.ipResponse, info.errOut, err = k8s.Exec(nscPodNode, nscPodNode.Spec.Containers[0].Name, "ip", "-6", "addr")
 	}
-	Expect(err).To(BeNil())
-	Expect(info.errOut).To(Equal(""))
-	Expect(strings.Contains(info.ipResponse, checkIP)).To(Equal(true))
-	Expect(strings.Contains(info.ipResponse, "nsm")).To(Equal(true))
+	k8s.g.Expect(err).To(BeNil())
+	k8s.g.Expect(info.errOut).To(Equal(""))
+	k8s.g.Expect(strings.Contains(info.ipResponse, checkIP)).To(Equal(true))
+	k8s.g.Expect(strings.Contains(info.ipResponse, "nsm")).To(Equal(true))
 
 	if err != nil || info.errOut != "" {
 		logrus.Println("NSC IP status, NOK")
@@ -582,10 +578,10 @@ func checkNSCConfig(k8s *K8s, nscPodNode *v1.Pod, checkIP, pingIP string) *NSCCh
 	} else {
 		info.routeResponse, info.errOut, err = k8s.Exec(nscPodNode, nscPodNode.Spec.Containers[0].Name, "ip", "-6", "route")
 	}
-	Expect(err).To(BeNil())
-	Expect(info.errOut).To(Equal(""))
-	Expect(strings.Contains(info.routeResponse, publicDNSAddress)).To(Equal(true))
-	Expect(strings.Contains(info.routeResponse, "nsm")).To(Equal(true))
+	k8s.g.Expect(err).To(BeNil())
+	k8s.g.Expect(info.errOut).To(Equal(""))
+	k8s.g.Expect(strings.Contains(info.routeResponse, publicDNSAddress)).To(Equal(true))
+	k8s.g.Expect(strings.Contains(info.routeResponse, "nsm")).To(Equal(true))
 
 	if err != nil || info.errOut != "" {
 		logrus.Println("NSC Route status, NOK")
@@ -598,11 +594,11 @@ func checkNSCConfig(k8s *K8s, nscPodNode *v1.Pod, checkIP, pingIP string) *NSCCh
 
 	/* Check ping */
 	info.pingResponse, info.errOut, err = k8s.Exec(nscPodNode, nscPodNode.Spec.Containers[0].Name, pingCommand, pingIP, "-A", "-c", "5")
-	Expect(err).To(BeNil())
-	Expect(info.errOut).To(Equal(""))
+	k8s.g.Expect(err).To(BeNil())
+	k8s.g.Expect(info.errOut).To(Equal(""))
 
 	pingNOK := strings.Contains(info.pingResponse, "100% packet loss")
-	Expect(pingNOK).To(Equal(false))
+	k8s.g.Expect(pingNOK).To(Equal(false))
 	if err != nil || info.errOut != "" || pingNOK {
 		logrus.Printf("NSC Ping, NOK")
 		logrus.Println("pingResponse:", info.pingResponse)
@@ -630,7 +626,7 @@ func HealNscChecker(k8s *K8s, nscPod *v1.Pod) *NSCCheckInfo {
 		}
 		<-time.After(time.Second)
 	}
-	Expect(success).To(BeTrue())
+	k8s.g.Expect(success).To(BeTrue())
 	return rv
 }
 
@@ -679,7 +675,7 @@ func getNSEAddr(k8s *K8s, nsc *v1.Pod, parseIP ipParser, showIPCommand ...string
 
 func pingNse(k8s *K8s, from *v1.Pod) string {
 	nseIp, err := getNSEAddr(k8s, from, parseAddr, "ip", "addr")
-	Expect(err).Should(BeNil())
+	k8s.g.Expect(err).Should(BeNil())
 	logrus.Infof("%v trying ping to %v", from.Name, nseIp)
 	response, _, _ := k8s.Exec(from, from.Spec.Containers[0].Name, "ping", nseIp.String(), "-A", "-c", "4")
 	logrus.Infof("ping result: %s", response)
@@ -711,10 +707,10 @@ func PrintErrors(failures []string, k8s *K8s, nodesSetup []*NodeConf, nscInfo *N
 // ServiceRegistryAt creates new service registry on 5000 port
 func ServiceRegistryAt(k8s *K8s, nsmgr *v1.Pod) (serviceregistry.ServiceRegistry, func()) {
 	fwd, err := k8s.NewPortForwarder(nsmgr, 5000)
-	Expect(err).To(BeNil())
+	k8s.g.Expect(err).To(BeNil())
 
 	err = fwd.Start()
-	Expect(err).To(BeNil())
+	k8s.g.Expect(err).To(BeNil())
 
 	sr := nsmd2.NewServiceRegistryAt(fmt.Sprintf("localhost:%d", fwd.ListenPort))
 	return sr, fwd.Stop
@@ -725,10 +721,10 @@ func PrepareRegistryClients(k8s *K8s, nsmd *v1.Pod) (registry.NetworkServiceRegi
 	serviceRegistry, closeFunc := ServiceRegistryAt(k8s, nsmd)
 
 	nseRegistryClient, err := serviceRegistry.NseRegistryClient()
-	Expect(err).To(BeNil())
+	k8s.g.Expect(err).To(BeNil())
 
 	nsmRegistryClient, err := serviceRegistry.NsmRegistryClient()
-	Expect(err).To(BeNil())
+	k8s.g.Expect(err).To(BeNil())
 
 	return nseRegistryClient, nsmRegistryClient, closeFunc
 }
@@ -748,6 +744,6 @@ func ExpectNSEsCountToBe(k8s *K8s, countWas, countExpected int) {
 
 	nses, err := k8s.GetNSEs()
 
-	Expect(err).To(BeNil())
-	Expect(len(nses)).To(Equal(countExpected), fmt.Sprint(nses))
+	k8s.g.Expect(err).To(BeNil())
+	k8s.g.Expect(len(nses)).To(Equal(countExpected), fmt.Sprint(nses))
 }

--- a/test/kubetest/vpp_utils.go
+++ b/test/kubetest/vpp_utils.go
@@ -47,10 +47,10 @@ func checkVppAgentNSCConfig(k8s *K8s, nscPodNode *v1.Pod, checkIP string) *NSCCh
 		info.ipResponse = response
 		info.errOut = errOut
 	}
-	Expect(info.ipResponse).ShouldNot(Equal(""))
-	Expect(info.errOut).Should(Equal(""))
+	k8s.g.Expect(info.ipResponse).ShouldNot(Equal(""))
+	k8s.g.Expect(info.errOut).Should(Equal(""))
 	logrus.Printf("NSC IP status Ok")
-	Expect(true, IsVppAgentNsePinged(k8s, nscPodNode))
+	k8s.g.Expect(true, IsVppAgentNsePinged(k8s, nscPodNode))
 
 	return info
 }
@@ -71,7 +71,7 @@ func parseVppAgentAddr(ipReponse string) (string, error) {
 // IsVppAgentNsePinged - Check if vpp agent NSE is pinged
 func IsVppAgentNsePinged(k8s *K8s, from *v1.Pod) (result bool) {
 	nseIP, err := GetVppAgentNSEAddr(k8s, from)
-	Expect(err).Should(BeNil())
+	k8s.g.Expect(err).Should(BeNil())
 	logrus.Infof("%v trying vppctl ping to %v", from.Name, nseIP)
 	response, _, _ := k8s.Exec(from, from.Spec.Containers[0].Name, "vppctl", "ping", nseIP.String())
 	logrus.Infof("ping result: %s", response)


### PR DESCRIPTION
Signed-off-by: Artem Belov <artem.belov@xored.com>

## Description
RegisterTestingT was changed to NewWithT

## Motivation and Context
RegisterTestingT is now deprecated and  NewWithT() should be used instead.
RegisterTestingT could be the cause of #1392 issue

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [x] Covered by existing integration testing
- [ ] Added integration testing to cover
- [x] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
