### PR TITLE
Add stack filter for deleting all aws clusters tool

### DIFF
--- a/scripts/aws/destroy-kubernetes-cluster.go
+++ b/scripts/aws/destroy-kubernetes-cluster.go
@@ -282,7 +282,7 @@ func deleteAllKubernetesClusters(saveDuration time.Duration) {
 	cfClient := cloudformation.New(sess)
 
 	var filter = []*string{aws.String("CREATE_IN_PROGRESS"), aws.String("CREATE_FAILED"), aws.String("CREATE_COMPLETE"), aws.String("ROLLBACK_IN_PROGRESS"), aws.String("ROLLBACK_FAILED"), aws.String("ROLLBACK_COMPLETE"), aws.String("DELETE_IN_PROGRESS"), aws.String("DELETE_FAILED"), aws.String("UPDATE_IN_PROGRESS"), aws.String("UPDATE_COMPLETE_CLEANUP_IN_PROGRESS"), aws.String("UPDATE_COMPLETE"), aws.String("UPDATE_ROLLBACK_IN_PROGRESS"), aws.String("UPDATE_ROLLBACK_FAILED"), aws.String("UPDATE_ROLLBACK_COMPLETE_CLEANUP_IN_PROGRESS"), aws.String("UPDATE_ROLLBACK_COMPLETE"), aws.String("REVIEW_IN_PROGRESS")}
-	stacks, err := cfClient.ListStacks(&cloudformation.ListStacksInput{StackStatusFilter:filter})
+	stacks, err := cfClient.ListStacks(&cloudformation.ListStacksInput{StackStatusFilter: filter})
 	if err != nil {
 		logrus.Infof("AWS EKS Error: %v", err)
 		return

--- a/scripts/aws/destroy-kubernetes-cluster.go
+++ b/scripts/aws/destroy-kubernetes-cluster.go
@@ -281,7 +281,8 @@ func deleteAllKubernetesClusters(saveDuration time.Duration) {
 	sess := session.Must(session.NewSession())
 	cfClient := cloudformation.New(sess)
 
-	stacks, err := cfClient.ListStacks(&cloudformation.ListStacksInput{})
+	var filter = []*string{aws.String("CREATE_IN_PROGRESS"), aws.String("CREATE_FAILED"), aws.String("CREATE_COMPLETE"), aws.String("ROLLBACK_IN_PROGRESS"), aws.String("ROLLBACK_FAILED"), aws.String("ROLLBACK_COMPLETE"), aws.String("DELETE_IN_PROGRESS"), aws.String("DELETE_FAILED"), aws.String("UPDATE_IN_PROGRESS"), aws.String("UPDATE_COMPLETE_CLEANUP_IN_PROGRESS"), aws.String("UPDATE_COMPLETE"), aws.String("UPDATE_ROLLBACK_IN_PROGRESS"), aws.String("UPDATE_ROLLBACK_FAILED"), aws.String("UPDATE_ROLLBACK_COMPLETE_CLEANUP_IN_PROGRESS"), aws.String("UPDATE_ROLLBACK_COMPLETE"), aws.String("REVIEW_IN_PROGRESS")}
+	stacks, err := cfClient.ListStacks(&cloudformation.ListStacksInput{StackStatusFilter:filter})
 	if err != nil {
 		logrus.Infof("AWS EKS Error: %v", err)
 		return


### PR DESCRIPTION
Signed-off-by: Artem Belov <artem.belov@xored.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
Filter out deleted stacks when deleting all clusters

## Motivation and Context
cloudformation.ListStacksInput api function returns limited result of stacks. Filtering out deleted stacks give full list of active stacks.

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [ ] Covered by existing integration testing
- [ ] Added integration testing to cover
- [x] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
