### PR TITLE
Cleanup crds after cloudtest examples

### DIFF
--- a/.cloudtest.yaml
+++ b/.cloudtest.yaml
@@ -55,10 +55,12 @@ executions:
       make k8s-check
       make k8s-logs-snapshot
       make k8s-delete
+      make k8s-deconfig k8s-config
     on_fail: |
       kubectl get pod -o=custom-columns=NAME:.metadata.name,STATUS:.status.phase,NODE:.spec.nodeName --all-namespaces
       make k8s-logs-snapshot
       make k8s-delete
+      make k8s-deconfig k8s-config
   - name: "Example-vpn"
     kind: shell
     env:
@@ -76,10 +78,12 @@ executions:
       make k8s-check
       make k8s-logs-snapshot
       make k8s-delete
+      make k8s-deconfig k8s-config
     on_fail: |
       kubectl get pod -o=custom-columns=NAME:.metadata.name,STATUS:.status.phase,NODE:.spec.nodeName --all-namespaces
       make k8s-logs-snapshot
       make k8s-delete
+      make k8s-deconfig k8s-config
   - name: "Example-helm-icmp"
     kind: shell
     env:
@@ -94,7 +98,9 @@ executions:
       make k8s-check
       make k8s-logs-snapshot
       make helm-delete-icmp-responder helm-delete-nsm
+      make k8s-deconfig k8s-config
     on_fail: |
       kubectl get pod -o=custom-columns=NAME:.metadata.name,STATUS:.status.phase,NODE:.spec.nodeName --all-namespaces
       make k8s-logs-snapshot
       make helm-delete-icmp-responder helm-delete-nsm
+      make k8s-deconfig k8s-config


### PR DESCRIPTION
Signed-off-by: Artem Belov <artem.belov@xored.com>

## Description
Cleanup Custom Resources after cloudtest examples to avoid affecting on integration tests.

## Motivation and Context
Examples tests break all next integration tests

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [x] Covered by existing integration testing
- [ ] Added integration testing to cover
- [x] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
