### PR TITLE
Fix error on second k8s cleanup

### DIFF
--- a/test/kubetest/k8s.go
+++ b/test/kubetest/k8s.go
@@ -573,7 +573,7 @@ func (k8s *K8s) Cleanup() {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		_ = k8s.DeleteRoles(k8s.roles)
+		k8s.roles, _ = k8s.DeleteRoles(k8s.roles)
 	}()
 
 	wg.Wait()
@@ -1045,15 +1045,16 @@ func (k8s *K8s) CreateRoles(rolesList ...string) ([]nsmrbac.Role, error) {
 }
 
 // DeleteRoles delete roles
-func (k8s *K8s) DeleteRoles(rolesList []nsmrbac.Role) error {
+func (k8s *K8s) DeleteRoles(rolesList []nsmrbac.Role) ([]nsmrbac.Role, error) {
 	for i := range rolesList {
 		err := rolesList[i].Delete(k8s.clientset, rolesList[i].GetName())
 		if err != nil {
 			logrus.Errorf("failed deleting role: %v %v", rolesList[i], err)
-			return err
+			return rolesList[i:], err
 		}
 	}
-	return nil
+
+	return nil, nil
 }
 
 // setIPVersion choose whether or not to use IPv6 in testing


### PR DESCRIPTION
Signed-off-by: Artem Belov <artem.belov@xored.com>

## Description
Clear roles list after success deleting to avoid "role not found" error

## Motivation and Context
TestNSMDDeploy sometimes fails with "role not found" error
https://94838-127937836-gh.circle-artifacts.com/0/home/circleci/project/.tests/cloud_test/packet-2/011-TestNSMDDeploy-run.log

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [x] Covered by existing integration testing
- [ ] Added integration testing to cover
- [x] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
