### PR TITLE
Fix concurrent access to Connection structure

### DIFF
--- a/controlplane/pkg/apis/plugins/connection_plugin_helpers.go
+++ b/controlplane/pkg/apis/plugins/connection_plugin_helpers.go
@@ -1,6 +1,8 @@
 package plugins
 
 import (
+	"github.com/golang/protobuf/proto"
+
 	local "github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/local/connection"
 	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/nsm/connection"
 	remote "github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/remote/connection"
@@ -32,4 +34,9 @@ func (w *ConnectionWrapper) SetConnection(conn connection.Connection) {
 			LocalConnection: conn.(*local.Connection),
 		}
 	}
+}
+
+// Clone clones wrapper with connection
+func (w *ConnectionWrapper) Clone() *ConnectionWrapper {
+	return proto.Clone(w).(*ConnectionWrapper)
 }

--- a/controlplane/pkg/nsm/nsm.go
+++ b/controlplane/pkg/nsm/nsm.go
@@ -534,7 +534,7 @@ func (srv *networkServiceManager) updateConnection(ctx context.Context, conn con
 		return conn, err
 	}
 
-	return wrapper.GetConnection(), nil
+	return wrapper.GetConnection().Clone(), nil
 }
 
 func (srv *networkServiceManager) updateConnectionContext(ctx context.Context, source, destination connection.Connection) error {

--- a/controlplane/pkg/nsm/nsm.go
+++ b/controlplane/pkg/nsm/nsm.go
@@ -534,7 +534,7 @@ func (srv *networkServiceManager) updateConnection(ctx context.Context, conn con
 		return conn, err
 	}
 
-	return wrapper.GetConnection().Clone(), nil
+	return wrapper.GetConnection(), nil
 }
 
 func (srv *networkServiceManager) updateConnectionContext(ctx context.Context, source, destination connection.Connection) error {

--- a/controlplane/pkg/plugins/connection_plugin.go
+++ b/controlplane/pkg/plugins/connection_plugin.go
@@ -64,7 +64,7 @@ func (cpm *connectionPluginManager) UpdateConnection(ctx context.Context, wrappe
 			return nil, fmt.Errorf("'%s' connection plugin returned an error: %v", name, err)
 		}
 	}
-	return wrapper, nil
+	return wrapper.Clone(), nil
 }
 
 func (cpm *connectionPluginManager) ValidateConnection(ctx context.Context, wrapper *plugins.ConnectionWrapper) (*plugins.ConnectionValidationResult, error) {


### PR DESCRIPTION
Signed-off-by: Artem Belov <artem.belov@xored.com>

## Description
Jaeger client iterating Connection structure at the same time when we are trying to change it, so we need to make a deep copy before using it.

## Motivation and Context
Failed tests in a few open pull requests:
https://90920-127937836-gh.circle-artifacts.com/0/home/circleci/project/.tests/cloud_test/gke-2_packet-1/logs/TestInterdomainVPNNSCRemote/nsmgr-gke-gke-2-2019-8-20-9092-default-pool-70c83abb-7027%3Ansmd-previous.log

The same issue with another request: #901

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [x] Covered by existing integration testing
- [ ] Added integration testing to cover
- [ ] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
