### PR TITLE
Add pod name to cross connect mechanism

### DIFF
--- a/controlplane/pkg/apis/local/connection/constants.go
+++ b/controlplane/pkg/apis/local/connection/constants.go
@@ -2,6 +2,7 @@ package connection
 
 const (
 	NetNsInodeKey           = "netnsInode"
+	PodNameKey              = "podName"
 	InterfaceNameKey        = "name"
 	InterfaceDescriptionKey = "description"
 	LinuxIfMaxLength        = 15 // Linux has a limit of 15 characters for an interface name

--- a/controlplane/pkg/apis/local/connection/mechanism_helpers.go
+++ b/controlplane/pkg/apis/local/connection/mechanism_helpers.go
@@ -16,7 +16,11 @@ import (
 func NewMechanism(t MechanismType, name, description string) (*Mechanism, error) {
 	inodeNum, err := tools.GetCurrentNS()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to get current network namespace: %v", err)
+	}
+	podName, err := tools.GetCurrentPodNameFromHostname()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get current pod name from hostname: %v", err)
 	}
 	rv := &Mechanism{
 		Type: t,
@@ -25,6 +29,7 @@ func NewMechanism(t MechanismType, name, description string) (*Mechanism, error)
 			InterfaceDescriptionKey: description,
 			SocketFilename:          path.Join(name, MemifSocket),
 			NetNsInodeKey:           inodeNum,
+			PodNameKey:              podName,
 		},
 	}
 	err = rv.IsValid()

--- a/pkg/tools/tools.go
+++ b/pkg/tools/tools.go
@@ -58,6 +58,12 @@ func GetCurrentNS() (string, error) {
 	return "", fmt.Errorf("namespace is not found")
 }
 
+// GetCurrentPodNameFromHostname returns pod name a container is running in
+func GetCurrentPodNameFromHostname() (string, error) {
+	podName, err := os.Hostname()
+	return podName, err
+}
+
 // SocketCleanup check for the presence of a stale socket and if it finds it, removes it.
 func SocketCleanup(listenEndpoint string) error {
 	fi, err := os.Stat(listenEndpoint)


### PR DESCRIPTION
This adds pod name taken from `/etc/hostname` as additional information to mechanism, in order to make cross connects and metrics more descriptive

Signed-off-by: Ivana Yovcheva <iyovcheva@vmware.com>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Related to kernel-forwarder metrics and Prometheus integration, as observability would require looking for traffic between specific pods

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [ ] Covered by existing integration testing
- [ ] Added integration testing to cover
- [x] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

Tested by comparing cross connects pod name data in the crossconnect-monitor with skydive

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. - documentation is going to be part of the Prometheus integration