### PR TITLE
Add ability to rebase with /rebase comment via GitHub Actions

### DIFF
--- a/.github/workflows/rebase.yaml
+++ b/.github/workflows/rebase.yaml
@@ -1,0 +1,13 @@
+---
+on: issue_comment
+name: Automatic Rebase
+jobs:
+  rebase:
+    name: Rebase
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - name: Automatic Rebase
+        uses: cirrus-actions/rebase@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -6,6 +6,7 @@ yaml-files:
   - '*.yml'
 
 rules:
+  truthy: disable
   # 80 chars should be enough, but don't fail if a line is longer
   line-length: disable
   comments-indentation:


### PR DESCRIPTION
Also disable 'truthy' yamllint rule, which will fail on the
GitHub Actions yaml file key 'on' even though its completely valid.



<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [ ] Covered by existing integration testing
- [ ] Added integration testing to cover
- [ ] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.