### PR TITLE
Scale back packet retries due to high API volume

### DIFF
--- a/.cloudtest/packet.yaml
+++ b/.cloudtest/packet.yaml
@@ -3,7 +3,7 @@ providers:
   - name: "packet"
     kind: "packet"
     instances: 2
-    retry: 5
+    retry: 1
     node-count: 2
     enabled: true
     timeout: 600 # 10 minutes to start cluster


### PR DESCRIPTION
Packet has complained that we are creating issues with high API volume:

https://support.packet.com/tickets/BQHG-3192-IDKS

This may be because of our 5 retries times 2 servers == 10 requests when there is an issue with packet.  While we sort out what to do about it, lets reduce the retries to 1 for the moment.

Signed-off-by: Ed Warnicke <hagbard@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [ ] Covered by existing integration testing
- [ ] Added integration testing to cover
- [ ] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
