### PR TITLE
Disable matching any selector if already has been matched by some non…

### DIFF
--- a/controlplane/pkg/selector/match_selector.go
+++ b/controlplane/pkg/selector/match_selector.go
@@ -51,11 +51,22 @@ func isSubset(A, B map[string]string) bool {
 
 func (m *matchSelector) matchEndpoint(nsLabels map[string]string, ns *registry.NetworkService, networkServiceEndpoints []*registry.NetworkServiceEndpoint) *registry.NetworkServiceEndpoint {
 	logrus.Infof("Matching endpoint for labels %v", nsLabels)
+
+	matchedNonEmptySelector := false
 	//Iterate through the matches
 	for _, match := range ns.GetMatches() {
 		// All match source selector labels should be present in the requested labels map
 		if !isSubset(nsLabels, match.GetSourceSelector()) {
 			continue
+		}
+
+		// If we already have matched any non empty selector we shouldn't match empty selector
+		if len(match.GetSourceSelector()) == 0 && matchedNonEmptySelector {
+			continue
+		}
+
+		if len(match.GetSourceSelector()) != 0 {
+			matchedNonEmptySelector = true
 		}
 
 		nseCandidates := []*registry.NetworkServiceEndpoint{}

--- a/controlplane/pkg/selector/match_selector_test.go
+++ b/controlplane/pkg/selector/match_selector_test.go
@@ -466,7 +466,53 @@ func Test_matchSelector_SelectEndpoint(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "match any with non-empty source selector",
+			args: args{
+				requestConnection: &connection.Connection{
+					Labels: map[string]string{
+						"app": "firewall",
+					},
+				},
+				ns: &registry.NetworkService{
+					Name: "test-ns",
+					Matches: []*registry.Match{
+						{
+							SourceSelector: map[string]string{
+								"app": "firewall",
+							},
+							Routes: []*registry.Destination{
+								{
+									DestinationSelector: map[string]string{
+										"app": "passthrough-1",
+									},
+								},
+							},
+						},
+						{
+							Routes: []*registry.Destination{
+								{
+									DestinationSelector: map[string]string{
+										"app": "firewall",
+									},
+								},
+							},
+						},
+					},
+				},
+				networkServiceEndpoints: []*registry.NetworkServiceEndpoint{
+					{
+						Name: "firewall",
+						Labels: map[string]string{
+							"app": "firewall",
+						},
+					},
+				},
+			},
+			want: nil,
+		},
 	}
+
 	m := NewMatchSelector()
 
 	for _, tt := range tests {


### PR DESCRIPTION
…-empty one

Signed-off-by: lobkovilya <ilya.lobkov@xored.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Disable matching any selector if already has been matched by some non-empty selector

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
If we have NetworkService:
```yaml
---
apiVersion: networkservicemesh.io/v1alpha1
kind: NetworkService
metadata:
  name: secure-intranet-connectivity
spec:
  payload: IP
  matches:
    - match:
      sourceSelector:
        app: firewall
      route:
        - destination:
          destinationSelector:
            app: passthrough-1
    - match:
      sourceSelector:
        app: passthrough-1
      route:
        - destination:
          destinationSelector:
            app: passthrough-2
    - match:
      sourceSelector:
        app: passthrough-2
      route:
        - destination:
          destinationSelector:
            app: passthrough-3
    - match:
      sourceSelector:
        app: passthrough-3
      route:
        - destination:
          destinationSelector:
            app: vpn-gateway
    - match:
      route:
        - destination:
          destinationSelector:
            app: firewall
```

And we have request with *sourceSelector* is `app: firewall` but there is no available `app: passthrough-1` we will match empty *sourceSelector* and request will be forwarded to `firewall`. 

That doesn't look like expected behavior. If we successfully matched some *sourceSelector* and there is no endpoint with matched *destinationSelector* we have to return empty list of endpoints.

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [ ] Covered by existing integration testing
- [X] Added integration testing to cover
- [X] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
