### PR TITLE
Allow inbound traffic for aws and gke clouds

### DIFF
--- a/.mk/gke.mk
+++ b/.mk/gke.mk
@@ -24,6 +24,9 @@ gke-start: gcloud-check
 		time gcloud container clusters create ${GKE_CLUSTER_NAME} --project=${GKE_PROJECT_ID} --machine-type=${GKE_CLUSTER_TYPE} --num-nodes=${GKE_CLUSTER_NUM_NODES} --zone=${GKE_CLUSTER_ZONE} -q; \
 		echo "Writing config to ${KUBECONFIG}"; \
 		gcloud container clusters get-credentials ${GKE_CLUSTER_NAME} --project=${GKE_PROJECT_ID} --zone=${GKE_CLUSTER_ZONE} ; \
+		gcloud compute firewall-rules create allow-proxy-nsm --action ALLOW --rules tcp:80 --project=${GKE_PROJECT_ID}; \
+		gcloud compute firewall-rules create allow-nsm --action ALLOW --rules tcp:5000-5100 --project=${GKE_PROJECT_ID}; \
+		gcloud compute firewall-rules create allow-vxlan --action ALLOW --rules udp:4789 --project=${GKE_PROJECT_ID}; \
 		kubectl create clusterrolebinding cluster-admin-binding \
 			--clusterrole cluster-admin \
   			--user $$(gcloud config get-value account); \

--- a/scripts/aws/create-kubernetes-cluster.go
+++ b/scripts/aws/create-kubernetes-cluster.go
@@ -321,6 +321,57 @@ func AuthorizeSecurityGroupIngress(ec2client *ec2.EC2, groupId *string) {
 					},
 				},
 			},
+			{
+				IpProtocol: aws.String("tcp"),
+				ToPort:     aws.Int64(80),
+				FromPort:   aws.Int64(80),
+				IpRanges: []*ec2.IpRange{
+					{
+						CidrIp:      aws.String("0.0.0.0/0"),
+						Description: aws.String("Remote ip4 access"),
+					},
+				},
+				Ipv6Ranges: []*ec2.Ipv6Range{
+					{
+						CidrIpv6:    aws.String("::/0"),
+						Description: aws.String("Remote ip6 access"),
+					},
+				},
+			},
+			{
+				IpProtocol: aws.String("tcp"),
+				ToPort:     aws.Int64(5100),
+				FromPort:   aws.Int64(5000),
+				IpRanges: []*ec2.IpRange{
+					{
+						CidrIp:      aws.String("0.0.0.0/0"),
+						Description: aws.String("Remote ip4 access"),
+					},
+				},
+				Ipv6Ranges: []*ec2.Ipv6Range{
+					{
+						CidrIpv6:    aws.String("::/0"),
+						Description: aws.String("Remote ip6 access"),
+					},
+				},
+			},
+			{
+				IpProtocol: aws.String("udp"),
+				ToPort:     aws.Int64(4789),
+				FromPort:   aws.Int64(4789),
+				IpRanges: []*ec2.IpRange{
+					{
+						CidrIp:      aws.String("0.0.0.0/0"),
+						Description: aws.String("Remote ip4 access"),
+					},
+				},
+				Ipv6Ranges: []*ec2.Ipv6Range{
+					{
+						CidrIpv6:    aws.String("::/0"),
+						Description: aws.String("Remote ip6 access"),
+					},
+				},
+			},
 		},
 	})
 	checkError(err)


### PR DESCRIPTION
Signed-off-by: Artem Belov <artem.belov@xored.com>

## Description
Allow inbound traffic for aws and gke clouds for interdomain connection purposes

## Motivation and Context
Required for Interdomain NSM connection (#1298) #714

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [ ] Covered by existing integration testing
- [ ] Added integration testing to cover
- [x] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
