### PR TITLE
Clear k8s namespaces on failed tests

### DIFF
--- a/test/cloudtest/pkg/runners/gotest_runner.go
+++ b/test/cloudtest/pkg/runners/gotest_runner.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/prometheus/common/log"
+
 	"github.com/networkservicemesh/networkservicemesh/test/cloudtest/pkg/model"
 	"github.com/networkservicemesh/networkservicemesh/test/cloudtest/pkg/shell"
 	"github.com/networkservicemesh/networkservicemesh/test/cloudtest/pkg/utils"
@@ -76,7 +78,7 @@ func cleanupCreatedNamespaces(env []string, writer *bufio.Writer) {
 				cCmd = fmt.Sprintf("kubectl delete ns %s", ns)
 				_, err = utils.RunCommand(timeoutCtx, cCmd, logger, writer, env, map[string]string{}, true)
 				if err != nil {
-					// Ignore error
+					log.Warnf("Namespace %s was not cleared", ns)
 				}
 			}
 		}


### PR DESCRIPTION
Signed-off-by: Artem Belov <artem.belov@xored.com>

## Description
There are could be namespaces with pods left after failed tests (for example if test was failed by timeout). Clearing namespaces will remove affecting on next tests

## Motivation and Context

https://circleci.com/gh/networkservicemesh/networkservicemesh/93507?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-checks-link
TestMovingConnection was failed first on timeout. Pods were not deleted. All next tests were failed because of busy node ports

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [ ] Covered by existing integration testing
- [ ] Added integration testing to cover
- [x] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
