### PR TITLE
Fix cloudtest to run tests on multiple clusters

### DIFF
--- a/test/cloudtest/pkg/model/tests.go
+++ b/test/cloudtest/pkg/model/tests.go
@@ -51,6 +51,7 @@ const (
 type TestEntry struct {
 	Name            string // Test name
 	Tags            string // A list of tags
+	Key             string // Unique key
 	ExecutionConfig *config.ExecutionConfig
 
 	Executions []TestEntryExecution


### PR DESCRIPTION
Signed-off-by: Artem Belov <artem.belov@xored.com>

## Description
Keep order of tests clusters from configuration file
Add clusters names to keys of tests map.

## Motivation and Context

Some tests are skipped because of duplicating of tests names for one cluster. (#1480)

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [x] Covered by existing integration testing
- [ ] Added integration testing to cover
- [x] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

Tested on integration tests:
https://circleci.com/gh/networkservicemesh/networkservicemesh/89208

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
