### PR TITLE
Do force deleting of stucked pods after examples tests

### DIFF
--- a/.cloudtest.yaml
+++ b/.cloudtest.yaml
@@ -128,11 +128,13 @@ executions:
       make k8s-logs-snapshot
       make helm-delete-vpn helm-delete-nsm
       make k8s-deconfig k8s-config
+      kubectl delete pods --force --grace-period 0 -n "$NSM_NAMESPACE" --all
     on_fail: |
       kubectl get pod -o=custom-columns=NAME:.metadata.name,STATUS:.status.phase,NODE:.spec.nodeName --all-namespaces
       make k8s-logs-snapshot
       make helm-delete-vpn helm-delete-nsm
       make k8s-deconfig k8s-config
+      kubectl delete pods --force --grace-period 0 -n "$NSM_NAMESPACE" --all
 
   - name: "Example-helm-icmp"
     kind: shell
@@ -149,8 +151,10 @@ executions:
       make k8s-logs-snapshot
       make helm-delete-icmp-responder helm-delete-nsm
       make k8s-deconfig k8s-config
+      kubectl delete pods --force --grace-period 0 -n "$NSM_NAMESPACE" --all
     on_fail: |
       kubectl get pod -o=custom-columns=NAME:.metadata.name,STATUS:.status.phase,NODE:.spec.nodeName --all-namespaces
       make k8s-logs-snapshot
       make helm-delete-icmp-responder helm-delete-nsm
       make k8s-deconfig k8s-config
+      kubectl delete pods --force --grace-period 0 -n "$NSM_NAMESPACE" --all


### PR DESCRIPTION
Signed-off-by: Artem Belov <artem.belov@xored.com>

## Description
Do force pods deleting to be sure that nsmgr release node ports.

## Motivation and Context
Sometimes pods are stuck at _Terminating_ status after helm-delete-* command. Stucked pod does not release node port and breakes next tests
https://circleci.com/gh/networkservicemesh/networkservicemesh/96707

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [x] Covered by existing integration testing
- [ ] Added integration testing to cover
- [x] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
