### PR TITLE
Fix CloudTest to work with timeouts and make Packet Destroy more smart.

### DIFF
--- a/.cloudtest.yaml
+++ b/.cloudtest.yaml
@@ -1,6 +1,6 @@
 version: 1.0
 root: "./.tests/cloud_test/"
-timeout: 3600 # 1 hour total timeout
+timeout: 7200 # 2 hour total total timeout
 import:
   - .cloudtest/packet.yaml
   - .cloudtest/gke.yaml

--- a/.cloudtest/packet.yaml
+++ b/.cloudtest/packet.yaml
@@ -6,7 +6,7 @@ providers:
     retry: 5
     node-count: 2
     enabled: true
-    timeout: 600 # 10 minutes to start cluster
+    timeout: 1800 # 30 minutes to start cluster
     env:
       - CLUSTER_RULES_PREFIX=null # To not add any specific code
       - KUBECONFIG=$(tempdir)/config

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,13 @@
 module github.com/networkservicemesh/networkservicemesh
 
 // Use ./scripts/switch_k8s_version.sh to change k8s version
+replace gonum.org/v1/gonum => github.com/gonum/gonum v0.0.0-20190331200053-3d26580ed485
+
+replace gonum.org/v1/netlib => github.com/gonum/netlib v0.0.0-20190331212654-76723241ea4e
 
 require (
+	github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 // indirect
+	github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4 // indirect
 	github.com/aws/aws-sdk-go v1.22.0
 	github.com/caddyserver/caddy v1.0.1
 	github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd // indirect
@@ -24,6 +29,7 @@ require (
 	github.com/opentracing/opentracing-go v1.1.0
 	github.com/packethost/packngo v0.1.1-0.20190507131943-1343be729ca2
 	github.com/pkg/errors v0.8.1
+	github.com/prometheus/common v0.6.0
 	github.com/rs/xid v1.2.1
 	github.com/sirupsen/logrus v1.4.2
 	github.com/spf13/cobra v0.0.5

--- a/go.sum
+++ b/go.sum
@@ -26,7 +26,11 @@ github.com/Rican7/retry v0.1.0/go.mod h1:FgOROf8P5bebcC1DS0PdOQiqGUridaZvikzUmkF
 github.com/Shopify/sarama v1.21.0/go.mod h1:yuqtN/pe8cXRWG5zPaO7hCfNJp5MwmkoJEoLjkm5tCQ=
 github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMxUHB2q5Ap20/P/eIdh4G0pI=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
+github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 h1:JYp7IbQjafoB+tBA3gMyHYHrpOtNuDiK/uB5uXxq5wM=
+github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
+github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4 h1:Hs82Z41s6SdL1CELW+XaDYmOH4hkBN4/N9og/AsOv7E=
+github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
@@ -188,6 +192,8 @@ github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db/go.mod h1:/XxbfmMg8l
 github.com/golangplus/bytes v0.0.0-20160111154220-45c989fe5450/go.mod h1:Bk6SMAONeMXrxql8uvOKuAZSu8aM5RUGv+1C6IJaEho=
 github.com/golangplus/fmt v0.0.0-20150411045040-2a5d6d7d2995/go.mod h1:lJgMEyOkYFkPcDKwRXegd+iM6E7matEszMG5HhwytU8=
 github.com/golangplus/testing v0.0.0-20180327235837-af21d9c3145e/go.mod h1:0AA//k/eakGydO4jKRoRL2j92ZKSzTgj9tclaCrvXHk=
+github.com/gonum/gonum v0.0.0-20190331200053-3d26580ed485/go.mod h1:2ltnJ7xHfj0zHS40VVPYEAAMTa3ZGguvHGBSJeRWqE0=
+github.com/gonum/netlib v0.0.0-20190331212654-76723241ea4e/go.mod h1:kS+toOQn6AQKjmKJ7gzohV1XkqsFehRA2FbsbkopSuQ=
 github.com/google/btree v0.0.0-20160524151835-7d79101e329e/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
@@ -613,6 +619,7 @@ google.golang.org/grpc v1.21.1/go.mod h1:oYelfM1adQP15Ek0mdvEgi9Df8B9CZIaU1084ij
 google.golang.org/grpc v1.23.0 h1:AzbTB6ux+okLTzP8Ru1Xs41C303zdcfEht7MQnYJt5A=
 google.golang.org/grpc v1.23.0/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyacEbxg=
 gopkg.in/DataDog/dd-trace-go.v1 v1.15.0/go.mod h1:DVp8HmDh8PuTu2Z0fVVlBsyWaC++fzwVCaGWylTe3tg=
+gopkg.in/alecthomas/kingpin.v2 v2.2.6 h1:jMFz6MfLP0/4fUyZle81rXUoxOBFi19VUFKVDOQfozc=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/test/cloudtest/pkg/commands/main.go
+++ b/test/cloudtest/pkg/commands/main.go
@@ -210,7 +210,7 @@ func PerformTesting(config *config.CloudTestConfig, factory k8s.ValidationFactor
 
 	err := ctx.performExecution()
 	reportfile, err2 := ctx.generateJUnitReportFile()
-	if err2 != nil && err != nil {
+	if err2 != nil {
 		logrus.Errorf("Error during generation of report: %v", err2)
 	}
 	if err != nil {
@@ -283,10 +283,10 @@ func (ctx *executionContext) performExecution() error {
 		case <-time.After(30 * time.Second):
 			ctx.printStatistics()
 		case <-termChannel:
-			return fmt.Errorf("Termination request is received")
+			return fmt.Errorf("termination request is received")
 		case <-timeoutCtx.Done():
 			ctx.printStatistics()
-			return fmt.Errorf("Global timeout elapsed: %v seconds", ctx.cloudTestConfig.Timeout)
+			return fmt.Errorf("global timeout elapsed: %v seconds", ctx.cloudTestConfig.Timeout)
 		}
 	}
 	logrus.Infof("Completed tasks %v Tasks left: %v", len(ctx.completed), len(ctx.tasks))

--- a/test/cloudtest/pkg/commands/main.go
+++ b/test/cloudtest/pkg/commands/main.go
@@ -261,7 +261,7 @@ func (ctx *executionContext) performExecution() error {
 	ctx.startTime = time.Now()
 	ctx.clusterReadyTime = ctx.startTime
 
-	timeoutCtx, _ := context.WithTimeout(context.Background(), time.Duration(ctx.cloudTestConfig.Timeout) * time.Second )
+	timeoutCtx, _ := context.WithTimeout(context.Background(), time.Duration(ctx.cloudTestConfig.Timeout)*time.Second)
 
 	termChannel := tools.NewOSSignalChannel()
 	for len(ctx.tasks) > 0 || len(ctx.running) > 0 {
@@ -283,7 +283,7 @@ func (ctx *executionContext) performExecution() error {
 			ctx.printStatistics()
 		case <-termChannel:
 			return fmt.Errorf("Termination request is received")
-		case <- timeoutCtx.Done():
+		case <-timeoutCtx.Done():
 			ctx.printStatistics()
 			return fmt.Errorf("Global timeout elapsed: %v seconds", ctx.cloudTestConfig.Timeout)
 		}

--- a/test/cloudtest/pkg/commands/main.go
+++ b/test/cloudtest/pkg/commands/main.go
@@ -459,16 +459,37 @@ func (ctx *executionContext) printStatistics() {
 		oneTask := elapsed / time.Duration(len(ctx.completed))
 		remaining = fmt.Sprintf("%v", time.Duration(len(ctx.tasks)+len(ctx.running))*oneTask)
 	}
-	logrus.Infof("Statistics:"+
-		"\n\tElapsed total: %v"+
-		"\n\tTests time: %v"+
-		"\n\tTasks  Completed: %d"+
-		"\n\t		Remaining: %v (%d).\n"+
-		"%s%s",
-		elapsed,
-		elapsedRunning, len(ctx.completed),
-		remaining, len(ctx.running)+len(ctx.tasks),
-		running, clustersMsg)
+
+	successTests := 0
+	failedTests := 0
+	skippedTests := 0
+	timeoutTests := 0
+
+	for _, t := range ctx.completed {
+		switch t.test.Status {
+		case model.StatusSuccess:
+			successTests++
+		case model.StatusTimeout:
+			timeoutTests++
+		case model.StatusSkipped:
+			skippedTests++
+		case model.StatusFailed:
+			failedTests++
+		case model.StatusSkippedSinceNoClusters:
+			skippedTests++
+		}
+	}
+
+	logrus.Infof("Statistics:" +
+		fmt.Sprintf("\n\tElapsed total: %v", elapsed) +
+		fmt.Sprintf("\n\tTests time: %v", elapsedRunning) +
+		fmt.Sprintf("\n\tTasks  Completed: %d", len(ctx.completed)) +
+		fmt.Sprintf("\n\t		Remaining: %v (%d).\n", remaining, len(ctx.running)+len(ctx.tasks)) +
+		fmt.Sprintf("%s%s", running, clustersMsg) +
+		fmt.Sprintf("\n\tStatus  Passed: %d"+
+			"\n\tStatus  Failed: %d"+
+			"\n\tStatus  Timeout: %d"+
+			"\n\tStatus  Skipped: %d", successTests, failedTests, timeoutTests, skippedTests))
 }
 
 func fromClusterState(state clusterState) string {
@@ -739,7 +760,12 @@ func (ctx *executionContext) startCluster(ci *clusterInstance) {
 			execution.logFile = errFile
 			execution.errMsg = err
 			execution.status = clusterCrashed
-			ctx.destroyCluster(ci, true, false)
+			destroyErr := ctx.destroyCluster(ci, true, false)
+			if destroyErr != nil {
+				logrus.Errorf("Both start and destroy of cluster returned errors, stop retrying operations with this cluster %v", ci.instance)
+				ci.startCount = ci.group.config.RetryCount + 1
+				execution.status = clusterNotAvailable
+			}
 		} else {
 			execution.status = clusterReady
 		}
@@ -762,8 +788,8 @@ func (ctx *executionContext) startCluster(ci *clusterInstance) {
 func (ctx *executionContext) getClusterTimeout(group *clustersGroup) time.Duration {
 	timeout := time.Duration(group.config.Timeout) * time.Second
 	if group.config.Timeout == 0 {
-		logrus.Infof("test timeout is not specified, use default value 5min")
-		timeout = 5 * time.Minute
+		logrus.Infof("cluster timeout is not specified, use default value 15min")
+		timeout = 15 * time.Minute
 	}
 	return timeout
 }
@@ -801,13 +827,13 @@ func (ctx *executionContext) monitorCluster(context context.Context, ci *cluster
 	}
 }
 
-func (ctx *executionContext) destroyCluster(ci *clusterInstance, sendUpdate, fork bool) {
+func (ctx *executionContext) destroyCluster(ci *clusterInstance, sendUpdate, fork bool) error {
 	ci.lock.Lock()
 	defer ci.lock.Unlock()
 
 	if ci.state == clusterCrashed || ci.state == clusterNotAvailable || ci.state == clusterShutdown {
 		// It is already destroyed or not available.
-		return
+		return nil
 	}
 
 	ci.state = clusterBusy
@@ -825,7 +851,7 @@ func (ctx *executionContext) destroyCluster(ci *clusterInstance, sendUpdate, for
 				logrus.Errorf("Failed to destroy cluster")
 			}
 		}()
-		return
+		return nil
 	}
 	err := ci.instance.Destroy(timeout)
 	if err != nil {
@@ -843,7 +869,7 @@ func (ctx *executionContext) destroyCluster(ci *clusterInstance, sendUpdate, for
 			kind:            eventClusterUpdate,
 		}
 	}
-
+	return err
 }
 
 func (ctx *executionContext) createClusters() error {

--- a/test/cloudtest/pkg/commands/main.go
+++ b/test/cloudtest/pkg/commands/main.go
@@ -261,7 +261,8 @@ func (ctx *executionContext) performExecution() error {
 	ctx.startTime = time.Now()
 	ctx.clusterReadyTime = ctx.startTime
 
-	timeoutCtx, _ := context.WithTimeout(context.Background(), time.Duration(ctx.cloudTestConfig.Timeout)*time.Second)
+	timeoutCtx, cancelFunc := context.WithTimeout(context.Background(), time.Duration(ctx.cloudTestConfig.Timeout)*time.Second)
+	defer cancelFunc()
 
 	termChannel := tools.NewOSSignalChannel()
 	for len(ctx.tasks) > 0 || len(ctx.running) > 0 {

--- a/test/cloudtest/pkg/config/config.go
+++ b/test/cloudtest/pkg/config/config.go
@@ -57,6 +57,6 @@ type CloudTestConfig struct {
 	} `yaml:"reporting"` // A reporting options.
 
 	Executions []*ExecutionConfig `yaml:"executions"`
-	Timeout    int64              `yaml:"timeout"` // Global timeout in minutes
+	Timeout    int64              `yaml:"timeout"` // Global timeout in seconds
 	Imports    []string           `yaml:"import"`  // A set of configurations for import
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

1. Fix for use of global timeout in CloudTest
2. Fix Packet.Destroy to use timeout and wait for devices to be really destroyed.
3. Fix CloudTest to stop operation on cluster if both start/destroy caused errors.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [ ] Covered by existing integration testing
- [ ] Added integration testing to cover
- [ ] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
