### PR TITLE
Downgrade version of linter to 1.16.0 to reduce resource class of linter job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,6 +50,7 @@ jobs:
 
 # code analysis
   test-static-code-analysis:
+    resource_class: medium+
     docker:
       - image: circleci/golang:1.12-stretch
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,6 @@ jobs:
 
 # code analysis
   test-static-code-analysis:
-    resource_class: xlarge
     docker:
       - image: circleci/golang:1.12-stretch
     steps:

--- a/.mk/code_analysis.mk
+++ b/.mk/code_analysis.mk
@@ -4,7 +4,7 @@ lint-fix:
 
 .PHONY: lint-install
 lint-install:
-	GO111MODULE=on go get -u github.com/golangci/golangci-lint/cmd/golangci-lint@v1.17.1
+	GO111MODULE=on go get -u github.com/golangci/golangci-lint/cmd/golangci-lint@v1.16.0
 
 .PHONY: lint-check-diff
 lint-check-diff:

--- a/scripts/lint-download.sh
+++ b/scripts/lint-download.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
-
+version=1.16.0
 {
-    wget -O - -q https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- v1.17.1
+    wget -O - -q https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- v${version}
     sudo cp ./bin/golangci-lint "$(go env GOPATH)"/bin/
 } || {
-    wget -O - -q https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- v1.17.1
+    wget -O - -q https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- v${version}
     sudo cp ./bin/golangci-lint "$(go env GOPATH)"/bin/
 } || {
     make lint-install


### PR DESCRIPTION
Signed-off-by: denis-tingajkin <denis.tingajkin@xored.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
Last version of golang-ci linter has memory management problems, for example:
1) https://github.com/golangci/golangci-lint/issues/634
2) https://github.com/golangci/golangci-lint/issues/628

Resource class of current linter job (xlarge) takes much resources. It could affect to the containers builds.


## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [ ] Covered by existing integration testing
- [ ] Added integration testing to cover
- [ ] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
