### PR TITLE
Fix vet error about not finding a constant in case of MacOS host machine

### DIFF
--- a/dataplane/kernel-forwarder/pkg/kernelforwarder/common.go
+++ b/dataplane/kernel-forwarder/pkg/kernelforwarder/common.go
@@ -247,7 +247,7 @@ func addNeighbors(link netlink.Link, neighbors []*connectioncontext.IpNeighbor) 
 		}
 		neigh := netlink.Neigh{
 			LinkIndex:    link.Attrs().Index,
-			State:        netlink.NUD_REACHABLE,
+			State:        0x02, // netlink.NUD_REACHABLE, // the constant is somehow not being found in the package in case of using a darwin based machine
 			IP:           net.ParseIP(neighbor.GetIp()),
 			HardwareAddr: mac,
 		}


### PR DESCRIPTION
Signed-off-by: Radoslav Dimitrov <dimitrovr@vmware.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Replace the constant with its value. For some reason on Mac the `netlink.NUD_REACHABLE` constant cannot be found in the `netlink` package resulting in a vet error.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [ ] Covered by existing integration testing
- [ ] Added integration testing to cover
- [ ] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.