### PR TITLE
Unify nsm namespaces for cloudtest

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -128,7 +128,7 @@ jobs:
           path: ~/postmortem
     environment:
       GO111MODULE: "on"
-      NSM_NAMESPACE: "nsm-system-integration"
+      NSM_NAMESPACE: "nsm-system"
 
 # build
   build-container:

--- a/.cloudtest.yaml
+++ b/.cloudtest.yaml
@@ -136,7 +136,7 @@ executions:
   - name: "Example-helm-icmp"
     kind: shell
     env:
-      - NSM_NAMESPACE=default
+      - NSM_NAMESPACE=nsm-system
       - CLUSTER_RULES_PREFIX=null
     kubernetes-env:
       - KUBECONFIG


### PR DESCRIPTION
Signed-off-by: Artem Belov <artem.belov@xored.com>

## Description
Change NSM_NAMESPACE system env to nsm-system for all cloud tests

## Motivation and Context
Go tests does not cleanup stacked pods because of different namespaces
https://circleci.com/gh/networkservicemesh/networkservicemesh/96707

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [x] Covered by existing integration testing
- [ ] Added integration testing to cover
- [ ] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
