### PR TITLE
Fix panic error in test moving connection

### DIFF
--- a/test/integration/bench_connection_test.go
+++ b/test/integration/bench_connection_test.go
@@ -148,6 +148,9 @@ func createNodes(g *WithT, k8s *kubetest.K8s, count int) []*kubetest.NodeConf {
 func createNscAndPingIcmp(g *WithT, k8s *kubetest.K8s, id int, node *v1.Node, done chan nscPingResult, nscDeploy kubetest.PodSupplier, pingNse kubetest.NsePinger) {
 	nsc := nscDeploy(k8s, node, nscDefaultName+strconv.Itoa(id), defaultTimeout)
 	g.Expect(nsc.Name).To(Equal(nscDefaultName + strconv.Itoa(id)))
+	defer func() {
+		recover()
+	}()
 	done <- nscPingResult{
 		success: pingNse(k8s, nsc),
 		nsc:     nsc,


### PR DESCRIPTION
Signed-off-by: Artem Belov <artem.belov@xored.com>

## Description
Do recover if "done" channel is already closed. 

## Motivation and Context
Pods are not cleaned up properly if "done" channel is already closed.
```
panic: send on closed channel

goroutine 429 [running]:
github.com/networkservicemesh/networkservicemesh/test/integration.createNscAndPingIcmp(0xc000333cd0, 0xc0003c0510, 0x2, 0xc0002cd080, 0xc000193440, 0x21e9660, 0x21e9680)
	/Users/artem/go/src/github.com/networkservicemesh/networkservicemesh/test/integration/bench_connection_test.go:152 +0x2da
created by github.com/networkservicemesh/networkservicemesh/test/integration.testMovingConnection
	/Users/artem/go/src/github.com/networkservicemesh/networkservicemesh/test/integration/bench_connection_test.go:102 +0x391
```

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [ ] Covered by existing integration testing
- [ ] Added integration testing to cover
- [x] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
