### PR TITLE
Fixing internal dependency versions.

### DIFF
--- a/controllers/sriov-controller/go.mod
+++ b/controllers/sriov-controller/go.mod
@@ -2,7 +2,7 @@ module github.com/networkservicemesh/networkservicemesh/controllers/sriov-contro
 
 require (
 	github.com/ghodss/yaml v0.0.0-20180820084758-c7ce16629ff4
-	github.com/networkservicemesh/networkservicemesh/pkg v0.1.0
+	github.com/networkservicemesh/networkservicemesh/pkg v0.2.0
 	github.com/sirupsen/logrus v1.4.2
 	golang.org/x/net v0.0.0-20190912160710-24e19bdeb0f2
 	google.golang.org/grpc v1.23.1

--- a/controlplane/api/go.mod
+++ b/controlplane/api/go.mod
@@ -3,8 +3,8 @@ module github.com/networkservicemesh/networkservicemesh/controlplane/api
 require (
 	github.com/gogo/protobuf v1.2.2-0.20190723190241-65acae22fc9d
 	github.com/golang/protobuf v1.3.2
-	github.com/networkservicemesh/networkservicemesh/pkg v0.1.0
-	github.com/networkservicemesh/networkservicemesh/utils v0.1.0
+	github.com/networkservicemesh/networkservicemesh/pkg v0.2.0
+	github.com/networkservicemesh/networkservicemesh/utils v0.2.0
 	github.com/sirupsen/logrus v1.4.2
 	golang.org/x/net v0.0.0-20190812203447-cdfb69ac37fc
 	google.golang.org/grpc v1.23.1

--- a/controlplane/go.mod
+++ b/controlplane/go.mod
@@ -4,11 +4,11 @@ require (
 	github.com/gogo/protobuf v1.2.2-0.20190723190241-65acae22fc9d
 	github.com/golang/protobuf v1.3.2
 	github.com/grpc-ecosystem/grpc-opentracing v0.0.0-20180507213350-8e809c8a8645
-	github.com/networkservicemesh/networkservicemesh/controlplane/api v0.1.0
-	github.com/networkservicemesh/networkservicemesh/dataplane/api v0.1.0
-	github.com/networkservicemesh/networkservicemesh/pkg v0.1.0
-	github.com/networkservicemesh/networkservicemesh/sdk v0.1.0
-	github.com/networkservicemesh/networkservicemesh/utils v0.1.0
+	github.com/networkservicemesh/networkservicemesh/controlplane/api v0.2.0
+	github.com/networkservicemesh/networkservicemesh/dataplane/api v0.2.0
+	github.com/networkservicemesh/networkservicemesh/pkg v0.2.0
+	github.com/networkservicemesh/networkservicemesh/sdk v0.2.0
+	github.com/networkservicemesh/networkservicemesh/utils v0.2.0
 	github.com/onsi/gomega v1.7.0
 	github.com/opentracing/opentracing-go v1.1.0
 	github.com/sirupsen/logrus v1.4.2

--- a/dataplane/api/go.mod
+++ b/dataplane/api/go.mod
@@ -2,7 +2,7 @@ module github.com/networkservicemesh/networkservicemesh/dataplane/api
 
 require (
 	github.com/golang/protobuf v1.3.2
-	github.com/networkservicemesh/networkservicemesh/controlplane/api v0.1.0
+	github.com/networkservicemesh/networkservicemesh/controlplane/api v0.2.0
 	google.golang.org/grpc v1.23.1
 )
 

--- a/dataplane/go.mod
+++ b/dataplane/go.mod
@@ -5,11 +5,11 @@ require (
 	github.com/golang/protobuf v1.3.2
 	github.com/ligato/cn-infra v2.0.0+incompatible
 	github.com/ligato/vpp-agent v2.1.1+incompatible
-	github.com/networkservicemesh/networkservicemesh/controlplane v0.1.0
-	github.com/networkservicemesh/networkservicemesh/controlplane/api v0.1.0
-	github.com/networkservicemesh/networkservicemesh/dataplane/api v0.1.0
-	github.com/networkservicemesh/networkservicemesh/pkg v0.1.0
-	github.com/networkservicemesh/networkservicemesh/utils v0.1.0
+	github.com/networkservicemesh/networkservicemesh/controlplane v0.2.0
+	github.com/networkservicemesh/networkservicemesh/controlplane/api v0.2.0
+	github.com/networkservicemesh/networkservicemesh/dataplane/api v0.2.0
+	github.com/networkservicemesh/networkservicemesh/pkg v0.2.0
+	github.com/networkservicemesh/networkservicemesh/utils v0.2.0
 	github.com/onsi/gomega v1.7.0
 	github.com/opentracing/opentracing-go v1.1.0
 	github.com/rs/xid v1.2.1

--- a/dataplane/go.sum
+++ b/dataplane/go.sum
@@ -72,6 +72,7 @@ golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20190422165155-953cdadca894 h1:Cz4ceDQGXuKRnVBDTS23GTn/pU5OE2C0WrNTOYK1Uuc=
 golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190618155005-516e3c20635f h1:dHNZYIYdq2QuU6w73vZ/DzesPbVlZVYZTtTZmrnsbQ8=
 golang.org/x/sys v0.0.0-20190618155005-516e3c20635f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ require (
 	github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd // indirect
 	github.com/go-errors/errors v1.0.1
 	github.com/grpc-ecosystem/grpc-opentracing v0.0.0-20180507213350-8e809c8a8645
-	github.com/networkservicemesh/networkservicemesh/test v0.1.0
+	github.com/networkservicemesh/networkservicemesh/test v0.2.0
 	github.com/onsi/gomega v1.7.0
 	github.com/opentracing/opentracing-go v1.1.0
 	github.com/pkg/errors v0.8.1

--- a/k8s/api/go.mod
+++ b/k8s/api/go.mod
@@ -2,7 +2,7 @@ module github.com/networkservicemesh/networkservicemesh/k8s/api
 
 require (
 	github.com/golang/protobuf v1.3.2
-	github.com/networkservicemesh/networkservicemesh/controlplane/api v0.1.0
+	github.com/networkservicemesh/networkservicemesh/controlplane/api v0.2.0
 	google.golang.org/appengine v1.4.0 // indirect
 	google.golang.org/genproto v0.0.0-20190611190212-a7e196e89fd3 // indirect
 	google.golang.org/grpc v1.23.1

--- a/k8s/go.mod
+++ b/k8s/go.mod
@@ -9,12 +9,12 @@ require (
 	github.com/golang/protobuf v1.3.2
 	github.com/grpc-ecosystem/grpc-opentracing v0.0.0-20180507213350-8e809c8a8645
 	github.com/miekg/dns v1.1.15
-	github.com/networkservicemesh/networkservicemesh/controlplane v0.1.0
-	github.com/networkservicemesh/networkservicemesh/controlplane/api v0.1.0
-	github.com/networkservicemesh/networkservicemesh/k8s/api v0.1.0
-	github.com/networkservicemesh/networkservicemesh/pkg v0.1.0
-	github.com/networkservicemesh/networkservicemesh/sdk v0.1.0
-	github.com/networkservicemesh/networkservicemesh/utils v0.1.0
+	github.com/networkservicemesh/networkservicemesh/controlplane v0.2.0
+	github.com/networkservicemesh/networkservicemesh/controlplane/api v0.2.0
+	github.com/networkservicemesh/networkservicemesh/k8s/api v0.2.0
+	github.com/networkservicemesh/networkservicemesh/pkg v0.2.0
+	github.com/networkservicemesh/networkservicemesh/sdk v0.2.0
+	github.com/networkservicemesh/networkservicemesh/utils v0.2.0
 	github.com/onsi/gomega v1.7.0
 	github.com/opentracing/opentracing-go v1.1.0
 	github.com/pkg/errors v0.8.1

--- a/sdk/go.mod
+++ b/sdk/go.mod
@@ -7,10 +7,10 @@ require (
 	github.com/ligato/cn-infra v2.0.0+incompatible
 	github.com/ligato/vpp-agent v2.1.1+incompatible
 	github.com/mesos/mesos-go v0.0.9
-	github.com/networkservicemesh/networkservicemesh/controlplane v0.1.0
-	github.com/networkservicemesh/networkservicemesh/controlplane/api v0.1.0
-	github.com/networkservicemesh/networkservicemesh/pkg v0.1.0
-	github.com/networkservicemesh/networkservicemesh/utils v0.1.0
+	github.com/networkservicemesh/networkservicemesh/controlplane v0.2.0
+	github.com/networkservicemesh/networkservicemesh/controlplane/api v0.2.0
+	github.com/networkservicemesh/networkservicemesh/pkg v0.2.0
+	github.com/networkservicemesh/networkservicemesh/utils v0.2.0
 	github.com/onsi/gomega v1.7.0
 	github.com/opentracing/opentracing-go v1.1.0
 	github.com/pkg/errors v0.8.1

--- a/side-cars/go.mod
+++ b/side-cars/go.mod
@@ -1,13 +1,12 @@
 module github.com/networkservicemesh/networkservicemesh/side-cars
 
 require (
-	github.com/networkservicemesh/networkservicemesh/controlplane v0.1.0
-	github.com/networkservicemesh/networkservicemesh/controlplane/api v0.1.0
-	github.com/networkservicemesh/networkservicemesh/k8s/api v0.1.0
-	github.com/networkservicemesh/networkservicemesh/pkg v0.1.0
-	github.com/networkservicemesh/networkservicemesh/sdk v0.1.0
-	github.com/networkservicemesh/networkservicemesh/utils v0.1.0
-	github.com/onsi/gomega v1.7.0
+	github.com/networkservicemesh/networkservicemesh/controlplane v0.2.0
+	github.com/networkservicemesh/networkservicemesh/controlplane/api v0.2.0
+	github.com/networkservicemesh/networkservicemesh/k8s/api v0.2.0
+	github.com/networkservicemesh/networkservicemesh/pkg v0.2.0
+	github.com/networkservicemesh/networkservicemesh/sdk v0.2.0
+	github.com/networkservicemesh/networkservicemesh/utils v0.2.0
 	github.com/opentracing/opentracing-go v1.1.0
 	github.com/sirupsen/logrus v1.4.2
 )

--- a/test/go.mod
+++ b/test/go.mod
@@ -8,15 +8,15 @@ require (
 	github.com/google/uuid v1.1.1
 	github.com/ligato/cn-infra v2.0.0+incompatible
 	github.com/ligato/vpp-agent v2.1.1+incompatible
-	github.com/networkservicemesh/networkservicemesh/controlplane v0.1.0
-	github.com/networkservicemesh/networkservicemesh/controlplane/api v0.1.0
-	github.com/networkservicemesh/networkservicemesh/dataplane v0.1.0
-	github.com/networkservicemesh/networkservicemesh/dataplane/api v0.1.0
-	github.com/networkservicemesh/networkservicemesh/k8s v0.1.0
-	github.com/networkservicemesh/networkservicemesh/pkg v0.1.0
-	github.com/networkservicemesh/networkservicemesh/sdk v0.1.0
-	github.com/networkservicemesh/networkservicemesh/side-cars v0.1.0
-	github.com/networkservicemesh/networkservicemesh/utils v0.1.0
+	github.com/networkservicemesh/networkservicemesh/controlplane v0.2.0
+	github.com/networkservicemesh/networkservicemesh/controlplane/api v0.2.0
+	github.com/networkservicemesh/networkservicemesh/dataplane v0.2.0
+	github.com/networkservicemesh/networkservicemesh/dataplane/api v0.2.0
+	github.com/networkservicemesh/networkservicemesh/k8s v0.2.0
+	github.com/networkservicemesh/networkservicemesh/pkg v0.2.0
+	github.com/networkservicemesh/networkservicemesh/sdk v0.2.0
+	github.com/networkservicemesh/networkservicemesh/side-cars v0.2.0
+	github.com/networkservicemesh/networkservicemesh/utils v0.2.0
 	github.com/onsi/gomega v1.7.0
 	github.com/opentracing/opentracing-go v1.1.0
 	github.com/packethost/packngo v0.1.1-0.20190507131943-1343be729ca2

--- a/utils/go.mod
+++ b/utils/go.mod
@@ -2,8 +2,8 @@ module github.com/networkservicemesh/networkservicemesh
 
 require (
 	github.com/go-errors/errors v1.0.1
-	github.com/networkservicemesh/networkservicemesh/controlplane/api v0.1.0
-	github.com/networkservicemesh/networkservicemesh/utils v0.1.0
+	github.com/networkservicemesh/networkservicemesh/controlplane/api v0.2.0
+	github.com/networkservicemesh/networkservicemesh/utils v0.2.0
 	github.com/onsi/gomega v1.7.0
 	github.com/sirupsen/logrus v1.4.2
 )


### PR DESCRIPTION
Version v0.1.0 is a real version, and not at all
what we are depending on in the main networkservicemesh repo.

According to:
https://golang.org/cmd/go/#hdr-Pseudo_versions

It appears we should shift to v0.2.0 here so we can using v0.2.0-${timstamp}-${git commit id} in downstream projects like example to reference the modules.

Signed-off-by: Ed Warnicke <hagbard@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [ ] Covered by existing integration testing
- [ ] Added integration testing to cover
- [ ] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.