### PR TITLE
Introduce `make helm-init`

### DIFF
--- a/.cloudtest/aws.yaml
+++ b/.cloudtest/aws.yaml
@@ -26,8 +26,4 @@ providers:
       stop: |
         make aws-destroy
       prepare: |
-        make k8s-config
-        helm init --wait
-        kubectl create serviceaccount --namespace kube-system tiller
-        kubectl create clusterrolebinding tiller-cluster-rule --clusterrole=cluster-admin --serviceaccount=kube-system:tiller
-        kubectl patch deploy --namespace kube-system tiller-deploy -p "{\"spec\":{\"template\":{\"spec\":{\"serviceAccount\":\"tiller\"}}}}"
+        make k8s-config helm-init

--- a/.cloudtest/azure.yaml
+++ b/.cloudtest/azure.yaml
@@ -28,8 +28,4 @@ providers:
         make azure-start
       stop: make azure-destroy
       prepare: |
-        make k8s-config
-        helm init --wait
-        kubectl create serviceaccount --namespace kube-system tiller
-        kubectl create clusterrolebinding tiller-cluster-rule --clusterrole=cluster-admin --serviceaccount=kube-system:tiller
-        kubectl patch deploy --namespace kube-system tiller-deploy -p "{\"spec\":{\"template\":{\"spec\":{\"serviceAccount\":\"tiller\"}}}}"
+        make k8s-config helm-init

--- a/.cloudtest/gke.yaml
+++ b/.cloudtest/gke.yaml
@@ -29,8 +29,4 @@ providers:
       stop: make gke-destroy
       #config: # We do not need it since we put KUBECONFIG into env.
       prepare: |
-        make k8s-config
-        helm init --wait
-        kubectl create serviceaccount --namespace kube-system tiller
-        kubectl create clusterrolebinding tiller-cluster-rule --clusterrole=cluster-admin --serviceaccount=kube-system:tiller
-        kubectl patch deploy --namespace kube-system tiller-deploy -p "{\"spec\":{\"template\":{\"spec\":{\"serviceAccount\":\"tiller\"}}}}"
+        make k8s-config helm-init

--- a/.cloudtest/packet.yaml
+++ b/.cloudtest/packet.yaml
@@ -41,8 +41,4 @@ providers:
         ssh-add $(tempdir)/sshkey
       start: ./.cloudtest/packet/create-kubernetes-cluster.sh $(device.Master.pub.ip.4) $(device.Worker.pub.ip.4)
       prepare: |
-        make k8s-config
-        helm init --wait
-        kubectl create serviceaccount --namespace kube-system tiller
-        kubectl create clusterrolebinding tiller-cluster-rule --clusterrole=cluster-admin --serviceaccount=kube-system:tiller
-        kubectl patch deploy --namespace kube-system tiller-deploy -p "{\"spec\":{\"template\":{\"spec\":{\"serviceAccount\":\"tiller\"}}}}"
+        make k8s-config helm-init

--- a/deployments/helm/nsm/templates/crd-networkserviceendpoints.yaml
+++ b/deployments/helm/nsm/templates/crd-networkserviceendpoints.yaml
@@ -15,7 +15,7 @@ spec:
       - nse
       - nses
     singular: networkserviceendpoint
-  scope: Cluster
+  scope: Namespaced
   version: v1alpha1
   versions:
     - name: v1alpha1

--- a/deployments/helm/nsm/templates/crd-networkservicemanagers.yaml
+++ b/deployments/helm/nsm/templates/crd-networkservicemanagers.yaml
@@ -15,7 +15,7 @@ spec:
       - nsm
       - nsms
     singular: networkservicemanager
-  scope: Cluster
+  scope: Namespaced
   version: v1alpha1
   versions:
     - name: v1alpha1

--- a/deployments/helm/nsm/templates/crd-networkservices.yaml
+++ b/deployments/helm/nsm/templates/crd-networkservices.yaml
@@ -15,7 +15,7 @@ spec:
       - netsvc
       - netsvcs
     singular: networkservice
-  scope: Cluster
+  scope: Namespaced
   version: v1alpha1
   versions:
     - name: v1alpha1

--- a/docs/guide-helm.md
+++ b/docs/guide-helm.md
@@ -59,4 +59,6 @@ tag: master
 
 ## Makefile integration
 
-For developers' and testing convenience, we have added a number of make targets to support helm chart deployments. They are in the form `helm-install-<chart>` and `helm-delete-<chart>`. For example a basic NSM infra installation can be achieved by issuing `make helm-install-nsm` in the root folder. It will use the default values except for `org` and `tag` which can be overwritten by setting `CONTAINER_REPO` (defaults to `networkservicemesh`) and `CONTAINER_TAG` (defaults to `latest`). The defaults allow for easy local development. Cleaning up is also ease with the `make helm-delete-nsm` command.
+For developers' and testing convenience, we have added a number of make targets to support helm chart deployments.
+Initialisation of Helm, including the creation fo the service account for tiler is wrappen in `make helm-init`.
+The targets to deploy software are in the form `helm-install-<chart>` and `helm-delete-<chart>`. For example a basic NSM infra installation can be achieved by issuing `make helm-install-nsm` in the root folder. It will use the default values except for `org` and `tag` which can be overwritten by setting `CONTAINER_REPO` (defaults to `networkservicemesh`) and `CONTAINER_TAG` (defaults to `latest`). The defaults allow for easy local development. Cleaning up is also easy with the `make helm-delete-nsm` command.


### PR DESCRIPTION
Signed-off-by: Nikolay Nikolaev <nnikolay@vmware.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
Add a unified `helm-init` make target to assist in deploying helm to the cluster where NSM is to be installed with the helm chart.

## Motivation and Context
Have a convenient and unified way of initialising helm in the work cluster.

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [x] Covered by existing integration testing
- [ ] Added integration testing to cover
- [x] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
