### PR TITLE
Nsm init retry

### DIFF
--- a/sdk/client/client.go
+++ b/sdk/client/client.go
@@ -53,6 +53,7 @@ type NsmClient struct {
 func (nsmc *NsmClient) Connect(ctx context.Context, name, mechanism, description string) (*connection.Connection, error) {
 	return nsmc.ConnectRetry(ctx, name, mechanism, description, 1, 0)
 }
+
 // Connect implements the business logic
 func (nsmc *NsmClient) ConnectRetry(ctx context.Context, name, mechanism, description string, retryCount int, retryDelay time.Duration) (*connection.Connection, error) {
 
@@ -108,7 +109,7 @@ func (nsmc *NsmClient) ConnectRetry(ctx context.Context, name, mechanism, descri
 
 		var attemptSpan opentracing.Span
 		if opentracing.IsGlobalTracerRegistered() {
-			attemptSpan, attempCtx  = opentracing.StartSpanFromContext(attempCtx, fmt.Sprintf("nsmClient.Connect.attempt:%v", maxRetry-retryCount))
+			attemptSpan, attempCtx = opentracing.StartSpanFromContext(attempCtx, fmt.Sprintf("nsmClient.Connect.attempt:%v", maxRetry-retryCount))
 			defer attemptSpan.Finish()
 		}
 
@@ -126,8 +127,8 @@ func (nsmc *NsmClient) ConnectRetry(ctx context.Context, name, mechanism, descri
 			} else {
 				attemptLogger.Errorf("nsm client: Failed to connect %v. Retry attempts: %v Delaying: %v", err, retryCount, retryDelay)
 			}
-			retryCount --
-			<- time.After(retryDelay)
+			retryCount--
+			<-time.After(retryDelay)
 			continue
 		}
 		break

--- a/sdk/client/clientlist.go
+++ b/sdk/client/clientlist.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"os"
 	"strconv"
+	"time"
 
 	"github.com/sirupsen/logrus"
 
@@ -42,9 +43,14 @@ type NsmClientList struct {
 
 // Connect will create new interfaces with the specified name and mechanism
 func (nsmcl *NsmClientList) Connect(ctx context.Context, name, mechanism, description string) error {
+	return nsmcl.ConnectRetry(ctx, name, mechanism, description, 0, 0)
+}
+
+// Connect will create new interfaces with the specified name and mechanism
+func (nsmcl *NsmClientList) ConnectRetry(ctx context.Context, name, mechanism, description string, retryCount int, retryDelay time.Duration) error {
 	for idx := range nsmcl.clients {
 		entry := &nsmcl.clients[idx]
-		conn, err := entry.client.Connect(ctx, name+strconv.Itoa(idx), mechanism, description)
+		conn, err := entry.client.ConnectRetry(ctx, name+strconv.Itoa(idx), mechanism, description, retryCount, retryDelay)
 		if err != nil {
 			return err
 		}

--- a/side-cars/pkg/nsm-init/nsm-init.go
+++ b/side-cars/pkg/nsm-init/nsm-init.go
@@ -16,9 +16,11 @@ package nsminit
 
 import (
 	"context"
-	"github.com/networkservicemesh/networkservicemesh/pkg/tools"
+
 	"github.com/opentracing/opentracing-go"
 	"github.com/sirupsen/logrus"
+
+	"github.com/networkservicemesh/networkservicemesh/pkg/tools"
 
 	"github.com/networkservicemesh/networkservicemesh/sdk/client"
 )

--- a/test/applications/cmd/monitoring-nsc/main.go
+++ b/test/applications/cmd/monitoring-nsc/main.go
@@ -16,8 +16,11 @@ package main
 
 import (
 	"context"
-	nsmmonitor "github.com/networkservicemesh/networkservicemesh/side-cars/pkg/nsm-monitor"
+
+	"github.com/opentracing/opentracing-go"
 	"github.com/sirupsen/logrus"
+
+	nsmmonitor "github.com/networkservicemesh/networkservicemesh/side-cars/pkg/nsm-monitor"
 
 	"github.com/networkservicemesh/networkservicemesh/pkg/tools"
 	"github.com/networkservicemesh/networkservicemesh/sdk/client"

--- a/test/applications/cmd/monitoring-nsc/main.go
+++ b/test/applications/cmd/monitoring-nsc/main.go
@@ -16,10 +16,7 @@ package main
 
 import (
 	"context"
-
 	nsmmonitor "github.com/networkservicemesh/networkservicemesh/side-cars/pkg/nsm-monitor"
-
-	"github.com/opentracing/opentracing-go"
 	"github.com/sirupsen/logrus"
 
 	"github.com/networkservicemesh/networkservicemesh/pkg/tools"
@@ -49,10 +46,7 @@ func main() {
 	}
 	logrus.Info(nscLogFormat, "nsm client: initialization is completed successfully")
 
-	ctx, cancelProc := context.WithTimeout(context.Background(), client.ConnectTimeout)
-	defer cancelProc()
-
-	_, err = nsc.Connect(ctx, "nsm", "kernel", "Primary interface")
+	_, err = nsc.ConnectRetry(context.Background(), "nsm", "kernel", "Primary interface", client.ConnectionRetry, client.RequestDelay)
 	if err != nil {
 		logrus.Fatalf(nscLogWithParamFormat, "Failed to connect", err)
 	}

--- a/test/kubetest/k8s_exec.go.go
+++ b/test/kubetest/k8s_exec.go.go
@@ -30,7 +30,7 @@ func (o *K8s) Exec(pod *v1.Pod, container string, command ...string) (string, st
 	for retryCount := 0; retryCount < 10; retryCount++ {
 		resp1, resp2, err = o.doExec(pod, container, command...)
 		if err != nil && strings.Contains(err.Error(), fmt.Sprintf("container not found (\"%v\")", container)) {
-			<- time.After(100*time.Millisecond)
+			<-time.After(100 * time.Millisecond)
 			continue
 		}
 		break

--- a/test/kubetest/k8s_exec.go.go
+++ b/test/kubetest/k8s_exec.go.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
@@ -24,6 +25,19 @@ func (w *Writer) Write(p []byte) (n int, err error) {
 }
 
 func (o *K8s) Exec(pod *v1.Pod, container string, command ...string) (string, string, error) {
+	var resp1, resp2 string
+	var err error
+	for retryCount := 0; retryCount < 10; retryCount++ {
+		resp1, resp2, err = o.doExec(pod, container, command...)
+		if err != nil && strings.Contains(err.Error(), fmt.Sprintf("container not found (\"%v\")", container)) {
+			<- time.After(100*time.Millisecond)
+			continue
+		}
+		break
+	}
+	return resp1, resp2, err
+}
+func (o *K8s) doExec(pod *v1.Pod, container string, command ...string) (string, string, error) {
 	logrus.Infof("Executing: %v in pod %v:%v", command, pod.Name, container)
 	execRequest := o.clientset.CoreV1().RESTClient().Post().
 		Resource("pods").


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Restore nsm monitor to retry connecting to network service. Should fix #1622 

+ Fixes issue with K8s.Exec() in case pod is not available.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [x] Covered by existing integration testing
- [ ] Added integration testing to cover
- [x] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
