### PR TITLE
Move nsm_monitor tests to nsm monitor in sidecar/ to avoid dep      controlplane/go.mod should not depend on side-car

### DIFF
--- a/controlplane/go.mod
+++ b/controlplane/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/networkservicemesh/networkservicemesh/dataplane/api v0.1.0
 	github.com/networkservicemesh/networkservicemesh/pkg v0.1.0
 	github.com/networkservicemesh/networkservicemesh/sdk v0.1.0
-	github.com/networkservicemesh/networkservicemesh/side-cars v0.1.0
 	github.com/networkservicemesh/networkservicemesh/utils v0.1.0
 	github.com/onsi/gomega v1.7.0
 	github.com/opentracing/opentracing-go v1.1.0

--- a/controlplane/go.sum
+++ b/controlplane/go.sum
@@ -16,7 +16,9 @@ github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5y
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/grpc-ecosystem/grpc-opentracing v0.0.0-20180507213350-8e809c8a8645 h1:MJG/KsmcqMwFAkh8mTnAwhyKoB+sTAnY4CACC110tbU=
 github.com/grpc-ecosystem/grpc-opentracing v0.0.0-20180507213350-8e809c8a8645/go.mod h1:6iZfnjpejD4L/4DwD7NryNaJyCQdzwWwH2MWhCA90Kw=
+github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
+github.com/hashicorp/go-multierror v1.0.0 h1:iVjPR7a6H0tWELX5NxNe7bYopibicUzc7uPribsnS6o=
 github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
@@ -40,6 +42,7 @@ github.com/sirupsen/logrus v1.4.2 h1:SPIRibHv4MatM3XXNO2BJeFLZwZ2LvZgfQ5+UNI2im4
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+github.com/teris-io/shortid v0.0.0-20171029131806-771a37caa5cf h1:Z2X3Os7oRzpdJ75iPqWZc0HeJWFYNCvKsfpQwFpRNTA=
 github.com/teris-io/shortid v0.0.0-20171029131806-771a37caa5cf/go.mod h1:M8agBzgqHIhgj7wEn9/0hJUZcrvt9VY+Ln+S1I5Mha0=
 github.com/uber/jaeger-client-go v2.17.0+incompatible h1:35tpDuT3k0oBiN/aGoSWuiFaqKgKZSciSMnWrazhSHE=
 github.com/uber/jaeger-client-go v2.17.0+incompatible/go.mod h1:WVhlPFC8FDjOFMMWRy2pZqQJSXxYSwNYOkTr/Z6d3Kk=

--- a/controlplane/pkg/tests/heal_nse_test.go
+++ b/controlplane/pkg/tests/heal_nse_test.go
@@ -17,28 +17,28 @@ import (
 func TestHealRemoteNSE(t *testing.T) {
 	g := NewWithT(t)
 
-	storage := newSharedStorage()
-	srv := newNSMDFullServer(Master, storage)
-	srv2 := newNSMDFullServer(Worker, storage)
+	storage := NewSharedStorage()
+	srv := NewNSMDFullServer(Master, storage)
+	srv2 := NewNSMDFullServer(Worker, storage)
 	defer srv.Stop()
 	defer srv2.Stop()
 
-	srv.testModel.AddDataplane(testDataplane1)
-	srv2.testModel.AddDataplane(testDataplane2)
+	srv.TestModel.AddDataplane(testDataplane1)
+	srv2.TestModel.AddDataplane(testDataplane2)
 
 	// Register in both
 	nseReg := srv2.registerFakeEndpointWithName("golden_network", "test", Worker, "ep1")
 	nseReg2 := srv2.registerFakeEndpointWithName("golden_network", "test", Worker, "ep2")
 
 	// Add to local endpoints for Server2
-	srv2.testModel.AddEndpoint(nseReg)
-	srv2.testModel.AddEndpoint(nseReg2)
+	srv2.TestModel.AddEndpoint(nseReg)
+	srv2.TestModel.AddEndpoint(nseReg2)
 
 	l1 := newTestConnectionModelListener()
 	l2 := newTestConnectionModelListener()
 
-	srv.testModel.AddListener(l1)
-	srv2.testModel.AddListener(l2)
+	srv.TestModel.AddListener(l1)
+	srv2.TestModel.AddListener(l2)
 
 	// Now we could try to connect via Client API
 	nsmClient, conn := srv.requestNSMConnection("nsm-1")
@@ -73,10 +73,10 @@ func TestHealRemoteNSE(t *testing.T) {
 	g.Expect(nsmResponse.GetNetworkService()).To(Equal("golden_network"))
 
 	// We need to check for cross connections.
-	clientConnection1 := srv.testModel.GetClientConnection(nsmResponse.GetId())
+	clientConnection1 := srv.TestModel.GetClientConnection(nsmResponse.GetId())
 	g.Expect(clientConnection1.GetID()).To(Equal("1"))
 
-	clientConnection2 := srv2.testModel.GetClientConnection(clientConnection1.Xcon.GetRemoteDestination().GetId())
+	clientConnection2 := srv2.TestModel.GetClientConnection(clientConnection1.Xcon.GetRemoteDestination().GetId())
 	g.Expect(clientConnection2.GetID()).To(Equal("1"))
 
 	// We need to inform cross connection monitor about this connection, since dataplane is fake one.
@@ -90,7 +90,7 @@ func TestHealRemoteNSE(t *testing.T) {
 		t.Fatal("Err must be nil")
 	}
 
-	srv2.testModel.DeleteEndpoint(epName)
+	srv2.TestModel.DeleteEndpoint(epName)
 
 	// Simlate delete
 	clientConnection2.Xcon.GetLocalDestination().State = connection.State_DOWN
@@ -101,7 +101,7 @@ func TestHealRemoteNSE(t *testing.T) {
 	// Second update is update
 	l1.WaitUpdate(7, timeout, t)
 
-	clientConnection1_1 := srv.testModel.GetClientConnection(nsmResponse.GetId())
+	clientConnection1_1 := srv.TestModel.GetClientConnection(nsmResponse.GetId())
 	g.Expect(clientConnection1_1.GetID()).To(Equal("1"))
 	g.Expect(clientConnection1_1.Xcon.GetRemoteDestination().GetId()).To(Equal("3"))
 }

--- a/controlplane/pkg/tests/nsmd_plugin_registry_test.go
+++ b/controlplane/pkg/tests/nsmd_plugin_registry_test.go
@@ -36,11 +36,11 @@ func (cp *dummyConnectionPlugin) ValidateConnection(ctx context.Context, wrapper
 func TestDummyConnectionPlugin(t *testing.T) {
 	g := NewWithT(t)
 
-	storage := newSharedStorage()
-	srv := newNSMDFullServer(Master, storage)
+	storage := NewSharedStorage()
+	srv := NewNSMDFullServer(Master, storage)
 	defer srv.Stop()
-	srv.addFakeDataplane("test_data_plane", "tcp:some_addr")
-	srv.testModel.AddEndpoint(srv.registerFakeEndpoint("golden_network", "test", Master))
+	srv.AddFakeDataplane("test_data_plane", "tcp:some_addr")
+	srv.TestModel.AddEndpoint(srv.RegisterFakeEndpoint("golden_network", "test", Master))
 
 	plugin := &dummyConnectionPlugin{
 		prefixes: []string{"10.10.1.0/24"},
@@ -50,7 +50,7 @@ func TestDummyConnectionPlugin(t *testing.T) {
 	nsmClient, conn := srv.requestNSMConnection("nsm")
 	defer func() { _ = conn.Close() }()
 
-	request := createRequest()
+	request := CreateRequest()
 
 	nsmResponse, err := nsmClient.Request(context.Background(), request)
 	g.Expect(err).To(BeNil())
@@ -64,11 +64,11 @@ func TestDummyConnectionPlugin(t *testing.T) {
 func TestDummyConnectionPlugin2(t *testing.T) {
 	g := NewWithT(t)
 
-	storage := newSharedStorage()
-	srv := newNSMDFullServer(Master, storage)
+	storage := NewSharedStorage()
+	srv := NewNSMDFullServer(Master, storage)
 	defer srv.Stop()
-	srv.addFakeDataplane("test_data_plane", "tcp:some_addr")
-	srv.testModel.AddEndpoint(srv.registerFakeEndpoint("golden_network", "test", Master))
+	srv.AddFakeDataplane("test_data_plane", "tcp:some_addr")
+	srv.TestModel.AddEndpoint(srv.RegisterFakeEndpoint("golden_network", "test", Master))
 
 	plugin := &dummyConnectionPlugin{
 		shouldFail: true,
@@ -78,7 +78,7 @@ func TestDummyConnectionPlugin2(t *testing.T) {
 	nsmClient, conn := srv.requestNSMConnection("nsm")
 	defer func() { _ = conn.Close() }()
 
-	request := createRequest()
+	request := CreateRequest()
 
 	_, err := nsmClient.Request(context.Background(), request)
 	g.Expect(err).NotTo(BeNil())

--- a/controlplane/pkg/tests/nsmd_registry_test.go
+++ b/controlplane/pkg/tests/nsmd_registry_test.go
@@ -15,12 +15,12 @@ import (
 func TestNSMDRestart1(t *testing.T) {
 	g := NewWithT(t)
 
-	storage := newSharedStorage()
+	storage := NewSharedStorage()
 
-	srv := newNSMDFullServer("nsm1", storage)
-	srv.addFakeDataplane("test_data_plane", "tcp:some_addr")
+	srv := NewNSMDFullServer("nsm1", storage)
+	srv.AddFakeDataplane("test_data_plane", "tcp:some_addr")
 
-	reply := srv.requestNSM("nsm-1")
+	reply := srv.RequestNSM("nsm-1")
 
 	configuration := &common.NSConfiguration{
 		Workspace:        reply.Workspace,
@@ -41,22 +41,22 @@ func TestNSMDRestart1(t *testing.T) {
 	}
 
 	l1 := newTestConnectionModelListener()
-	srv.testModel.AddListener(l1)
+	srv.TestModel.AddListener(l1)
 	_ = nsmEndpoint.Start()
 	defer nsmEndpoint.Delete()
 
 	// Wait for at least one NSE is available.
 	l1.WaitEndpoints(1, time.Second*30, t)
 
-	endpoints1 := srv.testModel.GetEndpointsByNetworkService("test_nse")
+	endpoints1 := srv.TestModel.GetEndpointsByNetworkService("test_nse")
 	g.Expect(len(endpoints1)).To(Equal(1))
 	srv.StopNoClean()
 
 	// We need to restart server
-	storage2 := newSharedStorage()
+	storage2 := NewSharedStorage()
 	srv = newNSMDFullServerAt(context.Background(), "nsm2", storage2, srv.rootDir)
-	srv.addFakeDataplane("test_data_plane", "tcp:some_addr")
-	endpoints2 := srv.testModel.GetEndpointsByNetworkService("test_nse")
+	srv.AddFakeDataplane("test_data_plane", "tcp:some_addr")
+	endpoints2 := srv.TestModel.GetEndpointsByNetworkService("test_nse")
 
 	g.Expect(len(endpoints2)).To(Equal(1))
 	g.Expect(endpoints1[0].SocketLocation).To(Equal(endpoints2[0].SocketLocation))

--- a/controlplane/pkg/tests/nsmd_remote_test.go
+++ b/controlplane/pkg/tests/nsmd_remote_test.go
@@ -21,20 +21,20 @@ import (
 func TestNSMDRequestClientRemoteNSMD(t *testing.T) {
 	g := NewWithT(t)
 
-	storage := newSharedStorage()
-	srv := newNSMDFullServer(Master, storage)
-	srv2 := newNSMDFullServer(Worker, storage)
+	storage := NewSharedStorage()
+	srv := NewNSMDFullServer(Master, storage)
+	srv2 := NewNSMDFullServer(Worker, storage)
 	defer srv.Stop()
 	defer srv2.Stop()
 
-	srv.testModel.AddDataplane(testDataplane1)
+	srv.TestModel.AddDataplane(testDataplane1)
 
-	srv2.testModel.AddDataplane(testDataplane2)
+	srv2.TestModel.AddDataplane(testDataplane2)
 
 	// Register in both
-	nseReg := srv2.registerFakeEndpoint("golden_network", "test", Worker)
+	nseReg := srv2.RegisterFakeEndpoint("golden_network", "test", Worker)
 	// Add to local endpoints for Server2
-	srv2.testModel.AddEndpoint(nseReg)
+	srv2.TestModel.AddEndpoint(nseReg)
 
 	// Now we could try to connect via Client API
 	nsmClient, conn := srv.requestNSMConnection("nsm-1")
@@ -75,12 +75,12 @@ func TestNSMDRequestClientRemoteNSMD(t *testing.T) {
 func TestNSMDCloseCrossConnection(t *testing.T) {
 	g := NewWithT(t)
 
-	storage := newSharedStorage()
-	srv := newNSMDFullServer(Master, storage)
-	srv2 := newNSMDFullServer(Worker, storage)
+	storage := NewSharedStorage()
+	srv := NewNSMDFullServer(Master, storage)
+	srv2 := NewNSMDFullServer(Worker, storage)
 	defer srv.Stop()
 	defer srv2.Stop()
-	srv.testModel.AddDataplane(&model.Dataplane{
+	srv.TestModel.AddDataplane(&model.Dataplane{
 		RegisteredName: "test_data_plane",
 		SocketLocation: "tcp:some_addr",
 		LocalMechanisms: []connection.Mechanism{
@@ -100,7 +100,7 @@ func TestNSMDCloseCrossConnection(t *testing.T) {
 		MechanismsConfigured: true,
 	})
 
-	srv2.testModel.AddDataplane(&model.Dataplane{
+	srv2.TestModel.AddDataplane(&model.Dataplane{
 		RegisteredName: "test_data_plane",
 		SocketLocation: "tcp:some_addr",
 		RemoteMechanisms: []connection.Mechanism{
@@ -116,9 +116,9 @@ func TestNSMDCloseCrossConnection(t *testing.T) {
 	})
 
 	// Register in both
-	nseReg := srv2.registerFakeEndpoint("golden_network", "test", Worker)
+	nseReg := srv2.RegisterFakeEndpoint("golden_network", "test", Worker)
 	// Add to local endpoints for Server2
-	srv2.testModel.AddEndpoint(nseReg)
+	srv2.TestModel.AddEndpoint(nseReg)
 
 	// Now we could try to connect via Client API
 	nsmClient, conn := srv.requestNSMConnection("nsm-1")
@@ -151,12 +151,12 @@ func TestNSMDCloseCrossConnection(t *testing.T) {
 	g.Expect(nsmResponse.GetNetworkService()).To(Equal("golden_network"))
 
 	// We need to check for cross connections.
-	cross_connection := srv.testModel.GetClientConnection(nsmResponse.Id)
+	cross_connection := srv.TestModel.GetClientConnection(nsmResponse.Id)
 	g.Expect(cross_connection).ToNot(BeNil())
 
 	destConnectionId := cross_connection.Xcon.GetRemoteDestination().GetId()
 
-	cross_connection2 := srv2.testModel.GetClientConnection(destConnectionId)
+	cross_connection2 := srv2.TestModel.GetClientConnection(destConnectionId)
 	g.Expect(cross_connection2).ToNot(BeNil())
 
 	//Cross connection successfully created, check it closing
@@ -164,10 +164,10 @@ func TestNSMDCloseCrossConnection(t *testing.T) {
 	g.Expect(err).To(BeNil())
 
 	//We need to check that xcons have been removed from model
-	cross_connection = srv.testModel.GetClientConnection(nsmResponse.Id)
+	cross_connection = srv.TestModel.GetClientConnection(nsmResponse.Id)
 	g.Expect(cross_connection).To(BeNil())
 
-	cross_connection2 = srv2.testModel.GetClientConnection(destConnectionId)
+	cross_connection2 = srv2.TestModel.GetClientConnection(destConnectionId)
 	g.Expect(cross_connection2).To(BeNil())
 
 }
@@ -175,25 +175,25 @@ func TestNSMDCloseCrossConnection(t *testing.T) {
 func TestNSMDDelayRemoteMechanisms(t *testing.T) {
 	g := NewWithT(t)
 
-	storage := newSharedStorage()
-	srv := newNSMDFullServer(Master, storage)
-	srv2 := newNSMDFullServer(Worker, storage)
+	storage := NewSharedStorage()
+	srv := NewNSMDFullServer(Master, storage)
+	srv2 := NewNSMDFullServer(Worker, storage)
 	defer srv.Stop()
 	defer srv2.Stop()
 
-	srv.testModel.AddDataplane(testDataplane1)
+	srv.TestModel.AddDataplane(testDataplane1)
 
 	testDataplane2_2 := &model.Dataplane{
 		RegisteredName: "test_data_plane2",
 		SocketLocation: "tcp:some_addr",
 	}
 
-	srv2.testModel.AddDataplane(testDataplane2_2)
+	srv2.TestModel.AddDataplane(testDataplane2_2)
 
 	// Register in both
-	nseReg := srv2.registerFakeEndpoint("golden_network", "test", Worker)
+	nseReg := srv2.RegisterFakeEndpoint("golden_network", "test", Worker)
 	// Add to local endpoints for Server2
-	srv2.testModel.AddEndpoint(nseReg)
+	srv2.TestModel.AddEndpoint(nseReg)
 
 	// Now we could try to connect via Client API
 	nsmClient, conn := srv.requestNSMConnection("nsm-1")
@@ -237,7 +237,7 @@ func TestNSMDDelayRemoteMechanisms(t *testing.T) {
 	testDataplane2_2.LocalMechanisms = testDataplane2.LocalMechanisms
 	testDataplane2_2.RemoteMechanisms = testDataplane2.RemoteMechanisms
 	testDataplane2_2.MechanismsConfigured = true
-	srv2.testModel.UpdateDataplane(testDataplane2_2)
+	srv2.TestModel.UpdateDataplane(testDataplane2_2)
 
 	res := <-resultChan
 	g.Expect(res.err).To(BeNil())

--- a/controlplane/pkg/tests/restore_state_test.go
+++ b/controlplane/pkg/tests/restore_state_test.go
@@ -14,11 +14,11 @@ import (
 func TestRestoreConnectionState(t *testing.T) {
 	g := NewWithT(t)
 
-	storage := newSharedStorage()
-	srv := newNSMDFullServer(Master, storage)
+	storage := NewSharedStorage()
+	srv := NewNSMDFullServer(Master, storage)
 	defer srv.Stop()
 
-	srv.addFakeDataplane("dp1", "tcp:some_address")
+	srv.AddFakeDataplane("dp1", "tcp:some_address")
 
 	g.Expect(srv.nsmServer.Manager().WaitForDataplane(context.Background(), 1*time.Millisecond).Error()).To(Equal("Failed to wait for NSMD stare restore... timeout 1ms happened"))
 
@@ -30,11 +30,11 @@ func TestRestoreConnectionState(t *testing.T) {
 func TestRestoreConnectionStateWrongDst(t *testing.T) {
 	g := NewWithT(t)
 
-	storage := newSharedStorage()
-	srv := newNSMDFullServer(Master, storage)
+	storage := NewSharedStorage()
+	srv := NewNSMDFullServer(Master, storage)
 	defer srv.Stop()
 
-	srv.addFakeDataplane("dp1", "tcp:some_address")
+	srv.AddFakeDataplane("dp1", "tcp:some_address")
 	srv.registerFakeEndpointWithName("ns1", "IP", Worker, "ep2")
 
 	requestConnection := &connection.Connection{
@@ -65,5 +65,5 @@ func TestRestoreConnectionStateWrongDst(t *testing.T) {
 	}
 	srv.nsmServer.Manager().RestoreConnections(xcons, "dp1")
 	g.Expect(srv.nsmServer.Manager().WaitForDataplane(context.Background(), 1*time.Second)).To(BeNil())
-	g.Expect(len(srv.testModel.GetAllClientConnections())).To(Equal(0))
+	g.Expect(len(srv.TestModel.GetAllClientConnections())).To(Equal(0))
 }

--- a/controlplane/pkg/tests/select_dataplane_test.go
+++ b/controlplane/pkg/tests/select_dataplane_test.go
@@ -51,25 +51,25 @@ func TestSelectDataplane(t *testing.T) {
 			},
 		})
 
-	storage := newSharedStorage()
-	srv := newNSMDFullServer(Master, storage)
-	srv2 := newNSMDFullServer(Worker, storage)
+	storage := NewSharedStorage()
+	srv := NewNSMDFullServer(Master, storage)
+	srv2 := NewNSMDFullServer(Worker, storage)
 	defer srv.Stop()
 	defer srv2.Stop()
-	srv.testModel.AddDataplane(testDataplane1)
-	srv2.testModel.AddDataplane(testDataplane2)
-	srv.testModel.AddDataplane(testDataplane1_1)
+	srv.TestModel.AddDataplane(testDataplane1)
+	srv2.TestModel.AddDataplane(testDataplane2)
+	srv.TestModel.AddDataplane(testDataplane1_1)
 
 	// Register in both
-	nseReg := srv2.registerFakeEndpoint("golden_network", "test", Worker)
+	nseReg := srv2.RegisterFakeEndpoint("golden_network", "test", Worker)
 	// Add to local endpoints for Server2
-	srv2.testModel.AddEndpoint(nseReg)
+	srv2.TestModel.AddEndpoint(nseReg)
 
 	l1 := newTestConnectionModelListener()
 	l2 := newTestConnectionModelListener()
 
-	srv.testModel.AddListener(l1)
-	srv2.testModel.AddListener(l2)
+	srv.TestModel.AddListener(l1)
+	srv2.TestModel.AddListener(l2)
 
 	// Now we could try to connect via Client API
 	nsmClient, conn := srv.requestNSMConnection("nsm-1")

--- a/dataplane/go.sum
+++ b/dataplane/go.sum
@@ -86,6 +86,7 @@ golang.org/x/tools v0.0.0-20190311212946-11955173bddd/go.mod h1:LCzVGOaR6xXOjkQ3
 golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
+google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8 h1:Nw54tB0rB7hY/N0NQvRW8DG4Yk3Q6T9cu9RcFQDu1tc=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/genproto v0.0.0-20190611190212-a7e196e89fd3 h1:0LGHEA/u5XLibPOx6D7D8FBT/ax6wT57vNKY0QckCwo=
 google.golang.org/genproto v0.0.0-20190611190212-a7e196e89fd3/go.mod h1:z3L6/3dTEVtUr6QSP8miRzeRqwQOioJ9I66odjN4I7s=

--- a/go.sum
+++ b/go.sum
@@ -196,7 +196,9 @@ github.com/grpc-ecosystem/grpc-gateway v1.8.3/go.mod h1:vNeuVxBJEsws4ogUvrchl83t
 github.com/grpc-ecosystem/grpc-gateway v1.9.0/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
 github.com/grpc-ecosystem/grpc-opentracing v0.0.0-20180507213350-8e809c8a8645 h1:MJG/KsmcqMwFAkh8mTnAwhyKoB+sTAnY4CACC110tbU=
 github.com/grpc-ecosystem/grpc-opentracing v0.0.0-20180507213350-8e809c8a8645/go.mod h1:6iZfnjpejD4L/4DwD7NryNaJyCQdzwWwH2MWhCA90Kw=
+github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
+github.com/hashicorp/go-multierror v1.0.0 h1:iVjPR7a6H0tWELX5NxNe7bYopibicUzc7uPribsnS6o=
 github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
 github.com/hashicorp/go-syslog v1.0.0/go.mod h1:qPfqrKkXGihmCqbJM2mZgkZGvKG1dFdvsLplgctolz4=
 github.com/hashicorp/golang-lru v0.0.0-20180201235237-0fb14efe8c47/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
@@ -374,6 +376,7 @@ github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/syndtr/gocapability v0.0.0-20160928074757-e7cb7fa329f4/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
+github.com/teris-io/shortid v0.0.0-20171029131806-771a37caa5cf h1:Z2X3Os7oRzpdJ75iPqWZc0HeJWFYNCvKsfpQwFpRNTA=
 github.com/teris-io/shortid v0.0.0-20171029131806-771a37caa5cf/go.mod h1:M8agBzgqHIhgj7wEn9/0hJUZcrvt9VY+Ln+S1I5Mha0=
 github.com/tinylib/msgp v1.1.0/go.mod h1:+d+yLhGm8mzTaHzB+wgMYrodPfmZrzkirds8fDWklFE=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=

--- a/side-cars/go.mod
+++ b/side-cars/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/networkservicemesh/networkservicemesh/pkg v0.1.0
 	github.com/networkservicemesh/networkservicemesh/sdk v0.1.0
 	github.com/networkservicemesh/networkservicemesh/utils v0.1.0
+	github.com/onsi/gomega v1.7.0
 	github.com/opentracing/opentracing-go v1.1.0
 	github.com/sirupsen/logrus v1.4.2
 )

--- a/side-cars/go.sum
+++ b/side-cars/go.sum
@@ -27,6 +27,7 @@ github.com/ligato/vpp-agent v2.1.1+incompatible/go.mod h1:o9dJIGC/vLOSSajSGHZ6V0
 github.com/mesos/mesos-go v0.0.9/go.mod h1:kPYCMQ9gsOXVAle1OsoY4I1+9kPu8GHkf88aV59fDr4=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/gomega v1.5.1-0.20190520121345-efe19c39ca10/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
+github.com/onsi/gomega v1.7.0 h1:XPnZz8VVBHjVsy1vzJmRwIcSwiUO+JFfrv/xGiigmME=
 github.com/onsi/gomega v1.7.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/opentracing/opentracing-go v1.1.0 h1:pWlfV3Bxv7k65HYwkikxat0+s3pV4bsqf19k25Ur8rU=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
@@ -86,6 +87,7 @@ google.golang.org/grpc v1.23.1/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyac
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
+gopkg.in/yaml.v2 v2.2.1 h1:mUhvW9EsL+naU5Q3cakzfE91YhliOondGd6ZrsDBHQE=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/side-cars/pkg/nsm-monitor/nsm_monitor_test.go
+++ b/side-cars/pkg/nsm-monitor/nsm_monitor_test.go
@@ -1,22 +1,21 @@
-package tests
+package nsmmonitor
 
 import (
 	"context"
 	"testing"
 	"time"
 
-	nsm_monitor "github.com/networkservicemesh/networkservicemesh/side-cars/pkg/nsm-monitor"
-
 	. "github.com/onsi/gomega"
 	"github.com/sirupsen/logrus"
 
 	"github.com/networkservicemesh/networkservicemesh/controlplane/api/local/connection"
 	"github.com/networkservicemesh/networkservicemesh/controlplane/api/nsmdapi"
+	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/tests"
 	"github.com/networkservicemesh/networkservicemesh/sdk/common"
 )
 
 type nsmHelper struct {
-	nsm_monitor.EmptyNSMMonitorHandler
+	EmptyNSMMonitorHandler
 	response  *nsmdapi.ClientConnectionReply
 	connected chan bool
 	healing   chan bool
@@ -47,25 +46,25 @@ func (h *nsmHelper) GetConfiguration() *common.NSConfiguration {
 func TestNSMMonitorInit(t *testing.T) {
 	g := NewWithT(t)
 
-	storage := newSharedStorage()
-	srv := newNSMDFullServer(Master, storage)
+	storage := tests.NewSharedStorage()
+	srv := tests.NewNSMDFullServer(tests.Master, storage)
 	defer srv.Stop()
-	srv.addFakeDataplane("test_data_plane", "tcp:some_addr")
+	srv.AddFakeDataplane("test_data_plane", "tcp:some_addr")
 
-	srv.testModel.AddEndpoint(srv.registerFakeEndpoint("golden_network", "test", Master))
+	srv.TestModel.AddEndpoint(srv.RegisterFakeEndpoint("golden_network", "test", tests.Master))
 
-	monitorApp := nsm_monitor.NewNSMMonitorApp()
+	monitorApp := NewNSMMonitorApp()
 
-	response := srv.requestNSM("nsm")
+	response := srv.RequestNSM("nsm")
 	// Now we could try to connect via Client API
-	nsmClient, conn := srv.createNSClient(response)
+	nsmClient, conn := srv.CreateNSClient(response)
 	defer func() {
 		err := conn.Close()
 		if err != nil {
 			logrus.Error(err.Error())
 		}
 	}()
-	request := createRequest()
+	request := tests.CreateRequest()
 
 	nsmResponse, err := nsmClient.Request(context.Background(), request)
 	g.Expect(err).To(BeNil())


### PR DESCRIPTION
It does because nsm_monitor tests were mistakenly put in controlplane/

This patch moves them to the right place under side-car/

In the process, various test utils needed to be exposed outside
their package.

Signed-off-by: Ed Warnicke <hagbard@gmail.com>