### PR TITLE
Cloud testing fixes

### DIFF
--- a/test/cloudtest/pkg/commands/main.go
+++ b/test/cloudtest/pkg/commands/main.go
@@ -376,7 +376,7 @@ func statusName(status model.Status) interface{} {
 	case model.StatusAdded:
 		return "added"
 	case model.StatusFailed:
-		return "failsed"
+		return "failed"
 	case model.StatusSkipped:
 		return "skipped"
 	case model.StatusSuccess:
@@ -681,11 +681,12 @@ func (ctx *executionContext) startCluster(ci *clusterInstance) {
 	defer ci.lock.Unlock()
 
 	if ci.state != clusterAdded && ci.state != clusterCrashed {
-		// Cluster is already starting.
+		// no need to start
 		return
 	}
 
 	if ci.startCount > ci.group.config.RetryCount {
+		logrus.Infof("Marking cluster %v as not available attempts reached: %v", ci.id, ci.group.config.RetryCount )
 		ci.state = clusterNotAvailable
 		return
 	}
@@ -705,9 +706,6 @@ func (ctx *executionContext) startCluster(ci *clusterInstance) {
 			execution.errMsg = err
 			execution.status = clusterCrashed
 			ctx.destroyCluster(ci, true, false)
-			ctx.setClusterState(ci, func(ci *clusterInstance) {
-				ci.state = clusterCrashed
-			})
 		} else {
 			execution.status = clusterReady
 		}

--- a/test/cloudtest/pkg/commands/main.go
+++ b/test/cloudtest/pkg/commands/main.go
@@ -338,7 +338,7 @@ func (ctx *executionContext) processTaskUpdate(event operationEvent) {
 	// Make cluster as ready
 	for _, inst := range event.task.clusterInstances {
 		ctx.setClusterState(inst, func(inst *clusterInstance) {
-			if inst.state != clusterCrashed {
+			if inst.state == clusterBusy {
 				inst.state = clusterReady
 			}
 			inst.taskCancel = nil

--- a/test/cloudtest/pkg/commands/main.go
+++ b/test/cloudtest/pkg/commands/main.go
@@ -686,7 +686,7 @@ func (ctx *executionContext) startCluster(ci *clusterInstance) {
 	}
 
 	if ci.startCount > ci.group.config.RetryCount {
-		logrus.Infof("Marking cluster %v as not available attempts reached: %v", ci.id, ci.group.config.RetryCount )
+		logrus.Infof("Marking cluster %v as not available attempts reached: %v", ci.id, ci.group.config.RetryCount)
 		ci.state = clusterNotAvailable
 		return
 	}

--- a/test/cloudtest/pkg/commands/main.go
+++ b/test/cloudtest/pkg/commands/main.go
@@ -574,11 +574,11 @@ func (ctx *executionContext) startTask(task *testTask, instances []*clusterInsta
 		return fmt.Errorf("invalid task runner")
 	}
 
-	ctx.execiteTask(task, clusterConfigs, file, ids, runner, timeout, instances, err, fileName)
+	ctx.executeTask(task, clusterConfigs, file, ids, runner, timeout, instances, err, fileName)
 	return nil
 }
 
-func (ctx *executionContext) execiteTask(task *testTask, clusterConfigs []string, file io.Writer, ids string, runner runners.TestRunner, timeout int64, instances []*clusterInstance, err error, fileName string) {
+func (ctx *executionContext) executeTask(task *testTask, clusterConfigs []string, file io.Writer, ids string, runner runners.TestRunner, timeout int64, instances []*clusterInstance, err error, fileName string) {
 	go func() {
 		st := time.Now()
 		env := []string{}
@@ -639,7 +639,7 @@ func (ctx *executionContext) execiteTask(task *testTask, clusterConfigs []string
 				}
 				inst.taskCancel = nil
 			}
-			if timeoutCtx.Err() == context.Canceled && clusterNotAvailable {
+			if clusterNotAvailable {
 				logrus.Errorf("Test is canceled due timeout and cluster error.. Will be re-run")
 				ctx.updateTestExecution(task, fileName, model.StatusTimeout)
 			} else {

--- a/test/cloudtest/pkg/k8s/validator.go
+++ b/test/cloudtest/pkg/k8s/validator.go
@@ -73,7 +73,7 @@ func (v *k8sValidator) Validate() error {
 	if ready >= requiedNodes {
 		return nil
 	}
-	msg := fmt.Sprintf("Cluster doesn't have required number of nodes to be available. Required: %v Available: %v\n", requiedNodes, len(nodes))
+	msg := fmt.Sprintf("Cluster doesn't have required number of nodes to be available. Required: %v Available: %v\n", requiedNodes, ready)
 	err = fmt.Errorf(msg)
 	return err
 }

--- a/test/cloudtest/pkg/tests/sample/sample_interdomain_test.go
+++ b/test/cloudtest/pkg/tests/sample/sample_interdomain_test.go
@@ -11,8 +11,7 @@ import (
 )
 
 func TestInterDomainPass(t *testing.T) {
-	g := NewWithT(t)
-
+	NewWithT(t)
 	logrus.Infof("Passed test")
 }
 

--- a/test/cloudtest/pkg/tests/sample/sample_tagged_test.go
+++ b/test/cloudtest/pkg/tests/sample/sample_tagged_test.go
@@ -11,8 +11,7 @@ import (
 )
 
 func TestPassTag(t *testing.T) {
-	g := NewWithT(t)
-
+	NewWithT(t)
 	logrus.Infof("Passed test")
 }
 
@@ -25,7 +24,7 @@ func TestFailTag(t *testing.T) {
 }
 
 func TestTimeoutTag(t *testing.T) {
-	g := NewWithT(t)
+	NewWithT(t)
 
 	logrus.Infof("test timeout for 5 seconds")
 	<-time.After(5 * time.Second)

--- a/test/kubetest/k8s.go
+++ b/test/kubetest/k8s.go
@@ -274,6 +274,10 @@ type K8s struct {
 func NewK8s(g *WithT, prepare bool) (*K8s, error) {
 
 	client, err := NewK8sWithoutRoles(g, prepare)
+	if client == nil {
+		logrus.Errorf("Error Creating K8s %v", err)
+		return client, err
+	}
 	client.roles, _ = client.CreateRoles("admin", "view", "binding")
 	return client, err
 }
@@ -366,6 +370,7 @@ func (k8s *K8s) initNamespace() {
 	nsmNamespace := namespace.GetNamespace()
 	k8s.namespace, err = k8s.CreateTestNamespace(nsmNamespace)
 	if err != nil {
+		logrus.Errorf("Error during create of test namespace %v", err)
 		k8s.checkAPIServerAvailable()
 	}
 	k8s.g.Expect(err).To(BeNil())


### PR DESCRIPTION
Cloud testing fixes to make test failures in case of cluster failed more informative

Signed-off-by: Andrey Sobolev <haiodo@xored.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
Cloud testing tool should write a proper information about number of available nodes.

+ few fixes to prevent test to crash, they should fail instead of it.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [x] Covered by existing integration testing
- [x] Added integration testing to cover
- [ ] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
