### PR TITLE
Cleanup old aws clusters tool

### DIFF
--- a/scripts/aws/destroy-kubernetes-cluster.go
+++ b/scripts/aws/destroy-kubernetes-cluster.go
@@ -1,11 +1,12 @@
 package main
 
 import (
-	"github.com/sirupsen/logrus"
 	"log"
 	"os"
 	"sync"
 	"time"
+
+	"github.com/sirupsen/logrus"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
@@ -290,7 +291,7 @@ func deleteAllKubernetesClusters(saveDuration time.Duration) {
 	i := 0
 	for _, stack := range stacks.StackSummaries {
 		stackName := aws.StringValue(stack.StackName)
-		if  stackName[:7] != "nsm-srv" {
+		if stackName[:7] != "nsm-srv" {
 			continue
 		}
 
@@ -305,10 +306,10 @@ func deleteAllKubernetesClusters(saveDuration time.Duration) {
 			defer wg.Done()
 			logrus.Infof("Deleting %s", stackName[7:])
 			deleteAWSKubernetesCluster(stackName[7:])
-		} ()
+		}()
 
 		i++
-		if i % 5 == 0 {
+		if i%5 == 0 {
 			wg.Wait() // Guard from AWS Throttling error
 		}
 	}

--- a/scripts/aws/destroy-kubernetes-cluster.go
+++ b/scripts/aws/destroy-kubernetes-cluster.go
@@ -283,7 +283,7 @@ func deleteAllKubernetesClusters(saveDuration time.Duration) {
 
 	stacks, err := cfClient.ListStacks(&cloudformation.ListStacksInput{})
 	if err != nil {
-		logrus.Info("AWS EKS Error: %v", err)
+		logrus.Infof("AWS EKS Error: %v", err)
 		return
 	}
 
@@ -292,6 +292,10 @@ func deleteAllKubernetesClusters(saveDuration time.Duration) {
 	for _, stack := range stacks.StackSummaries {
 		stackName := aws.StringValue(stack.StackName)
 		if stackName[:7] != "nsm-srv" {
+			continue
+		}
+
+		if aws.StringValue(stack.StackStatus) == "DELETE_COMPLETE" {
 			continue
 		}
 

--- a/scripts/aws/destroy-kubernetes-cluster.go
+++ b/scripts/aws/destroy-kubernetes-cluster.go
@@ -287,6 +287,7 @@ func deleteAllKubernetesClusters(saveDuration time.Duration) {
 	}
 
 	var wg sync.WaitGroup
+	i := 0
 	for _, stack := range stacks.StackSummaries {
 		stackName := aws.StringValue(stack.StackName)
 		if  stackName[:7] != "nsm-srv" {
@@ -305,6 +306,11 @@ func deleteAllKubernetesClusters(saveDuration time.Duration) {
 			logrus.Infof("Deleting %s", stackName[7:])
 			deleteAWSKubernetesCluster(stackName[7:])
 		} ()
-		wg.Wait()
+
+		i++
+		if i % 5 == 0 {
+			wg.Wait() // Guard from AWS Throttling error
+		}
 	}
+	wg.Wait()
 }

--- a/scripts/aws/kubernetes-cluster.go
+++ b/scripts/aws/kubernetes-cluster.go
@@ -2,10 +2,11 @@ package main
 
 import (
 	"fmt"
-	"github.com/sirupsen/logrus"
 	"os"
 	"strconv"
 	"time"
+
+	"github.com/sirupsen/logrus"
 )
 
 const requestInterval = 5 * time.Second


### PR DESCRIPTION
Signed-off-by: Artem Belov <artem.belov@xored.com>

## Description
Cleanup aws clusters older than N hours

## Motivation and Context
AWS cluster consist of many parts (cluster, stack, nodes, keys, etc...). This tool helps to cleanup aws from old clusters

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [ ] Covered by existing integration testing
- [ ] Added integration testing to cover
- [x] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
