### PR TITLE
Fix yamllint so that we have *no* warnings

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,9 +13,10 @@ jobs:
       - checkout
       - run:
           command: |
-            sudo apt-get install yamllint python3-pkg-resources
+            sudo apt-get install python-pip python3-pkg-resources
+            pip install --user yamllint
             ./.circleci/install-shellcheck.sh
-      - run: yamllint -c .yamllint.yml $(git ls-files '*.yaml' '*.yml')
+      - run: yamllint -c .yamllint.yml --strict .
       - run: go version
       - run:
           name: Download Go Dependencies

--- a/.cloudtest.yaml
+++ b/.cloudtest.yaml
@@ -1,6 +1,7 @@
+---
 version: 1.0
 root: "./.tests/cloud_test/"
-timeout: 7200 # 2 hour total total timeout
+timeout: 7200  # 2 hour total total timeout
 import:
   - .cloudtest/packet.yaml
   - .cloudtest/gke.yaml

--- a/.cloudtest/aws.yaml
+++ b/.cloudtest/aws.yaml
@@ -1,3 +1,4 @@
+---
 version: 1.0
 providers:
   - name: "aws"
@@ -6,7 +7,7 @@ providers:
     retry: 2
     node-count: 2
     enabled: true
-    timeout: 3600 # 60 minutes to start cluster
+    timeout: 3600  # 60 minutes to start cluster
     env:
       - CLUSTER_RULES_PREFIX=aws
       - AWS_CLUSTER_NAME=$(cluster-name)-$(date)-${CIRCLE_BUILD_NUM}-$(rands10)

--- a/.cloudtest/azure.yaml
+++ b/.cloudtest/azure.yaml
@@ -1,3 +1,4 @@
+---
 version: 1.0
 providers:
   - name: "azure"
@@ -6,7 +7,7 @@ providers:
     retry: 5
     node-count: 2
     enabled: true
-    timeout: 3600 # 30 minutes to start cluster
+    timeout: 3600  # 30 minutes to start cluster
     env:
       - CLUSTER_RULES_PREFIX=azure
       - AZURE_CLUSTER_NAME=$(cluster-name)-$(date)-${CIRCLE_BUILD_NUM}-$(rands10)

--- a/.cloudtest/gke.yaml
+++ b/.cloudtest/gke.yaml
@@ -1,3 +1,4 @@
+---
 version: 1.0
 providers:
   - name: "gke"
@@ -6,7 +7,7 @@ providers:
     retry: 5
     node-count: 2
     enabled: true
-    timeout: 900 # 15 minutes to start cluster
+    timeout: 900  # 15 minutes to start cluster
     env:
       - GKE_PROJECT_ID=ci-management
       - CLUSTER_RULES_PREFIX=gke
@@ -23,10 +24,10 @@ providers:
       - COMMIT
     scripts:
       install: ./.cloudtest/gke/init.sh
-      zone-selector: ./.cloudtest/gke/list_zones.sh ci-management # List zones, but it need GKE_PROJECT_ID to be passed.
+      zone-selector: ./.cloudtest/gke/list_zones.sh ci-management  # List zones, but it need GKE_PROJECT_ID to be passed.
       start: |
         make gke-start
       stop: make gke-destroy
-      #config: # We do not need it since we put KUBECONFIG into env.
+      # config: # We do not need it since we put KUBECONFIG into env.
       prepare: |
         make k8s-config helm-init

--- a/.cloudtest/helm-rbac.yaml
+++ b/.cloudtest/helm-rbac.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/.cloudtest/kind.yaml
+++ b/.cloudtest/kind.yaml
@@ -1,3 +1,4 @@
+---
 version: 1.0
 providers:
   - name: "kind"
@@ -6,7 +7,7 @@ providers:
     node-count: 3
     retry: 10
     enabled: false
-    timeout: 300 # 5 minutes to start cluster
+    timeout: 300  # 5 minutes to start cluster
     stop-delay: 10
     env:
       - CLUSTER_RULES_PREFIX=kind

--- a/.cloudtest/packet.yaml
+++ b/.cloudtest/packet.yaml
@@ -1,3 +1,4 @@
+---
 version: 1.0
 providers:
   - name: "packet"
@@ -6,9 +7,9 @@ providers:
     retry: 5
     node-count: 2
     enabled: true
-    timeout: 1800 # 30 minutes to start cluster
+    timeout: 1800  # 30 minutes to start cluster
     env:
-      - CLUSTER_RULES_PREFIX=null # To not add any specific code
+      - CLUSTER_RULES_PREFIX=null  # To not add any specific code
       - KUBECONFIG=$(tempdir)/config
       - CLUSTER_NAME=$(cluster-name)-$(date)-${CIRCLE_BUILD_NUM}-$(rands10)
     env-check:

--- a/.cloudtest/vagrant.yaml
+++ b/.cloudtest/vagrant.yaml
@@ -1,3 +1,4 @@
+---
 version: 1.0
 providers:
   - name: "vagrant"
@@ -6,7 +7,7 @@ providers:
     retry: 3
     node-count: 2
     enabled: false
-    timeout: 900 # 15 minutes to start cluster
+    timeout: 900  # 15 minutes to start cluster
     env:
       - CLUSTER_RULES_PREFIX=vagrant
       - CONTAINER_BUILD_PREFIX=docker

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,3 +1,4 @@
+---
 run:
   concurrency: 4
   deadline: 15m
@@ -93,8 +94,8 @@ linters:
     - depguard
     - lll
     - gofmt
-    - varcheck #deprecated
-    - unused #deprecated
+    - varcheck  # deprecated
+    - unused  # deprecated
     - goimports
   enable-all: true
 issues:
@@ -125,7 +126,7 @@ issues:
         - dupl
     - path: controlplane/pkg/nsm.nsm.go
       linters:
-        - gocyclo # TODO: reduce nsm.request() complexity
+        - gocyclo  # TODO: reduce nsm.request() complexity
     - path: test/cloudtest/pkg/utils/process.go
       linters:
         - gosec

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,8 +1,12 @@
 ---
 extends: default
 
+yaml-files:
+  - '*.yaml'
+  - '*.yml'
+
 rules:
   # 80 chars should be enough, but don't fail if a line is longer
-  line-length:
-    max: 80
-    level: warning
+  line-length: disable
+  comments-indentation:
+    ignore: .circleci/config.yml

--- a/controllers/sriov-controller/sriov-client.yaml
+++ b/controllers/sriov-controller/sriov-client.yaml
@@ -22,14 +22,14 @@ spec:
           imagePullPolicy: Always
           resources:
             limits:
-#
-# Specify the list of network services required for a client pod.
-# The format should be: networkservicemesh.io/sriov-{network service name}: {number of services}
-#
-#              networkservicemesh.io/sriov-trunk: 2
-#              networkservicemesh.io/sriov-vlan10: 1
-#              networkservicemesh.io/sriov-vlan20: 1
-#              networkservicemesh.io/sriov-mgmt: 1
+            #
+            # Specify the list of network services required for a client pod.
+            # The format should be: networkservicemesh.io/sriov-{network service name}: {number of services}
+            #
+            #              networkservicemesh.io/sriov-trunk: 2
+            #              networkservicemesh.io/sriov-vlan10: 1
+            #              networkservicemesh.io/sriov-vlan20: 1
+            #              networkservicemesh.io/sriov-mgmt: 1
           securityContext:
             capabilities:
               add:

--- a/deployments/helm/icmp-responder/Chart.yaml
+++ b/deployments/helm/icmp-responder/Chart.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 appVersion: "0.2.0"
 description: A Helm chart for Kubernetes

--- a/deployments/helm/icmp-responder/values.yaml
+++ b/deployments/helm/icmp-responder/values.yaml
@@ -1,3 +1,4 @@
+---
 # Default values for icmp-responder.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.

--- a/deployments/helm/nsm-monitoring/Chart.yaml
+++ b/deployments/helm/nsm-monitoring/Chart.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 appVersion: "0.2.0"
 description: A Helm chart for Kubernetes

--- a/deployments/helm/nsm-monitoring/values.yaml
+++ b/deployments/helm/nsm-monitoring/values.yaml
@@ -1,3 +1,4 @@
+---
 # Default values for nsm-monitoring.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.

--- a/deployments/helm/nsm/Chart.yaml
+++ b/deployments/helm/nsm/Chart.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 appVersion: "0.2.0"
 description: A Helm chart for Kubernetes

--- a/deployments/helm/nsm/charts/admission-webhook/Chart.yaml
+++ b/deployments/helm/nsm/charts/admission-webhook/Chart.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 appVersion: "0.2.0"
 description: A Helm chart for Kubernetes

--- a/deployments/helm/nsm/charts/admission-webhook/values.yaml
+++ b/deployments/helm/nsm/charts/admission-webhook/values.yaml
@@ -1,3 +1,4 @@
+---
 # Default values for admission-webhook.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.

--- a/deployments/helm/nsm/values.yaml
+++ b/deployments/helm/nsm/values.yaml
@@ -1,3 +1,4 @@
+---
 # Default values for nsm.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.

--- a/deployments/helm/proxy-nsmgr/Chart.yaml
+++ b/deployments/helm/proxy-nsmgr/Chart.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Kubernetes

--- a/deployments/helm/proxy-nsmgr/values.yaml
+++ b/deployments/helm/proxy-nsmgr/values.yaml
@@ -1,3 +1,4 @@
+---
 # Default values for vpn.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.

--- a/deployments/helm/vpn/Chart.yaml
+++ b/deployments/helm/vpn/Chart.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 appVersion: "0.2.0"
 description: A Helm chart for Kubernetes

--- a/deployments/helm/vpn/values.yaml
+++ b/deployments/helm/vpn/values.yaml
@@ -1,3 +1,4 @@
+---
 # Default values for vpn.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.

--- a/deployments/helm/vpp-icmp-responder/Chart.yaml
+++ b/deployments/helm/vpp-icmp-responder/Chart.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 appVersion: "0.2.0"
 description: A Helm chart for Kubernetes

--- a/deployments/helm/vpp-icmp-responder/values.yaml
+++ b/deployments/helm/vpp-icmp-responder/values.yaml
@@ -1,3 +1,4 @@
+---
 # Default values for vpp-icmp-responder.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.

--- a/k8s/conf/admission-webhook-cfg.yaml
+++ b/k8s/conf/admission-webhook-cfg.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: MutatingWebhookConfiguration
 metadata:

--- a/k8s/conf/admission-webhook.yaml
+++ b/k8s/conf/admission-webhook.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/k8s/conf/cpu-defaults.yaml
+++ b/k8s/conf/cpu-defaults.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: LimitRange
 metadata:

--- a/k8s/conf/jaeger.yaml
+++ b/k8s/conf/jaeger.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/k8s/conf/skydive.yaml
+++ b/k8s/conf/skydive.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: Service
 metadata:

--- a/scripts/aws/aws-auth-cm-temp.yaml
+++ b/scripts/aws/aws-auth-cm-temp.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/scripts/kind.yaml
+++ b/scripts/kind.yaml
@@ -1,3 +1,4 @@
+---
 kind: Cluster
 apiVersion: kind.sigs.k8s.io/v1alpha3
 nodes:

--- a/scripts/vagrant/skydive.yaml
+++ b/scripts/vagrant/skydive.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: Service
 metadata:

--- a/test/cloudtest/pkg/tests/config1.yaml
+++ b/test/cloudtest/pkg/tests/config1.yaml
@@ -1,3 +1,4 @@
+---
 version: 1.0
 root: "./.tests/cloud_test/"
 providers:


### PR DESCRIPTION
Trying to fish actual errors out of the warnings is really
annoying.  This patch fixes the warnings, and shifts to
--strict to fail on warnings.

Also puts the file match for yaml files into the .yamllint.yaml file
so we can just run against .



<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [ ] Covered by existing integration testing
- [ ] Added integration testing to cover
- [ ] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.