### PR TITLE
#1341 Fix crash to prevent cloud leaking.

### DIFF
--- a/test/cloudtest/pkg/providers/packet/packet_provider.go
+++ b/test/cloudtest/pkg/providers/packet/packet_provider.go
@@ -247,7 +247,8 @@ func (pi *packetInstance) waitDevicesStartup(context context.Context) error {
 			var updatedDevice *packngo.Device
 			updatedDevice, _, err := pi.client.Devices.Get(d.ID, &packngo.GetOptions{})
 			if err != nil {
-				logrus.Errorf("Error %v", err)
+				logrus.Errorf("%v-%v Error accessing device Error: %v", pi.id, d.ID, err)
+				continue
 			} else if updatedDevice.State == "active" {
 				alive[key] = updatedDevice
 			}


### PR DESCRIPTION
Signed-off-by: Andrey Sobolev <haiodo@xored.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
Errors from Packet.net cluster handling caused CloudTest to crash, 
and some clouds could leak because of this.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [x] Covered by existing integration testing
- [ ] Added integration testing to cover
- [ ] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
