### PR TITLE
Refactor EventCheckers

### DIFF
--- a/test/integration/basic_monitor_crossconnect_test.go
+++ b/test/integration/basic_monitor_crossconnect_test.go
@@ -46,18 +46,16 @@ func TestSingleCrossConnect(t *testing.T) {
 	// checking goroutine for node1
 	expectedFunc1, waitFunc1 := kubetest.NewEventChecker(t, eventCh1)
 
-	expectedFunc0(kubetest.EventDescription{
+	expectedFunc0(&kubetest.SingleEventChecker{
 		EventType: crossconnect.CrossConnectEventType_INITIAL_STATE_TRANSFER,
 		SrcUp:     true,
 		DstUp:     true,
-		LastEvent: true,
 	})
 
-	expectedFunc1(kubetest.EventDescription{
+	expectedFunc1(&kubetest.SingleEventChecker{
 		EventType: crossconnect.CrossConnectEventType_INITIAL_STATE_TRANSFER,
 		SrcUp:     true,
 		DstUp:     true,
-		LastEvent: true,
 	})
 
 	waitFunc0()

--- a/test/integration/recover_xcon_monitor_test.go
+++ b/test/integration/recover_xcon_monitor_test.go
@@ -36,24 +36,23 @@ func TestXconMonitorSingleNodeHealFailed(t *testing.T) {
 	expectedFunc, waitFunc := kubetest.NewEventChecker(t, eventCh)
 	k8s.DeletePods(icmpPod)
 
-	expectedFunc(kubetest.EventDescription{
+	expectedFunc(&kubetest.SingleEventChecker{
 		EventType: crossconnect.CrossConnectEventType_INITIAL_STATE_TRANSFER,
 		SrcUp:     true,
 		DstUp:     true,
 	})
 
-	expectedFunc(kubetest.EventDescription{
+	expectedFunc(&kubetest.SingleEventChecker{
 		EventType: crossconnect.CrossConnectEventType_UPDATE,
 		SrcUp:     true,
 		DstUp:     false,
-		TillNext:  defaultTimeout, // waiting while heal finishes work
 	})
 
-	expectedFunc(kubetest.EventDescription{
+	expectedFunc(&kubetest.SingleEventChecker{
 		EventType: crossconnect.CrossConnectEventType_DELETE,
 		SrcUp:     true,
 		DstUp:     false,
-		LastEvent: true,
+		Timeout:   defaultTimeout, // waiting while heal finishes work
 	})
 
 	waitFunc()
@@ -87,24 +86,23 @@ func TestXconMonitorSingleNodeHealSuccess(t *testing.T) {
 
 	k8s.DeletePods(icmp0)
 
-	expectedFunc(kubetest.EventDescription{
+	expectedFunc(&kubetest.SingleEventChecker{
 		EventType: crossconnect.CrossConnectEventType_INITIAL_STATE_TRANSFER,
 		SrcUp:     true,
 		DstUp:     true,
 	})
 
-	expectedFunc(kubetest.EventDescription{
+	expectedFunc(&kubetest.SingleEventChecker{
 		EventType: crossconnect.CrossConnectEventType_UPDATE,
 		SrcUp:     true,
 		DstUp:     false,
-		TillNext:  defaultTimeout, // waiting while heal finishes work
 	})
 
-	expectedFunc(kubetest.EventDescription{
+	expectedFunc(&kubetest.SingleEventChecker{
 		EventType: crossconnect.CrossConnectEventType_UPDATE,
 		SrcUp:     true,
 		DstUp:     true,
-		LastEvent: true,
+		Timeout:   defaultTimeout,
 	})
 
 	waitFunc()
@@ -145,45 +143,43 @@ func TestXconMonitorMultiNodeHealFail(t *testing.T) {
 	k8s.DeletePods(icmp)
 
 	// expected events for node0
-	expectedFunc0(kubetest.EventDescription{
+	expectedFunc0(&kubetest.SingleEventChecker{
 		EventType: crossconnect.CrossConnectEventType_INITIAL_STATE_TRANSFER,
 		SrcUp:     true,
 		DstUp:     true,
 	})
 
-	expectedFunc0(kubetest.EventDescription{
+	expectedFunc0(&kubetest.SingleEventChecker{
 		EventType: crossconnect.CrossConnectEventType_UPDATE,
 		SrcUp:     true,
 		DstUp:     false,
-		TillNext:  defaultTimeout, // waiting while heal finishes work
 	})
 
-	expectedFunc0(kubetest.EventDescription{
+	expectedFunc0(&kubetest.SingleEventChecker{
 		EventType: crossconnect.CrossConnectEventType_DELETE,
 		SrcUp:     true,
 		DstUp:     false,
-		LastEvent: true,
+		Timeout:   defaultTimeout, // waiting while heal finishes work
 	})
 
 	// expected events for node1
-	expectedFunc1(kubetest.EventDescription{
+	expectedFunc1(&kubetest.SingleEventChecker{
 		EventType: crossconnect.CrossConnectEventType_INITIAL_STATE_TRANSFER,
 		SrcUp:     true,
 		DstUp:     true,
 	})
 
-	expectedFunc1(kubetest.EventDescription{
+	expectedFunc1(&kubetest.SingleEventChecker{
 		EventType: crossconnect.CrossConnectEventType_UPDATE,
 		SrcUp:     true,
 		DstUp:     false,
-		TillNext:  defaultTimeout, // waiting while heal finishes work
 	})
 
-	expectedFunc1(kubetest.EventDescription{
+	expectedFunc1(&kubetest.SingleEventChecker{
 		EventType: crossconnect.CrossConnectEventType_DELETE,
 		SrcUp:     true,
 		DstUp:     false,
-		LastEvent: true,
+		Timeout:   defaultTimeout, // waiting while heal finishes work
 	})
 
 	waitFunc0()
@@ -227,45 +223,43 @@ func TestXconMonitorMultiNodeHealSuccess(t *testing.T) {
 	k8s.DeletePods(icmp0)
 
 	// expected events for node0
-	expectedFunc0(kubetest.EventDescription{
+	expectedFunc0(&kubetest.SingleEventChecker{
 		EventType: crossconnect.CrossConnectEventType_INITIAL_STATE_TRANSFER,
 		SrcUp:     true,
 		DstUp:     true,
 	})
 
-	expectedFunc0(kubetest.EventDescription{
+	expectedFunc0(&kubetest.SingleEventChecker{
 		EventType: crossconnect.CrossConnectEventType_UPDATE,
 		SrcUp:     true,
 		DstUp:     false,
-		TillNext:  defaultTimeout, // waiting while heal finishes work
 	})
 
-	expectedFunc0(kubetest.EventDescription{
+	expectedFunc0(&kubetest.SingleEventChecker{
 		EventType: crossconnect.CrossConnectEventType_UPDATE,
 		SrcUp:     true,
 		DstUp:     true,
-		LastEvent: true,
+		Timeout:   defaultTimeout, // waiting while heal finishes work
 	})
 
 	// expected events for node1
-	expectedFunc1(kubetest.EventDescription{
+	expectedFunc1(&kubetest.SingleEventChecker{
 		EventType: crossconnect.CrossConnectEventType_INITIAL_STATE_TRANSFER,
 		SrcUp:     true,
 		DstUp:     true,
 	})
 
-	expectedFunc1(kubetest.EventDescription{
+	expectedFunc1(&kubetest.SingleEventChecker{
 		EventType: crossconnect.CrossConnectEventType_UPDATE,
 		SrcUp:     true,
 		DstUp:     false,
-		TillNext:  defaultTimeout, // waiting while heal finishes work
 	})
 
-	expectedFunc1(kubetest.EventDescription{
+	expectedFunc1(&kubetest.SingleEventChecker{
 		EventType: crossconnect.CrossConnectEventType_DELETE,
 		SrcUp:     true,
 		DstUp:     false,
-		LastEvent: true,
+		Timeout:   defaultTimeout, // waiting while heal finishes work
 	})
 
 	waitFunc0()
@@ -293,11 +287,10 @@ func TestXconMonitorNsmgrRestart(t *testing.T) {
 	eventCh, closeFunc := kubetest.XconProxyMonitor(k8s, nodesConf[0], "0")
 	expectFunc, waitFunc := kubetest.NewEventChecker(t, eventCh)
 
-	expectFunc(kubetest.EventDescription{
+	expectFunc(&kubetest.SingleEventChecker{
 		EventType: crossconnect.CrossConnectEventType_INITIAL_STATE_TRANSFER,
 		SrcUp:     true,
 		DstUp:     true,
-		LastEvent: true,
 	})
 
 	k8s.DeletePods(nodesConf[0].Nsmd)
@@ -312,12 +305,27 @@ func TestXconMonitorNsmgrRestart(t *testing.T) {
 	defer closeFuncR()
 	expectFuncR, waitFuncR := kubetest.NewEventChecker(t, eventChR)
 
-	expectFuncR(kubetest.EventDescription{
-		EventType: crossconnect.CrossConnectEventType_INITIAL_STATE_TRANSFER,
-		SrcUp:     true,
-		DstUp:     true,
-		LastEvent: true,
-	})
+	checker := &kubetest.OrEventChecker{
+		Event1: &kubetest.SingleEventChecker{
+			EventType: crossconnect.CrossConnectEventType_INITIAL_STATE_TRANSFER,
+			SrcUp:     true,
+			DstUp:     true,
+		},
+		Event2: &kubetest.MultipleEventChecker{
+			Events: []kubetest.EventChecker{
+				&kubetest.SingleEventChecker{
+					EventType: crossconnect.CrossConnectEventType_INITIAL_STATE_TRANSFER,
+					Empty:     true,
+				},
+				&kubetest.SingleEventChecker{
+					EventType: crossconnect.CrossConnectEventType_UPDATE,
+					SrcUp:     true,
+					DstUp:     true,
+				},
+			},
+		},
+	}
 
+	expectFuncR(checker)
 	waitFuncR()
 }

--- a/test/kubetest/monitor_utils.go
+++ b/test/kubetest/monitor_utils.go
@@ -18,16 +18,121 @@ import (
 	"github.com/networkservicemesh/networkservicemesh/test/kubetest/pods"
 )
 
+const (
+	defaultEventTimeout = 10 * time.Second
+)
+
 // MonitorClient is shorter name for crossconnect.MonitorCrossConnect_MonitorCrossConnectsClient
 type MonitorClient crossconnect.MonitorCrossConnect_MonitorCrossConnectsClient
 
-// EventDescription describes expected event
-type EventDescription struct {
-	TillNext  time.Duration
+// EventChecker abstracts checker of particular events from channel
+type EventChecker interface {
+	Check(eventCh <-chan *crossconnect.CrossConnectEvent) error
+}
+
+// SingleEventChecker checks single event in channel
+type SingleEventChecker struct {
+	Timeout   time.Duration
 	EventType crossconnect.CrossConnectEventType
+	Empty     bool
 	SrcUp     bool
 	DstUp     bool
-	LastEvent bool
+}
+
+// Check implements method from EventChecker interface
+func (e *SingleEventChecker) Check(eventCh <-chan *crossconnect.CrossConnectEvent) error {
+	if e.Timeout == 0 {
+		e.Timeout = defaultEventTimeout
+	}
+
+	select {
+	case actual, ok := <-eventCh:
+		if !ok {
+			return errors.New("end of channel")
+		}
+		logrus.Infof("Accept new event, type - %v", actual.GetType())
+
+		if actual.GetType() != e.EventType {
+			return fmt.Errorf("event type %v expected to be %v", actual.GetType(), e.EventType)
+		}
+
+		if actual.GetType() == crossconnect.CrossConnectEventType_DELETE {
+			// we don't care about state of connections since event is DELETE
+			return nil
+		}
+
+		if e.Empty != (len(actual.GetCrossConnects()) == 0) {
+			return fmt.Errorf("expected event with 1 cross-connect, actual - %v", len(actual.GetCrossConnects()))
+		}
+
+		for _, xcon := range actual.GetCrossConnects() {
+			logrus.Info(XconToString(xcon))
+			if err := checkXcon(xcon, e.SrcUp, e.DstUp); err != nil {
+				return err
+			}
+		}
+	case <-time.After(e.Timeout):
+		return fmt.Errorf("no event during %v seconds, type %v", e.Timeout, e.EventType)
+	}
+
+	return nil
+}
+
+// MultipleEventChecker checks subsequence of events in channel
+type MultipleEventChecker struct {
+	Events []EventChecker
+}
+
+// Check implements method from EventChecker interface
+func (e *MultipleEventChecker) Check(eventCh <-chan *crossconnect.CrossConnectEvent) error {
+	if len(e.Events) == 0 {
+		return errors.New("events array can't be empty")
+	}
+
+	for _, event := range e.Events {
+		if err := event.Check(eventCh); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// OrEventChecker checks that one of checker - Event1 or Event2 successfully finishes
+type OrEventChecker struct {
+	Event1 EventChecker
+	Event2 EventChecker
+}
+
+// Check implements method from EventChecker interface
+func (e *OrEventChecker) Check(eventCh <-chan *crossconnect.CrossConnectEvent) error {
+	copyCh := make(chan *crossconnect.CrossConnectEvent)
+	var buffer []*crossconnect.CrossConnectEvent
+	go func() {
+		event := <-eventCh
+		buffer = append(buffer, event)
+		copyCh <- event
+	}()
+
+	if err := e.Event1.Check(copyCh); err == nil {
+		return nil
+	}
+	logrus.Info("the first condition is false, checking the second...")
+
+	copyCh2 := make(chan *crossconnect.CrossConnectEvent)
+	go func() {
+		for _, event := range buffer {
+			copyCh2 <- event
+		}
+		event := <-eventCh
+		copyCh2 <- event
+	}()
+
+	if err := e.Event2.Check(copyCh2); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // CrossConnectClientAt returns channel of CrossConnectEvents from passed nsmgr pod
@@ -69,86 +174,36 @@ func XconProxyMonitor(k8s *K8s, conf *NodeConf, suffix string) (<-chan *crosscon
 	}
 }
 
-const defaultNextTimeout = 10 * time.Second
-
 // NewEventChecker starts goroutine that read events from actualCh and
-// compare it with EventDescription passed to expectedFunc
-func NewEventChecker(t *testing.T, actualCh <-chan *crossconnect.CrossConnectEvent) (expectedFunc func(EventDescription), waitFunc func()) {
-	expectedCh := make(chan EventDescription, 10)
+// compare it with SingleEventChecker passed to expectedFunc
+func NewEventChecker(t *testing.T, actualCh <-chan *crossconnect.CrossConnectEvent) (expectedFunc func(EventChecker), waitFunc func()) {
+	expectedCh := make(chan EventChecker, 10)
 	waitCh := make(chan struct{})
 
 	go checkEventsCh(t, actualCh, expectedCh, waitCh)
 
-	expectedFunc = func(d EventDescription) {
+	expectedFunc = func(d EventChecker) {
 		expectedCh <- d
 	}
 
 	waitFunc = func() {
-		<-waitCh
 		close(expectedCh)
+		<-waitCh
 	}
 
 	return
 }
 
 func checkEventsCh(t *testing.T, actualCh <-chan *crossconnect.CrossConnectEvent,
-	expectedCh <-chan EventDescription, waitCh chan struct{}) {
+	expectedCh <-chan EventChecker, waitCh chan struct{}) {
 	defer close(waitCh)
-	var nextTimeout time.Duration
 
-	for {
-		if nextTimeout == 0 {
-			nextTimeout = defaultNextTimeout
-		}
-
-		select {
-		case e, ok := <-actualCh:
-			if !ok {
-				return
-			}
-			logrus.Infof("New %v event:", e.Type)
-			for _, v := range e.CrossConnects {
-				logrus.Infof(XconToString(v))
-			}
-
-			expected := <-expectedCh
-
-			if err := checkSingleXconEvent(e, expected); err != nil {
-				t.Error(err)
-				return
-			}
-
-			if expected.LastEvent {
-				return
-			}
-			nextTimeout = expected.TillNext
-		case <-time.After(nextTimeout):
-			t.Errorf("No events during %v", nextTimeout)
+	for checker := range expectedCh {
+		if err := checker.Check(actualCh); err != nil {
+			t.Error(err)
 			return
 		}
 	}
-}
-
-func checkSingleXconEvent(actual *crossconnect.CrossConnectEvent, expected EventDescription) error {
-	if actual.GetType() != expected.EventType {
-		return fmt.Errorf("event type %v expected to be %v", actual.GetType(), expected.EventType)
-	}
-
-	if actual.GetType() == crossconnect.CrossConnectEventType_DELETE {
-		// we don't care about state of connections since event is DELETE
-		return nil
-	}
-
-	if len(actual.GetCrossConnects()) != 1 {
-		return fmt.Errorf("expected event with 1 cross-connect, actual - %v", len(actual.GetCrossConnects()))
-	}
-
-	for _, xcon := range actual.GetCrossConnects() {
-		if err := checkXcon(xcon, expected.SrcUp, expected.DstUp); err != nil {
-			return err
-		}
-	}
-	return nil
 }
 
 func checkXcon(actual *crossconnect.CrossConnect, srcUp, dstUp bool) error {

--- a/test/kubetest/monitor_utils.go
+++ b/test/kubetest/monitor_utils.go
@@ -109,15 +109,18 @@ func (e *OrEventChecker) Check(eventCh <-chan *crossconnect.CrossConnectEvent) e
 	copyCh := make(chan *crossconnect.CrossConnectEvent)
 	var buffer []*crossconnect.CrossConnectEvent
 	go func() {
-		event := <-eventCh
-		buffer = append(buffer, event)
-		copyCh <- event
+		for {
+			event := <-eventCh
+			buffer = append(buffer, event)
+			copyCh <- event
+		}
 	}()
 
-	if err := e.Event1.Check(copyCh); err == nil {
+	err := e.Event1.Check(copyCh)
+	if err == nil {
 		return nil
 	}
-	logrus.Info("the first condition is false, checking the second...")
+	logrus.Infof("the first condition is false: %v, checking the second...", err)
 
 	copyCh2 := make(chan *crossconnect.CrossConnectEvent)
 	go func() {

--- a/test/kubetest/monitor_utils_test.go
+++ b/test/kubetest/monitor_utils_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/local/connection"
 )
 
-func newXcon(id string, eventType crossconnect.CrossConnectEventType, srcUp, dstUp, empty bool) *crossconnect.CrossConnectEvent {
+func newXcon(eventType crossconnect.CrossConnectEventType, srcUp, dstUp, empty bool) *crossconnect.CrossConnectEvent {
 	srcState := connection.State_DOWN
 	if srcUp {
 		srcState = connection.State_UP
@@ -23,8 +23,8 @@ func newXcon(id string, eventType crossconnect.CrossConnectEventType, srcUp, dst
 	xcons := map[string]*crossconnect.CrossConnect{}
 	if !empty {
 		xcons = map[string]*crossconnect.CrossConnect{
-			id: {
-				Id: id,
+			"newid": {
+				Id: "newid",
 				Source: &crossconnect.CrossConnect_LocalSource{
 					LocalSource: &connection.Connection{
 						Id:    "1",
@@ -58,7 +58,7 @@ func TestSingleEventChecker(t *testing.T) {
 	}
 
 	go func() {
-		ch <- newXcon("1", crossconnect.CrossConnectEventType_INITIAL_STATE_TRANSFER, true, true, false)
+		ch <- newXcon(crossconnect.CrossConnectEventType_INITIAL_STATE_TRANSFER, true, true, false)
 	}()
 
 	g.Expect(ec.Check(ch)).To(BeNil())
@@ -86,9 +86,9 @@ func TestMultipleEventChecker(t *testing.T) {
 	}
 
 	go func() {
-		ch <- newXcon("1", crossconnect.CrossConnectEventType_INITIAL_STATE_TRANSFER, false, false, true)
-		ch <- newXcon("1", crossconnect.CrossConnectEventType_UPDATE, true, true, false)
-		ch <- newXcon("1", crossconnect.CrossConnectEventType_DELETE, false, false, false)
+		ch <- newXcon(crossconnect.CrossConnectEventType_INITIAL_STATE_TRANSFER, false, false, true)
+		ch <- newXcon(crossconnect.CrossConnectEventType_UPDATE, true, true, false)
+		ch <- newXcon(crossconnect.CrossConnectEventType_DELETE, false, false, false)
 	}()
 
 	g.Expect(ec.Check(ch)).To(BeNil())
@@ -132,9 +132,9 @@ func TestOrEventChecker_FirstSuccess(t *testing.T) {
 	}
 
 	go func() {
-		ch <- newXcon("1", crossconnect.CrossConnectEventType_INITIAL_STATE_TRANSFER, false, false, true)
-		ch <- newXcon("1", crossconnect.CrossConnectEventType_UPDATE, true, true, false)
-		ch <- newXcon("1", crossconnect.CrossConnectEventType_DELETE, false, false, false)
+		ch <- newXcon(crossconnect.CrossConnectEventType_INITIAL_STATE_TRANSFER, false, false, true)
+		ch <- newXcon(crossconnect.CrossConnectEventType_UPDATE, true, true, false)
+		ch <- newXcon(crossconnect.CrossConnectEventType_DELETE, false, false, false)
 	}()
 
 	g.Expect(ec.Check(ch)).To(BeNil())
@@ -178,8 +178,8 @@ func TestOrEventChecker_SecondSuccess(t *testing.T) {
 	}
 
 	go func() {
-		ch <- newXcon("1", crossconnect.CrossConnectEventType_INITIAL_STATE_TRANSFER, true, true, false)
-		ch <- newXcon("1", crossconnect.CrossConnectEventType_UPDATE, true, true, false)
+		ch <- newXcon(crossconnect.CrossConnectEventType_INITIAL_STATE_TRANSFER, true, true, false)
+		ch <- newXcon(crossconnect.CrossConnectEventType_UPDATE, true, true, false)
 	}()
 
 	g.Expect(ec.Check(ch)).To(BeNil())

--- a/test/kubetest/monitor_utils_test.go
+++ b/test/kubetest/monitor_utils_test.go
@@ -1,10 +1,12 @@
 package kubetest
 
 import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+
 	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/crossconnect"
 	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/local/connection"
-	. "github.com/onsi/gomega"
-	"testing"
 )
 
 func newXcon(id string, eventType crossconnect.CrossConnectEventType, srcUp, dstUp, empty bool) *crossconnect.CrossConnectEvent {

--- a/test/kubetest/monitor_utils_test.go
+++ b/test/kubetest/monitor_utils_test.go
@@ -1,0 +1,184 @@
+package kubetest
+
+import (
+	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/crossconnect"
+	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/local/connection"
+	. "github.com/onsi/gomega"
+	"testing"
+)
+
+func newXcon(id string, eventType crossconnect.CrossConnectEventType, srcUp, dstUp, empty bool) *crossconnect.CrossConnectEvent {
+	srcState := connection.State_DOWN
+	if srcUp {
+		srcState = connection.State_UP
+	}
+
+	dstState := connection.State_DOWN
+	if dstUp {
+		dstState = connection.State_UP
+	}
+
+	xcons := map[string]*crossconnect.CrossConnect{}
+	if !empty {
+		xcons = map[string]*crossconnect.CrossConnect{
+			id: {
+				Id: id,
+				Source: &crossconnect.CrossConnect_LocalSource{
+					LocalSource: &connection.Connection{
+						Id:    "1",
+						State: srcState,
+					},
+				},
+				Destination: &crossconnect.CrossConnect_LocalDestination{
+					LocalDestination: &connection.Connection{
+						Id:    "2",
+						State: dstState,
+					},
+				},
+			},
+		}
+	}
+
+	return &crossconnect.CrossConnectEvent{
+		Type:          eventType,
+		CrossConnects: xcons,
+	}
+}
+
+func TestSingleEventChecker(t *testing.T) {
+	g := NewWithT(t)
+
+	ch := make(chan *crossconnect.CrossConnectEvent)
+	ec := &SingleEventChecker{
+		EventType: crossconnect.CrossConnectEventType_INITIAL_STATE_TRANSFER,
+		SrcUp:     true,
+		DstUp:     true,
+	}
+
+	go func() {
+		ch <- newXcon("1", crossconnect.CrossConnectEventType_INITIAL_STATE_TRANSFER, true, true, false)
+	}()
+
+	g.Expect(ec.Check(ch)).To(BeNil())
+}
+
+func TestMultipleEventChecker(t *testing.T) {
+	g := NewWithT(t)
+
+	ch := make(chan *crossconnect.CrossConnectEvent)
+	ec := &MultipleEventChecker{
+		Events: []EventChecker{
+			&SingleEventChecker{
+				EventType: crossconnect.CrossConnectEventType_INITIAL_STATE_TRANSFER,
+				Empty:     true,
+			},
+			&SingleEventChecker{
+				EventType: crossconnect.CrossConnectEventType_UPDATE,
+				SrcUp:     true,
+				DstUp:     true,
+			},
+			&SingleEventChecker{
+				EventType: crossconnect.CrossConnectEventType_DELETE,
+			},
+		},
+	}
+
+	go func() {
+		ch <- newXcon("1", crossconnect.CrossConnectEventType_INITIAL_STATE_TRANSFER, false, false, true)
+		ch <- newXcon("1", crossconnect.CrossConnectEventType_UPDATE, true, true, false)
+		ch <- newXcon("1", crossconnect.CrossConnectEventType_DELETE, false, false, false)
+	}()
+
+	g.Expect(ec.Check(ch)).To(BeNil())
+}
+
+func TestOrEventChecker_FirstSuccess(t *testing.T) {
+	g := NewWithT(t)
+
+	ch := make(chan *crossconnect.CrossConnectEvent)
+	ec := &OrEventChecker{
+		Event1: &MultipleEventChecker{
+			Events: []EventChecker{
+				&SingleEventChecker{
+					EventType: crossconnect.CrossConnectEventType_INITIAL_STATE_TRANSFER,
+					Empty:     true,
+				},
+				&SingleEventChecker{
+					EventType: crossconnect.CrossConnectEventType_UPDATE,
+					SrcUp:     true,
+					DstUp:     true,
+				},
+				&SingleEventChecker{
+					EventType: crossconnect.CrossConnectEventType_DELETE,
+				},
+			},
+		},
+		Event2: &MultipleEventChecker{
+			Events: []EventChecker{
+				&SingleEventChecker{
+					EventType: crossconnect.CrossConnectEventType_INITIAL_STATE_TRANSFER,
+					SrcUp:     true,
+					DstUp:     true,
+				},
+				&SingleEventChecker{
+					EventType: crossconnect.CrossConnectEventType_UPDATE,
+					SrcUp:     true,
+					DstUp:     true,
+				},
+			},
+		},
+	}
+
+	go func() {
+		ch <- newXcon("1", crossconnect.CrossConnectEventType_INITIAL_STATE_TRANSFER, false, false, true)
+		ch <- newXcon("1", crossconnect.CrossConnectEventType_UPDATE, true, true, false)
+		ch <- newXcon("1", crossconnect.CrossConnectEventType_DELETE, false, false, false)
+	}()
+
+	g.Expect(ec.Check(ch)).To(BeNil())
+}
+
+func TestOrEventChecker_SecondSuccess(t *testing.T) {
+	g := NewWithT(t)
+
+	ch := make(chan *crossconnect.CrossConnectEvent)
+	ec := &OrEventChecker{
+		Event1: &MultipleEventChecker{
+			Events: []EventChecker{
+				&SingleEventChecker{
+					EventType: crossconnect.CrossConnectEventType_INITIAL_STATE_TRANSFER,
+					Empty:     true,
+				},
+				&SingleEventChecker{
+					EventType: crossconnect.CrossConnectEventType_UPDATE,
+					SrcUp:     true,
+					DstUp:     true,
+				},
+				&SingleEventChecker{
+					EventType: crossconnect.CrossConnectEventType_DELETE,
+				},
+			},
+		},
+		Event2: &MultipleEventChecker{
+			Events: []EventChecker{
+				&SingleEventChecker{
+					EventType: crossconnect.CrossConnectEventType_INITIAL_STATE_TRANSFER,
+					SrcUp:     true,
+					DstUp:     true,
+				},
+				&SingleEventChecker{
+					EventType: crossconnect.CrossConnectEventType_UPDATE,
+					SrcUp:     true,
+					DstUp:     true,
+				},
+			},
+		},
+	}
+
+	go func() {
+		ch <- newXcon("1", crossconnect.CrossConnectEventType_INITIAL_STATE_TRANSFER, true, true, false)
+		ch <- newXcon("1", crossconnect.CrossConnectEventType_UPDATE, true, true, false)
+	}()
+
+	g.Expect(ec.Check(ch)).To(BeNil())
+}


### PR DESCRIPTION
Signed-off-by: lobkovilya <ilya.lobkov@xored.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add new types of EventCheckers

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
There are bunch of tests that checks events from CrossConnectMonitor. Checker waits for `INITIAL_STATE_TRANSFER` with single crossconnect. But there is no guarantee that `INITIAL_STATE_TRANSFER` will be empty and we will see crossconnect only in the following `UPDATE` event. That situation reproduces in #1380, probably because of increasing delays. 

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [ ] Covered by existing integration testing
- [ ] Added integration testing to cover
- [ ] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
