### PR TITLE
Fix wait for Example-helm-icmp

### DIFF
--- a/.cloudtest.yaml
+++ b/.cloudtest.yaml
@@ -56,6 +56,7 @@ executions:
       make k8s-logs-snapshot
       make k8s-delete
     on_fail: |
+      kubectl get pod -o=custom-columns=NAME:.metadata.name,STATUS:.status.phase,NODE:.spec.nodeName --all-namespaces
       make k8s-logs-snapshot
       make k8s-delete
   - name: "Example-vpn"
@@ -76,6 +77,7 @@ executions:
       make k8s-logs-snapshot
       make k8s-delete
     on_fail: |
+      kubectl get pod -o=custom-columns=NAME:.metadata.name,STATUS:.status.phase,NODE:.spec.nodeName --all-namespaces
       make k8s-logs-snapshot
       make k8s-delete
   - name: "Example-helm-icmp"
@@ -93,5 +95,6 @@ executions:
       make k8s-logs-snapshot
       make helm-delete-icmp-responder helm-delete-nsm
     on_fail: |
+      kubectl get pod -o=custom-columns=NAME:.metadata.name,STATUS:.status.phase,NODE:.spec.nodeName --all-namespaces
       make k8s-logs-snapshot
       make helm-delete-icmp-responder helm-delete-nsm

--- a/.cloudtest.yaml
+++ b/.cloudtest.yaml
@@ -88,7 +88,7 @@ executions:
     run: |
       make k8s-deconfig helm-install-nsm
       make helm-install-icmp-responder
-      kubectl wait --all-namespaces --timeout=300s --for condition=Ready --all pods
+      kubectl wait -n ${NSM_NAMESPACE} --timeout=150s --for condition=Ready --all pods
       make k8s-check
       make k8s-logs-snapshot
       make helm-delete-icmp-responder helm-delete-nsm

--- a/test/cloudtest/pkg/runners/shelltest_runner.go
+++ b/test/cloudtest/pkg/runners/shelltest_runner.go
@@ -26,7 +26,8 @@ type shellTestRunner struct {
 func (runner *shellTestRunner) Run(timeoutCtx context.Context, env []string, writer *bufio.Writer) error {
 	runErr := runner.runCmd(timeoutCtx, utils.ParseScript(runner.test.RunScript), env, writer)
 	if runErr != nil {
-		onFailContext, _ := context.WithTimeout(context.Background(), onFailDefaultTimeout)
+		onFailContext, cancel := context.WithTimeout(context.Background(), onFailDefaultTimeout)
+		defer cancel()
 		onFailErr := runner.runCmd(onFailContext, utils.ParseScript(runner.test.OnFailScript), env, writer)
 		return errtools.Combine(runErr, onFailErr)
 	}

--- a/test/cloudtest/pkg/runners/shelltest_runner.go
+++ b/test/cloudtest/pkg/runners/shelltest_runner.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/networkservicemesh/networkservicemesh/utils/helper/errtools"
 
@@ -13,6 +14,8 @@ import (
 	"github.com/networkservicemesh/networkservicemesh/test/cloudtest/pkg/shell"
 	"github.com/networkservicemesh/networkservicemesh/test/cloudtest/pkg/utils"
 )
+
+const onFailDefaultTimeout = time.Minute * 3
 
 type shellTestRunner struct {
 	test   *model.TestEntry
@@ -23,7 +26,8 @@ type shellTestRunner struct {
 func (runner *shellTestRunner) Run(timeoutCtx context.Context, env []string, writer *bufio.Writer) error {
 	runErr := runner.runCmd(timeoutCtx, utils.ParseScript(runner.test.RunScript), env, writer)
 	if runErr != nil {
-		onFailErr := runner.runCmd(timeoutCtx, utils.ParseScript(runner.test.OnFailScript), env, writer)
+		onFailContext, _ := context.WithTimeout(context.Background(), onFailDefaultTimeout)
+		onFailErr := runner.runCmd(onFailContext, utils.ParseScript(runner.test.OnFailScript), env, writer)
 		return errtools.Combine(runErr, onFailErr)
 	}
 	return nil


### PR DESCRIPTION
Signed-off-by: denis-tingajkin <denis.tingajkin@xored.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
Example-helm-icmp waits for all pods in all namespaces. It might be a reason for failing tests on CI as by the link bellow. We should use `kubectl wait` onl y for current namespace.
 
## Motivation and Context
https://circleci.com/gh/networkservicemesh/networkservicemesh/88010

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [ ] Covered by existing integration testing
- [ ] Added integration testing to cover
- [ ] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
