### PR TITLE
Allow local vendoring

### DIFF
--- a/.env/vendoring.env
+++ b/.env/vendoring.env
@@ -1,0 +1,2 @@
+export VENDORING="-mod vendor"
+go mod vendor

--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ scripts/vagrant/.kube/
 .tests
 
 ./cloudtest
+vendor

--- a/.mk/docker.mk
+++ b/.mk/docker.mk
@@ -39,8 +39,8 @@ include .mk/vpp_agent.mk
 docker-build: $(addsuffix -build,$(addprefix docker-,$(BUILD_CONTAINERS)))
 
 .PHONY: docker-%-build
-docker-%-build:
-	@${DOCKERBUILD} --network="host" --build-arg VPP_AGENT=${VPP_AGENT}  --build-arg VERSION=${VERSION} -t ${ORG}/$* -f docker/Dockerfile.$* . && \
+docker-%-build::
+	@${DOCKERBUILD} --network="host" --build-arg VPP_AGENT=${VPP_AGENT} --build-arg VENDORING="${VENDORING}" --build-arg VERSION=${VERSION} -t ${ORG}/$* -f docker/Dockerfile.$* . && \
 	if [ "x${COMMIT}" != "x" ] ; then \
 		docker tag ${ORG}/$* ${ORG}/$*:${COMMIT} ;\
 	fi
@@ -80,7 +80,7 @@ docker-%-logs:
 
 .PHONY:
 docker-devenv-build: docker/debug/Dockerfile.debug
-	@${DOCKERBUILD} -t networkservicemesh/devenv -f docker/debug/Dockerfile.debug .
+	@${DOCKERBUILD} --build-arg VENDORING="${VENDORING}" -t networkservicemesh/devenv -f docker/debug/Dockerfile.debug .
 
 .PHONY: docker-devenv-run
 docker-devenv-run:

--- a/.mk/vpp_agent.mk
+++ b/.mk/vpp_agent.mk
@@ -10,7 +10,7 @@ endif
 
 .PHONY: docker-vppagent-dataplane-dev-build
 docker-vppagent-dataplane-dev-build: docker-vppagent-dataplane-build
-	@${DOCKERBUILD} --network="host" --build-arg VPP_AGENT=${VPP_AGENT} --build-arg VPP_DEV=${VPP_AGENT_DEV} --build-arg REPO=${ORG}  --build-arg VERSION=${VERSION}  -t ${ORG}/vppagent-dataplane-dev -f docker/Dockerfile.vppagent-dataplane-dev . && \
+	@${DOCKERBUILD} --network="host" --build-arg VPP_AGENT=${VPP_AGENT} --build-arg VENDORING="${VENDORING}" --build-arg VPP_DEV=${VPP_AGENT_DEV} --build-arg REPO=${ORG}  --build-arg VERSION=${VERSION}  -t ${ORG}/vppagent-dataplane-dev -f docker/Dockerfile.vppagent-dataplane-dev . && \
 	if [ "x${COMMIT}" != "x" ] ; then \
 		docker tag ${ORG}/vppagent-dataplane-dev ${ORG}/vppagent-dataplane-dev:${COMMIT} ;\
 	fi

--- a/build/Dockerfile.nsmd-k8s
+++ b/build/Dockerfile.nsmd-k8s
@@ -1,5 +1,6 @@
 FROM golang:alpine as build
 ARG VERSION=unspecified
+ARG VENDORING
 RUN apk --no-cache add git
 ENV PACKAGEPATH=github.com/networkservicemesh/networkservicemesh/
 ENV GO111MODULE=on
@@ -8,10 +9,10 @@ RUN mkdir /root/networkservicemesh
 ADD ["go.mod","/root/networkservicemesh"]
 ADD ["./scripts/go-mod-download.sh","/root/networkservicemesh"]
 WORKDIR /root/networkservicemesh/
-RUN ./go-mod-download.sh
+RUN VENDORING=${VENDORING} ./go-mod-download.sh
 
 ADD [".","/root/networkservicemesh"]
-RUN CGO_ENABLED=0 GOOS=linux go build -ldflags "-extldflags "-static" -X  main.version=${VERSION}" -o /go/bin/nsmd-k8s ./k8s/cmd/nsmd-k8s
+RUN CGO_ENABLED=0 GOOS=linux go build ${VENDORING} -ldflags "-extldflags '-static' -X  main.version=${VERSION}" -o /go/bin/nsmd-k8s ./k8s/cmd/nsmd-k8s
 
 FROM alpine as runtime
 COPY --from=build /go/bin/nsmd-k8s /bin/nsmd-k8s

--- a/build/Dockerfile.proxy-nsmd-k8s
+++ b/build/Dockerfile.proxy-nsmd-k8s
@@ -1,5 +1,6 @@
 FROM golang:alpine as build
 ARG VERSION=unspecified
+ARG VENDORING
 RUN apk --no-cache add git
 ENV PACKAGEPATH=github.com/networkservicemesh/networkservicemesh/
 ENV GO111MODULE=on
@@ -8,10 +9,10 @@ RUN mkdir /root/networkservicemesh
 ADD ["go.mod","/root/networkservicemesh"]
 ADD ["./scripts/go-mod-download.sh","/root/networkservicemesh"]
 WORKDIR /root/networkservicemesh/
-RUN ./go-mod-download.sh
+RUN VENDORING=${VENDORING} ./go-mod-download.sh
 
 ADD [".","/root/networkservicemesh"]
-RUN CGO_ENABLED=0 GOOS=linux go build -ldflags "-extldflags "-static" -X  main.version=${VERSION}" -o /go/bin/proxy-nsmd-k8s ./k8s/cmd/proxy-nsmd-k8s/main.go
+RUN CGO_ENABLED=0 GOOS=linux go build ${VENDORING} -ldflags "-extldflags '-static' -X  main.version=${VERSION}" -o /go/bin/proxy-nsmd-k8s ./k8s/cmd/proxy-nsmd-k8s/main.go
 
 FROM alpine as runtime
 COPY --from=build /go/bin/proxy-nsmd-k8s /bin/proxy-nsmd-k8s

--- a/controlplane/build/Dockerfile.nsmd
+++ b/controlplane/build/Dockerfile.nsmd
@@ -1,5 +1,6 @@
 FROM golang:alpine as build
 ARG VERSION=unspecified
+ARG VENDORING
 RUN apk --no-cache add git
 ENV PACKAGEPATH=github.com/networkservicemesh/networkservicemesh/
 ENV GO111MODULE=on
@@ -8,10 +9,10 @@ RUN mkdir /root/networkservicemesh
 ADD ["go.mod","/root/networkservicemesh"]
 ADD ["./scripts/go-mod-download.sh","/root/networkservicemesh"]
 WORKDIR /root/networkservicemesh/
-RUN ./go-mod-download.sh
+RUN VENDORING=${VENDORING} ./go-mod-download.sh
 
 ADD [".","/root/networkservicemesh"]
-RUN CGO_ENABLED=0 GOOS=linux go build -ldflags "-extldflags "-static" -X  main.version=${VERSION}" -o /go/bin/nsmd ./controlplane/cmd/nsmd
+RUN CGO_ENABLED=0 GOOS=linux go build ${VENDORING} -ldflags "-extldflags '-static' -X  main.version=${VERSION}" -o /go/bin/nsmd ./controlplane/cmd/nsmd
 
 FROM alpine as runtime
 COPY --from=build /go/bin/nsmd /bin/nsmd

--- a/controlplane/build/Dockerfile.proxy-nsmd
+++ b/controlplane/build/Dockerfile.proxy-nsmd
@@ -1,5 +1,6 @@
 FROM golang:alpine as build
 ARG VERSION=unspecified
+ARG VENDORING
 RUN apk --no-cache add git
 ENV PACKAGEPATH=github.com/networkservicemesh/networkservicemesh/
 ENV GO111MODULE=on
@@ -8,10 +9,10 @@ RUN mkdir /root/networkservicemesh
 ADD ["go.mod","/root/networkservicemesh"]
 ADD ["./scripts/go-mod-download.sh","/root/networkservicemesh"]
 WORKDIR /root/networkservicemesh/
-RUN ./go-mod-download.sh
+RUN VENDORING=${VENDORING} ./go-mod-download.sh
 
 ADD [".","/root/networkservicemesh"]
-RUN CGO_ENABLED=0 GOOS=linux go build -ldflags "-extldflags "-static" -X  main.version=${VERSION}" -o /go/bin/proxy-nsmd ./controlplane/cmd/proxynsmd/main.go
+RUN CGO_ENABLED=0 GOOS=linux go build ${VENDORING} -ldflags "-extldflags '-static' -X  main.version=${VERSION}" -o /go/bin/proxy-nsmd ./controlplane/cmd/proxynsmd/main.go
 
 FROM alpine as runtime
 COPY --from=build /go/bin/proxy-nsmd /bin/proxy-nsmd

--- a/dataplane/kernel-forwarder/build/Dockerfile.kernel-forwarder
+++ b/dataplane/kernel-forwarder/build/Dockerfile.kernel-forwarder
@@ -1,4 +1,5 @@
 FROM golang:alpine as build
+ARG VENDORING
 RUN apk --no-cache add git
 ENV PACKAGEPATH=github.com/networkservicemesh/networkservicemesh/
 ENV GO111MODULE=on
@@ -7,10 +8,10 @@ RUN mkdir /root/networkservicemesh
 ADD ["go.mod","/root/networkservicemesh"]
 ADD ["./scripts/go-mod-download.sh","/root/networkservicemesh"]
 WORKDIR /root/networkservicemesh/
-RUN ./go-mod-download.sh
+RUN VENDORING=${VENDORING} ./go-mod-download.sh
 
 ADD [".","/root/networkservicemesh"]
-RUN CGO_ENABLED=0 GOOS=linux go build -ldflags '-extldflags "-static"' -o /go/bin/kernel-forwarder ./dataplane/kernel-forwarder/cmd/kernel-forwarder.go
+RUN CGO_ENABLED=0 GOOS=linux go build ${VENDORING} -ldflags "-extldflags '-static'" -o /go/bin/kernel-forwarder ./dataplane/kernel-forwarder/cmd/kernel-forwarder.go
 
 FROM alpine as runtime
 COPY --from=build /go/bin/kernel-forwarder /bin/kernel-forwarder

--- a/dataplane/vppagent/build/Dockerfile.vppagent-dataplane
+++ b/dataplane/vppagent/build/Dockerfile.vppagent-dataplane
@@ -1,7 +1,7 @@
 ARG VPP_AGENT
-
 FROM golang:alpine as build
 ARG VERSION=unspecified
+ARG VENDORING
 RUN apk --no-cache add git
 ENV PACKAGEPATH=github.com/networkservicemesh/networkservicemesh/
 ENV GO111MODULE=on
@@ -10,10 +10,10 @@ RUN mkdir /root/networkservicemesh
 ADD ["go.mod","/root/networkservicemesh"]
 ADD ["./scripts/go-mod-download.sh","/root/networkservicemesh"]
 WORKDIR /root/networkservicemesh/
-RUN ./go-mod-download.sh
+RUN VENDORING=${VENDORING} ./go-mod-download.sh
 
 ADD [".","/root/networkservicemesh"]
-RUN CGO_ENABLED=0 GOOS=linux go build -ldflags "-extldflags "-static" -X  main.version=${VERSION}" -o /go/bin/vppagent-dataplane ./dataplane/vppagent/cmd
+RUN CGO_ENABLED=0 GOOS=linux go build ${VENDORING} -ldflags "-extldflags '-static' -X  main.version=${VERSION}" -o /go/bin/vppagent-dataplane ./dataplane/vppagent/cmd
 
 FROM ${VPP_AGENT} as runtime
 COPY --from=build /go/bin/vppagent-dataplane /bin/vppagent-dataplane

--- a/dataplane/vppagent/build/Dockerfile.vppagent-dataplane-dev
+++ b/dataplane/vppagent/build/Dockerfile.vppagent-dataplane-dev
@@ -30,6 +30,7 @@ COPY dataplane/vppagent/conf/supervisord/supervisord.conf /etc/supervisord/super
 
 FROM golang:alpine as build_vpp
 ARG VERSION=unspecified
+ARG VENDORING
 RUN apk --no-cache add git
 ENV PACKAGEPATH=github.com/networkservicemesh/networkservicemesh/
 ENV GO111MODULE=on
@@ -38,10 +39,10 @@ RUN mkdir /root/networkservicemesh
 ADD ["go.mod","/root/networkservicemesh"]
 ADD ["./scripts/go-mod-download.sh","/root/networkservicemesh"]
 WORKDIR /root/networkservicemesh/
-RUN ./go-mod-download.sh
+RUN VENDORING=${VENDORING} ./go-mod-download.sh
 
 ADD [".","/root/networkservicemesh"]
-RUN CGO_ENABLED=0 GOOS=linux go build -ldflags "-extldflags "-static" -X  main.version=${VERSION}" -o /go/bin/vppagent-dataplane ./dataplane/vppagent/cmd
+RUN CGO_ENABLED=0 GOOS=linux go build ${VENDORING} -ldflags "-extldflags '-static' -X  main.version=${VERSION}" -o /go/bin/vppagent-dataplane ./dataplane/vppagent/cmd
 
 FROM vpp_agent
 COPY --from=build_vpp /go/bin/vppagent-dataplane /bin/vppagent-dataplane

--- a/docker/Dockerfile.admission-webhook
+++ b/docker/Dockerfile.admission-webhook
@@ -1,5 +1,6 @@
 FROM golang:alpine as build
 ARG VERSION=unspecified
+ARG VENDORING
 RUN apk --no-cache add git
 ENV PACKAGEPATH=github.com/networkservicemesh/networkservicemesh/
 ENV GO111MODULE=on
@@ -8,10 +9,10 @@ RUN mkdir /root/networkservicemesh
 ADD ["go.mod","/root/networkservicemesh"]
 ADD ["./scripts/go-mod-download.sh","/root/networkservicemesh"]
 WORKDIR /root/networkservicemesh/
-RUN ./go-mod-download.sh
+RUN VENDORING=${VENDORING} ./go-mod-download.sh
 
 ADD [".","/root/networkservicemesh"]
-RUN CGO_ENABLED=0 GOOS=linux go build -ldflags "-extldflags "-static" -X  main.version=${VERSION}" -o /go/bin/admission-webhook ./k8s/cmd/admission-webhook
+RUN CGO_ENABLED=0 GOOS=linux go build ${VENDORING} -ldflags "-extldflags '-static' -X  main.version=${VERSION}" -o /go/bin/admission-webhook ./k8s/cmd/admission-webhook
 
 FROM alpine as runtime
 COPY --from=build /go/bin/admission-webhook /bin/admission-webhook

--- a/docker/Dockerfile.crossconnect-monitor
+++ b/docker/Dockerfile.crossconnect-monitor
@@ -1,5 +1,6 @@
 FROM golang:alpine as build
 ARG VERSION=unspecified
+ARG VENDORING
 RUN apk --no-cache add git
 ENV PACKAGEPATH=github.com/networkservicemesh/networkservicemesh/
 ENV GO111MODULE=on
@@ -8,10 +9,10 @@ RUN mkdir /root/networkservicemesh
 ADD ["go.mod","/root/networkservicemesh"]
 ADD ["./scripts/go-mod-download.sh","/root/networkservicemesh"]
 WORKDIR /root/networkservicemesh/
-RUN ./go-mod-download.sh
+RUN VENDORING=${VENDORING} ./go-mod-download.sh
 
 ADD [".","/root/networkservicemesh"]
-RUN CGO_ENABLED=0 GOOS=linux go build -ldflags "-extldflags "-static" -X  main.version=${VERSION}" -o /go/bin/crossconnect-monitor ./k8s/cmd/crossconnect-monitor
+RUN CGO_ENABLED=0 GOOS=linux go build ${VENDORING} -ldflags "-extldflags '-static' -X  main.version=${VERSION}" -o /go/bin/crossconnect-monitor ./k8s/cmd/crossconnect-monitor
 FROM alpine as runtime
 COPY --from=build /go/bin/crossconnect-monitor /bin/crossconnect-monitor
 ENTRYPOINT ["/bin/crossconnect-monitor"]

--- a/docker/Dockerfile.nsm-coredns
+++ b/docker/Dockerfile.nsm-coredns
@@ -1,4 +1,5 @@
 FROM golang:alpine as build
+ARG VENDORING
 ARG VERSION=unspecified
 RUN apk update && apk add --no-cache git ca-certificates tzdata && update-ca-certificates
 RUN apk --no-cache add git
@@ -10,9 +11,9 @@ WORKDIR /root/networkservicemesh/
 
 ADD [".","/root/networkservicemesh"]
 ADD ["./scripts/go-mod-download.sh","/root/networkservicemesh"]
-RUN ./go-mod-download.sh
+RUN VENDORING=${VENDORING} ./go-mod-download.sh
 WORKDIR /root/networkservicemesh/k8s/cmd/nsm-coredns
-RUN CGO_ENABLED=0 GOOS=linux go build -ldflags "-extldflags "-static" -X  main.version=${VERSION}" -o /go/bin/nsm-coredns
+RUN CGO_ENABLED=0 GOOS=linux go build ${VENDORING} -ldflags "-extldflags '-static' -X  main.version=${VERSION}" -o /go/bin/nsm-coredns
 FROM alpine as runtime
 COPY --from=build /go/bin/nsm-coredns /bin/nsm-coredns
 COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/

--- a/docs/guide-build.md
+++ b/docs/guide-build.md
@@ -45,6 +45,13 @@ because ```make k8s-save``` will build your containers and save them in `scripts
 
 > You can also selectively rebuild any component, say the `nsmd`, with ```make k8s-nsmd-save```
 
+## Speedup build speed by enabling local Vendoring
+
+```export VENDORING="-mod vendor"
+go mod vendor
+```
+Will enable use of vendor folder to share go dependencies. 
+
 ## Running the NSM code
 
 Network Service Mesh provides a handy Vagrant setup for running a two node K8s cluster. Once you've done ```make k8s-save```, you can deploy to it with:

--- a/k8s/build/Dockerfile.nsmdp
+++ b/k8s/build/Dockerfile.nsmdp
@@ -1,5 +1,6 @@
 FROM golang:alpine as build
 ARG VERSION=unspecified
+ARG VENDORING
 RUN apk --no-cache add git
 ENV PACKAGEPATH=github.com/networkservicemesh/networkservicemesh/
 ENV GO111MODULE=on
@@ -8,10 +9,10 @@ RUN mkdir /root/networkservicemesh
 ADD ["go.mod","/root/networkservicemesh"]
 ADD ["./scripts/go-mod-download.sh","/root/networkservicemesh"]
 WORKDIR /root/networkservicemesh/
-RUN ./go-mod-download.sh
+RUN VENDORING=${VENDORING} ./go-mod-download.sh
 
 ADD [".","/root/networkservicemesh"]
-RUN CGO_ENABLED=0 GOOS=linux go build -ldflags "-extldflags "-static" -X  main.version=${VERSION}" -o /go/bin/nsmdp ./k8s/cmd/nsmdp
+RUN CGO_ENABLED=0 GOOS=linux go build ${VENDORING} -ldflags "-extldflags '-static' -X  main.version=${VERSION}" -o /go/bin/nsmdp ./k8s/cmd/nsmdp
 FROM alpine as runtime
 COPY --from=build /go/bin/nsmdp /bin/nsmdp
 ENTRYPOINT ["/bin/nsmdp"]

--- a/scripts/go-mod-download.sh
+++ b/scripts/go-mod-download.sh
@@ -1,5 +1,13 @@
 #!/usr/bin/env sh
 
+if [ -z "$VENDORING" ]
+then
+      echo "No vendoring"
+else
+      echo "Vendoring is enabled, not need to download stuff."
+      exit 0
+fi
+
 limit=10;
 attempt=1;
 

--- a/scripts/go-mod-download.sh
+++ b/scripts/go-mod-download.sh
@@ -4,7 +4,7 @@ if [ -z "$VENDORING" ]
 then
       echo "No vendoring"
 else
-      echo "Vendoring is enabled, not need to download stuff."
+      echo "Vendoring is enabled, no need to download stuff."
       exit 0
 fi
 

--- a/scripts/vagrant/Vagrantfile
+++ b/scripts/vagrant/Vagrantfile
@@ -17,7 +17,7 @@ Vagrant.configure("2") do |config|
   end
   config.vm.provider "virtualbox" do |v, override|
     override.vm.box = "bento/ubuntu-18.04"
-    v.memory = 2048
+    v.memory = 4096
     v.cpus = 2
   end
   config.vm.provider "vmware_desktop" do |v, override|

--- a/scripts/vagrant/Vagrantfile
+++ b/scripts/vagrant/Vagrantfile
@@ -17,7 +17,7 @@ Vagrant.configure("2") do |config|
   end
   config.vm.provider "virtualbox" do |v, override|
     override.vm.box = "bento/ubuntu-18.04"
-    v.memory = 4096
+    v.memory = 2048
     v.cpus = 2
   end
   config.vm.provider "vmware_desktop" do |v, override|

--- a/side-cars/build/Dockerfile.nsm-init
+++ b/side-cars/build/Dockerfile.nsm-init
@@ -1,5 +1,6 @@
 FROM golang:alpine as build
 ARG VERSION=unspecified
+ARG VENDORING
 RUN apk --no-cache add git
 ENV PACKAGEPATH=github.com/networkservicemesh/networkservicemesh/
 ENV GO111MODULE=on
@@ -8,10 +9,10 @@ RUN mkdir /root/networkservicemesh
 ADD ["go.mod","/root/networkservicemesh"]
 ADD ["./scripts/go-mod-download.sh","/root/networkservicemesh"]
 WORKDIR /root/networkservicemesh/
-RUN ./go-mod-download.sh
+RUN VENDORING=${VENDORING} ./go-mod-download.sh
 
 ADD [".","/root/networkservicemesh"]
-RUN CGO_ENABLED=0 GOOS=linux go build -ldflags "-extldflags "-static" -X  main.version=${VERSION}" -o /go/bin/nsm-init ./side-cars/cmd/nsm-init
+RUN CGO_ENABLED=0 GOOS=linux go build ${VENDORING} -ldflags "-extldflags '-static' -X  main.version=${VERSION}" -o /go/bin/nsm-init ./side-cars/cmd/nsm-init
 
 FROM alpine as runtime
 COPY --from=build /go/bin/nsm-init /bin/nsm-init

--- a/side-cars/build/Dockerfile.nsm-monitor
+++ b/side-cars/build/Dockerfile.nsm-monitor
@@ -1,5 +1,6 @@
 FROM golang:alpine as build
 ARG VERSION=unspecified
+ARG VENDORING
 RUN apk --no-cache add git
 ENV PACKAGEPATH=github.com/networkservicemesh/networkservicemesh/
 ENV GO111MODULE=on
@@ -8,10 +9,10 @@ RUN mkdir /root/networkservicemesh
 ADD ["go.mod","/root/networkservicemesh"]
 ADD ["./scripts/go-mod-download.sh","/root/networkservicemesh"]
 WORKDIR /root/networkservicemesh/
-RUN ./go-mod-download.sh
+RUN VENDORING=${VENDORING} ./go-mod-download.sh
 
 ADD [".","/root/networkservicemesh"]
-RUN CGO_ENABLED=0 GOOS=linux go build -ldflags "-extldflags "-static" -X  main.version=${VERSION}" -o /go/bin/nsm-monitor ./side-cars/cmd/nsm-monitor
+RUN CGO_ENABLED=0 GOOS=linux go build ${VENDORING} -ldflags "-extldflags '-static' -X  main.version=${VERSION}" -o /go/bin/nsm-monitor ./side-cars/cmd/nsm-monitor
 
 FROM alpine as runtime
 COPY --from=build /go/bin/nsm-monitor /bin/nsm-monitor

--- a/test/applications/build/Dockerfile.test-common
+++ b/test/applications/build/Dockerfile.test-common
@@ -1,4 +1,5 @@
 FROM golang:alpine as build
+ARG VENDORING
 RUN apk --no-cache add git
 ENV PACKAGEPATH=github.com/networkservicemesh/networkservicemesh/
 ENV GO111MODULE=on
@@ -7,34 +8,38 @@ RUN mkdir /root/networkservicemesh
 ADD ["go.mod","/root/networkservicemesh"]
 ADD ["./scripts/go-mod-download.sh","/root/networkservicemesh"]
 WORKDIR /root/networkservicemesh/
-RUN ./go-mod-download.sh
+RUN VENDORING=${VENDORING} ./go-mod-download.sh
 
 ADD [".","/root/networkservicemesh"]
 
 # 1. icmp-responder-nse
 FROM build as build-1
 ARG VERSION=unspecified
-RUN CGO_ENABLED=0 GOOS=linux go build -ldflags "-extldflags "-static" -X  main.version=${VERSION}" -o /go/bin/icmp-responder-nse ./test/applications/cmd/icmp-responder-nse
+ARG VENDORING
+RUN CGO_ENABLED=0 GOOS=linux go build ${VENDORING} -ldflags "-extldflags '-static' -X  main.version=${VERSION}" -o /go/bin/icmp-responder-nse ./test/applications/cmd/icmp-responder-nse
 FROM alpine as runtime-1
 COPY --from=build-1 /go/bin/icmp-responder-nse /bin/icmp-responder-nse
 
 # 2. monitoring-nsc
 FROM build-1 as build-2
 ARG VERSION=unspecified
-RUN CGO_ENABLED=0 GOOS=linux go build -ldflags "-extldflags "-static" -X  main.version=${VERSION}"  -o /go/bin/monitoring-nsc ./test/applications/cmd/monitoring-nsc
+ARG VENDORING
+RUN CGO_ENABLED=0 GOOS=linux go build ${VENDORING} -ldflags "-extldflags '-static' -X  main.version=${VERSION}"  -o /go/bin/monitoring-nsc ./test/applications/cmd/monitoring-nsc
 FROM runtime-1 as runtime-2
 COPY --from=build-2 /go/bin/monitoring-nsc /bin/monitoring-nsc
 
 # 3. xcon-monitor
 FROM build-2 as build-3
 ARG VERSION=unspecified
-RUN CGO_ENABLED=0 GOOS=linux go build -ldflags "-extldflags "-static" -X  main.version=${VERSION}"  -o /go/bin/proxy-xcon-monitor ./test/applications/cmd/proxy-xcon-monitor
+ARG VENDORING
+RUN CGO_ENABLED=0 GOOS=linux go build ${VENDORING} -ldflags "-extldflags '-static' -X  main.version=${VERSION}"  -o /go/bin/proxy-xcon-monitor ./test/applications/cmd/proxy-xcon-monitor
 FROM runtime-2 as runtime-3
 COPY --from=build-3 /go/bin/proxy-xcon-monitor /bin/proxy-xcon-monitor
 
 # 4. monitoring-dns-nsc
 FROM build-3 as build-4
 ARG VERSION=unspecified
-RUN CGO_ENABLED=0 GOOS=linux go build -ldflags "-extldflags "-static" -X  main.version=${VERSION}"  -o /go/bin/monitoring-dns-nsc ./test/applications/cmd/monitoring-dns-nsc
+ARG VENDORING
+RUN CGO_ENABLED=0 GOOS=linux go build ${VENDORING} -ldflags "-extldflags '-static' -X  main.version=${VERSION}"  -o /go/bin/monitoring-dns-nsc ./test/applications/cmd/monitoring-dns-nsc
 FROM runtime-3 as runtime-4
 COPY --from=build-4 /go/bin/monitoring-dns-nsc /bin/monitoring-dns-nsc

--- a/test/applications/build/Dockerfile.vpp-test-common
+++ b/test/applications/build/Dockerfile.vpp-test-common
@@ -1,5 +1,5 @@
 ARG VPP_AGENT
-
+ARG VENDORING
 FROM golang:alpine as build
 RUN apk --no-cache add git
 ENV PACKAGEPATH=github.com/networkservicemesh/networkservicemesh/
@@ -9,7 +9,7 @@ RUN mkdir /root/networkservicemesh
 ADD ["go.mod","/root/networkservicemesh"]
 ADD ["./scripts/go-mod-download.sh","/root/networkservicemesh"]
 WORKDIR /root/networkservicemesh/
-RUN ./go-mod-download.sh
+RUN VENDORING=${VENDORING} ./go-mod-download.sh
 
 ADD [".","/root/networkservicemesh"]
 
@@ -24,7 +24,8 @@ RUN mkdir /tmp/vpp/
 # 1. vppagent-nsc
 FROM build as build-1
 ARG VERSION=unspecified
-RUN CGO_ENABLED=0 GOOS=linux go build -ldflags "-extldflags "-static" -X  main.version=${VERSION}" -o /go/bin/vppagent-nsc ./test/applications/cmd/vppagent-nsc
+ARG VENDORING
+RUN CGO_ENABLED=0 GOOS=linux go build ${VENDORING} -ldflags "-extldflags '-static' -X  main.version=${VERSION}" -o /go/bin/vppagent-nsc ./test/applications/cmd/vppagent-nsc
 FROM runtime as runtime-1
 COPY --from=build-1 /go/bin/vppagent-nsc /bin/vppagent-nsc
 RUN mkdir /tmp/vpp/vppagent-nsc/; echo 'Endpoint: "0.0.0.0:9113"' > /tmp/vpp/vppagent-nsc/grpc.conf
@@ -32,7 +33,8 @@ RUN mkdir /tmp/vpp/vppagent-nsc/; echo 'Endpoint: "0.0.0.0:9113"' > /tmp/vpp/vpp
 # 2. vppagent-icmp-responder-nse
 FROM build-1 as build-2
 ARG VERSION=unspecified
-RUN CGO_ENABLED=0 GOOS=linux go build -ldflags "-extldflags "-static" -X  main.version=${VERSION}" -o /go/bin/vppagent-icmp-responder-nse ./test/applications/cmd/vppagent-icmp-responder-nse
+ARG VENDORING
+RUN CGO_ENABLED=0 GOOS=linux go build ${VENDORING} -ldflags "-extldflags '-static' -X  main.version=${VERSION}" -o /go/bin/vppagent-icmp-responder-nse ./test/applications/cmd/vppagent-icmp-responder-nse
 FROM runtime-1 as runtime-2
 COPY --from=build-2 /go/bin/vppagent-icmp-responder-nse /bin/vppagent-icmp-responder-nse
 RUN mkdir /tmp/vpp/vppagent-icmp-responder-nse/; echo 'Endpoint: "0.0.0.0:9112"' > /tmp/vpp/vppagent-icmp-responder-nse/grpc.conf
@@ -40,7 +42,8 @@ RUN mkdir /tmp/vpp/vppagent-icmp-responder-nse/; echo 'Endpoint: "0.0.0.0:9112"'
 # 3. vppagent-firewall-nse
 FROM build-2 as build-3
 ARG VERSION=unspecified
-RUN CGO_ENABLED=0 GOOS=linux go build -ldflags "-extldflags "-static" -X  main.version=${VERSION}" -o /go/bin/vppagent-firewall-nse ./test/applications/cmd/vppagent-firewall-nse
+ARG VENDORING
+RUN CGO_ENABLED=0 GOOS=linux go build ${VENDORING} -ldflags "-extldflags '-static' -X  main.version=${VERSION}" -o /go/bin/vppagent-firewall-nse ./test/applications/cmd/vppagent-firewall-nse
 FROM runtime-2 as runtime-3
 COPY --from=build-3 /go/bin/vppagent-firewall-nse /bin/vppagent-firewall-nse
 RUN mkdir /tmp/vpp/vppagent-firewall-nse/; echo 'Endpoint: "0.0.0.0:9112"' > /tmp/vpp/vppagent-firewall-nse/grpc.conf

--- a/test/applications/build/Dockerfile.vpp-test-common
+++ b/test/applications/build/Dockerfile.vpp-test-common
@@ -1,6 +1,6 @@
 ARG VPP_AGENT
-ARG VENDORING
 FROM golang:alpine as build
+ARG VENDORING
 RUN apk --no-cache add git
 ENV PACKAGEPATH=github.com/networkservicemesh/networkservicemesh/
 ENV GO111MODULE=on


### PR DESCRIPTION
Passing VENDORING="-mod vendor" will enable local vendoring

<!--- Provide a general summary of your changes in the Title above -->

## Description

To speedup local development, local Vendoring cloud be enable by passing environment variable
```
export VENDORING="-mod vendor"
```

It will call `go mod vendor` to store all deps into vendor folder and will trigger all docker images to use vendored sources.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [x] Covered by existing integration testing
- [ ] Added integration testing to cover
- [x] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
