### PR TITLE
Clear old mechanism configuration before update

### DIFF
--- a/dataplane/vppagent/pkg/converter/cross_connect_converter.go
+++ b/dataplane/vppagent/pkg/converter/cross_connect_converter.go
@@ -105,17 +105,18 @@ func (c *CrossConnectConverter) MechanismsToDataRequest(rv *configurator.Config,
 
 	srcName := srcPrefix + c.GetId()
 
+	var err error
 	if c.GetRemoteSource() != nil {
-		rv, err := NewRemoteConnectionConverter(c.GetRemoteSource(), srcName, SOURCE).ToDataRequest(rv, connect)
+		rv, err = NewRemoteConnectionConverter(c.GetRemoteSource(), srcName, SOURCE).ToDataRequest(rv, connect)
 		if err != nil {
-			return rv, fmt.Errorf("Error Converting CrossConnect %v: %s", c, err)
+			return rv, fmt.Errorf("error Converting CrossConnect %v: %s", c, err)
 		}
 	}
 
 	if c.GetRemoteDestination() != nil {
-		rv, err := NewRemoteConnectionConverter(c.GetRemoteDestination(), "DST-"+c.GetId(), DESTINATION).ToDataRequest(rv, connect)
+		rv, err = NewRemoteConnectionConverter(c.GetRemoteDestination(), "DST-"+c.GetId(), DESTINATION).ToDataRequest(rv, connect)
 		if err != nil {
-			return rv, fmt.Errorf("Error Converting CrossConnect %v: %s", c, err)
+			return rv, fmt.Errorf("error Converting CrossConnect %v: %s", c, err)
 		}
 	}
 

--- a/dataplane/vppagent/pkg/converter/cross_connect_converter.go
+++ b/dataplane/vppagent/pkg/converter/cross_connect_converter.go
@@ -11,6 +11,11 @@ import (
 	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/apis/crossconnect"
 )
 
+const (
+	srcPrefix = "SRC-"
+	dstPrefix = "DST-"
+)
+
 type CrossConnectConverter struct {
 	*crossconnect.CrossConnect
 	conversionParameters *CrossConnectConversionParameters
@@ -36,8 +41,9 @@ func (c *CrossConnectConverter) ToDataRequest(rv *configurator.Config, connect b
 	if rv.VppConfig == nil {
 		rv.VppConfig = &vpp.ConfigData{}
 	}
-	srcName := "SRC-" + c.GetId()
-	dstName := "DST-" + c.GetId()
+
+	srcName := srcPrefix + c.GetId()
+	dstName := dstPrefix + c.GetId()
 
 	if c.GetLocalSource() != nil {
 		baseDir := path.Join(c.conversionParameters.BaseDir, c.GetLocalSource().GetMechanism().GetWorkspace())
@@ -48,13 +54,6 @@ func (c *CrossConnectConverter) ToDataRequest(rv *configurator.Config, connect b
 			BaseDir:   baseDir,
 		}
 		rv, err := NewLocalConnectionConverter(c.GetLocalSource(), conversionParameters).ToDataRequest(rv, connect)
-		if err != nil {
-			return rv, fmt.Errorf("Error Converting CrossConnect %v: %s", c, err)
-		}
-	}
-
-	if c.GetRemoteSource() != nil {
-		rv, err := NewRemoteConnectionConverter(c.GetRemoteSource(), srcName, SOURCE).ToDataRequest(rv, connect)
 		if err != nil {
 			return rv, fmt.Errorf("Error Converting CrossConnect %v: %s", c, err)
 		}
@@ -74,15 +73,13 @@ func (c *CrossConnectConverter) ToDataRequest(rv *configurator.Config, connect b
 		}
 	}
 
-	if c.GetRemoteDestination() != nil {
-		rv, err := NewRemoteConnectionConverter(c.GetRemoteDestination(), "DST-"+c.GetId(), DESTINATION).ToDataRequest(rv, connect)
-		if err != nil {
-			return rv, fmt.Errorf("Error Converting CrossConnect %v: %s", c, err)
-		}
+	rv, err := c.MechanismsToDataRequest(rv, connect)
+	if err != nil {
+		return rv, err
 	}
 
 	if len(rv.VppConfig.Interfaces) < 2 {
-		return nil, fmt.Errorf("Did not create enough interfaces to cross connect, expected at least 2, got %d", len(rv.VppConfig.Interfaces))
+		return nil, fmt.Errorf("did not create enough interfaces to cross connect, expected at least 2, got %d", len(rv.VppConfig.Interfaces))
 	}
 	ifaces := rv.VppConfig.Interfaces[len(rv.VppConfig.Interfaces)-2:]
 	rv.VppConfig.XconnectPairs = append(rv.VppConfig.XconnectPairs, &vpp_l2.XConnectPair{
@@ -93,6 +90,34 @@ func (c *CrossConnectConverter) ToDataRequest(rv *configurator.Config, connect b
 		ReceiveInterface:  ifaces[1].Name,
 		TransmitInterface: ifaces[0].Name,
 	})
+
+	return rv, nil
+}
+
+// MechanismsToDataRequest prepares data change with mechanisms parameters for vppagent
+func (c *CrossConnectConverter) MechanismsToDataRequest(rv *configurator.Config, connect bool) (*configurator.Config, error) {
+	if rv == nil {
+		rv = &configurator.Config{}
+	}
+	if rv.VppConfig == nil {
+		rv.VppConfig = &vpp.ConfigData{}
+	}
+
+	srcName := srcPrefix + c.GetId()
+
+	if c.GetRemoteSource() != nil {
+		rv, err := NewRemoteConnectionConverter(c.GetRemoteSource(), srcName, SOURCE).ToDataRequest(rv, connect)
+		if err != nil {
+			return rv, fmt.Errorf("Error Converting CrossConnect %v: %s", c, err)
+		}
+	}
+
+	if c.GetRemoteDestination() != nil {
+		rv, err := NewRemoteConnectionConverter(c.GetRemoteDestination(), "DST-"+c.GetId(), DESTINATION).ToDataRequest(rv, connect)
+		if err != nil {
+			return rv, fmt.Errorf("Error Converting CrossConnect %v: %s", c, err)
+		}
+	}
 
 	return rv, nil
 }

--- a/dataplane/vppagent/pkg/vppagent/vppagent.go
+++ b/dataplane/vppagent/pkg/vppagent/vppagent.go
@@ -125,7 +125,7 @@ func (v *VPPAgent) connectOrDisconnect(ctx context.Context, crossConnect *crossc
 	if connect {
 		entity := v.common.Monitor.Entities()[crossConnect.GetId()]
 		if entity != nil {
-			clearDataChange, cErr := converter.NewCrossConnectConverter(crossConnect, conversionParameters).MechanismsToDataRequest(nil, false)
+			clearDataChange, cErr := converter.NewCrossConnectConverter(entity.(*crossconnect.CrossConnect), conversionParameters).MechanismsToDataRequest(nil, false)
 			if cErr == nil && clearDataChange != nil {
 				logrus.Infof("Sending clearing DataChange to vppagent: %v", proto.MarshalTextString(clearDataChange))
 				_, cErr = client.Delete(ctx, &configurator.DeleteRequest{Delete: clearDataChange})

--- a/dataplane/vppagent/pkg/vppagent/vppagent.go
+++ b/dataplane/vppagent/pkg/vppagent/vppagent.go
@@ -121,6 +121,21 @@ func (v *VPPAgent) connectOrDisconnect(ctx context.Context, crossConnect *crossc
 		logrus.Error(err)
 		return nil, err
 	}
+
+	if connect {
+		entity := v.common.Monitor.Entities()[crossConnect.GetId()]
+		if entity != nil {
+			clearDataChange, cErr := converter.NewCrossConnectConverter(crossConnect, conversionParameters).MechanismsToDataRequest(nil, false)
+			if cErr == nil && clearDataChange != nil {
+				logrus.Infof("Sending clearing DataChange to vppagent: %v", proto.MarshalTextString(clearDataChange))
+				_, cErr = client.Delete(ctx, &configurator.DeleteRequest{Delete: clearDataChange})
+			}
+			if cErr != nil {
+				logrus.Warnf("Connection Mechanism was not cleared properly before updating: %s", cErr.Error())
+			}
+		}
+	}
+
 	logrus.Infof("Sending DataChange to vppagent: %v", proto.MarshalTextString(dataChange))
 	if connect {
 		_, err = client.Update(ctx, &configurator.UpdateRequest{Update: dataChange})


### PR DESCRIPTION
Signed-off-by: Artem Belov <artem.belov@xored.com>

## Description
Clear old mechanism configuration before updating connection
Taps should not be touched

## Motivation and Context
SRv6 mechanism will add new segments list to policy instead if update:
```
[0].-    BSID: fd25::1:2
    Behavior: Encapsulation
    Type: Default
    FIB table: 0
    Segment Lists:
      [0].- < fe80::a00:27ff:fec6:ca82, fd25::1:3 > weight: 0S
      [1].- < fe80::a00:27ff:fec6:ca82, fd25::1:5 > weight: 0
```
Also old mechanism configuration may not be cleared if changing remote mechanism

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [x] Covered by existing integration testing
- [ ] Added integration testing to cover
- [x] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
