### PR TITLE
Fix Missing logs from second cluster in interdomain circleci tests

### DIFF
--- a/test/kubetest/log_utils.go
+++ b/test/kubetest/log_utils.go
@@ -45,7 +45,6 @@ func archiveLogs(testName string) {
 		return
 	}
 	for _, file := range logFiles {
-		logrus.Info(file)
 		if file.IsDir() {
 			continue
 		}

--- a/test/kubetest/log_utils.go
+++ b/test/kubetest/log_utils.go
@@ -76,7 +76,6 @@ func archiveLogs(testName string) {
 	_ = os.RemoveAll(dir)
 	outfile := filepath.Join(logsDir(), testName+".zip")
 	if _, err := os.Stat(outfile); err == nil {
-		logrus.Info("asdadadad")
 		zr, err := zip.OpenReader(outfile)
 		if err != nil {
 			logrus.Errorf("Can not zip write, err: %v", err)
@@ -116,7 +115,7 @@ func distill(w *zip.Writer, r *zip.ReadCloser) {
 		}
 		_, err = io.Copy(hw, fr)
 		if err != nil {
-			logrus.Errorf("An error io.Copy(...), err: %v", err)
+			logrus.Errorf("An error during io.Copy(...), err: %v", err)
 		}
 	}
 }


### PR DESCRIPTION
Signed-off-by: denis-tingajkin <denis.tingajkin@xored.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
https://github.com/networkservicemesh/networkservicemesh/issues/1605
## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [ ] Covered by existing integration testing
- [ ] Added integration testing to cover
- [X] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
