### PR TITLE
Stabilize fanout tests

### DIFF
--- a/k8s/cmd/nsm-coredns/plugin/fanout/health_test.go
+++ b/k8s/cmd/nsm-coredns/plugin/fanout/health_test.go
@@ -22,7 +22,7 @@ func TestHealth(t *testing.T) {
 		ret := new(dns.Msg)
 		ret.SetReply(r)
 		w.WriteMsg(ret)
-	}, ".")
+	})
 	defer s.close()
 	<-time.After(time.Second)
 	p := createDNSClient(s.Addr, transport.DNS)
@@ -67,7 +67,7 @@ func TestHealthFailTwice(t *testing.T) {
 		ret := new(dns.Msg)
 		ret.SetReply(r)
 		w.WriteMsg(ret)
-	}, ".")
+	})
 	defer s.close()
 
 	p := createDNSClient(s.Addr, transport.DNS)
@@ -97,7 +97,7 @@ func TestHealthNoMaxFails(t *testing.T) {
 			ret.SetReply(r)
 			w.WriteMsg(ret)
 		}
-	}, ".")
+	})
 	defer s.close()
 
 	p := createDNSClient(s.Addr, transport.DNS)

--- a/k8s/cmd/nsm-coredns/plugin/fanout/persistent_test.go
+++ b/k8s/cmd/nsm-coredns/plugin/fanout/persistent_test.go
@@ -43,7 +43,7 @@ func TestCleanupByTimer(t *testing.T) {
 		ret := new(dns.Msg)
 		ret.SetReply(r)
 		w.WriteMsg(ret)
-	}, ".")
+	})
 	defer s.close()
 
 	tr := newTransport(s.Addr)
@@ -77,7 +77,7 @@ func TestPartialCleanup(t *testing.T) {
 		ret := new(dns.Msg)
 		ret.SetReply(r)
 		w.WriteMsg(ret)
-	}, ".")
+	})
 	defer s.close()
 
 	tr := newTransport(s.Addr)


### PR DESCRIPTION
Signed-off-by: denis-tingajkin <denis.tingajkin@xored.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
The fanout tests wich using more then one DNS can fails. 
Root cause: used dns.HandleFunc() which should be used only for tests with one DNS server.
This PR fixed the problem

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [X] Covered by existing integration testing
- [ ] Added integration testing to cover
- [X] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
