### PR TITLE
Get rid of '-ti' flags for exec, add attempts to ping

### DIFF
--- a/scripts/nsc_ping_all.sh
+++ b/scripts/nsc_ping_all.sh
@@ -7,7 +7,7 @@ EXIT_VAL=0
 for nsc in $(${kubectl} get pods -o=name | grep -E "alpine-nsc|vppagent-nsc" | sed 's@.*/@@'); do
     echo "===== >>>>> PROCESSING ${nsc}  <<<<< ==========="
     if [[ ${nsc} == vppagent-* ]]; then
-        for ip in $(${kubectl} exec -it "${nsc}" -- vppctl show int addr | grep L3 | awk '{print $2}'); do
+        for ip in $(${kubectl} exec "${nsc}" -- vppctl show int addr | grep L3 | awk '{print $2}'); do
             if [[ "${ip}" == 172.16.1.* ]];then
                 lastSegment=$(echo "${ip}" | cut -d . -f 4 | cut -d / -f 1)
                 nextOp=$((lastSegment + 1))
@@ -22,8 +22,8 @@ for nsc in $(${kubectl} get pods -o=name | grep -E "alpine-nsc|vppagent-nsc" | s
 
             if [ -n "${targetIp}" ]; then
                 # Prime the pump, its normal to get a packet loss due to arp
-                ${kubectl} exec -it "${nsc}" -- vppctl ping "${targetIp}" repeat 1 > /dev/null 2>&1
-                OUTPUT=$(${kubectl} exec -it "${nsc}" -- vppctl ping "${targetIp}" repeat 3)
+                ${kubectl} exec "${nsc}" -- vppctl ping "${targetIp}" repeat 1 > /dev/null 2>&1
+                OUTPUT=$(${kubectl} exec "${nsc}" -- vppctl ping "${targetIp}" repeat 3)
                 echo "${OUTPUT}"
                 RESULT=$(echo "${OUTPUT}"| grep "packet loss" | awk '{print $6}')
                 if [ "${RESULT}" = "0%" ]; then
@@ -38,7 +38,7 @@ for nsc in $(${kubectl} get pods -o=name | grep -E "alpine-nsc|vppagent-nsc" | s
             fi
         done
     else
-        for ip in $(${kubectl} exec -it "${nsc}" -- ip addr| grep inet | awk '{print $2}'); do
+        for ip in $(${kubectl} exec "${nsc}" -- ip addr| grep inet | awk '{print $2}'); do
             if [[ "${ip}" == 172.16.1.* ]];then
                 lastSegment=$(echo "${ip}" | cut -d . -f 4 | cut -d / -f 1)
                 nextOp=$((lastSegment + 1))
@@ -52,7 +52,7 @@ for nsc in $(${kubectl} get pods -o=name | grep -E "alpine-nsc|vppagent-nsc" | s
             fi
 
             if [ -n "${targetIp}" ]; then
-                if ${kubectl} exec -it "${nsc}" -- ping -c 1 "${targetIp}" ; then
+                if ${kubectl} exec "${nsc}" -- ping -c 1 "${targetIp}" ; then
                     echo "NSC ${nsc} with IP ${ip} pinging ${endpointName} TargetIP: ${targetIp} successful"
                     PingSuccess="true"
                 else
@@ -71,12 +71,12 @@ for nsc in $(${kubectl} get pods -o=name | grep -E "alpine-nsc|vppagent-nsc" | s
         ${kubectl} get pod "${nsc}" -o wide
         echo "POD ${nsc} Network dump -------------------------------"
         if [[ ${nsc} == vppagent-* ]]; then
-            ${kubectl} exec -ti "${nsc}" -- vppctl show int
-            ${kubectl} exec -ti "${nsc}" -- vppctl show int addr
-            ${kubectl} exec -ti "${nsc}" -- vppctl show memif
+            ${kubectl} exec "${nsc}" -- vppctl show int
+            ${kubectl} exec "${nsc}" -- vppctl show int addr
+            ${kubectl} exec "${nsc}" -- vppctl show memif
         else
-            ${kubectl} exec -ti "${nsc}" -- ip addr
-            ${kubectl} exec -ti "${nsc}" ip route
+            ${kubectl} exec "${nsc}" -- ip addr
+            ${kubectl} exec "${nsc}" ip route
         fi
         echo "+++++++==ERROR==ERROR=============================================================================+++++"
     fi


### PR DESCRIPTION
Signed-off-by: lobkovilya <ilya.lobkov@xored.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Get rid of '-ti' flags for exec
- Increase ping attempts
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
[circleci](https://circleci.com/gh/networkservicemesh/networkservicemesh/101390#tests/containers/0)
According to logs of `k8s-check`: 
```
>>>>>>Running: make k8s-check:<<<<<<
===== >>>>> PROCESSING vpn-gateway-nsc-d545dc984-dttmf  <<<<< ===========
Defaulting container name to alpine-img.
Use 'kubectl describe pod/vpn-gateway-nsc-d545dc984-dttmf -n nsm-system' to see all of the containers in this pod.
Unable to use a TTY - input is not a terminal or the right kind of file
Defaulting container name to alpine-img.
Use 'kubectl describe pod/vpn-gateway-nsc-d545dc984-dttmf -n nsm-system' to see all of the containers in this pod.
Unable to use a TTY - input is not a terminal or the right kind of file
PING 172.16.1.2 (172.16.1.2): 56 data bytes

--- 172.16.1.2 ping statistics ---
1 packets transmitted, 0 packets received, 100% packet loss
command terminated with exit code 1
NSC vpn-gateway-nsc-d545dc984-dttmf with IP 172.16.1.1/30 pinging vpn-gateway-nse TargetIP: 172.16.1.2 unsuccessful
Defaulting container name to alpine-img.
Use 'kubectl describe pod/vpn-gateway-nsc-d545dc984-dttmf -n nsm-system' to see all of the containers in this pod.
Unable to use a TTY - input is not a terminal or the right kind of file
Connecting to 172.16.1.2:80 (172.16.1.2:80)
null                 100% |********************************|   112  0:00:00 ETA
NSC vpn-gateway-nsc-d545dc984-dttmf with IP 172.16.1.1/30 accessing vpn-gateway-nse TargetIP: 172.16.1.2 TargetPort:80 successful
Defaulting container name to alpine-img.
Use 'kubectl describe pod/vpn-gateway-nsc-d545dc984-dttmf -n nsm-system' to see all of the containers in this pod.
Unable to use a TTY - input is not a terminal or the right kind of file
Connecting to 172.16.1.2:8080 (172.16.1.2:8080)
wget: download timed out
command terminated with exit code 1
NSC vpn-gateway-nsc-d545dc984-dttmf with IP 172.16.1.1/30 blocked vpn-gateway-nse TargetIP: 172.16.1.2 TargetPort:8080
+++++++==ERROR==ERROR=============================================================================+++++
NSC vpn-gateway-nsc-d545dc984-dttmf failed ping to a vpn-gateway NetworkService
NAME                              READY   STATUS    RESTARTS   AGE   IP              NODE                                          NOMINATED NODE   READINESS GATES
vpn-gateway-nsc-d545dc984-dttmf   3/3     Running   0          46s   192.168.192.4   worker-packet-1-2019-9-17-101390-b374b2a794   <none>           <none>
POD vpn-gateway-nsc-d545dc984-dttmf Network dump -------------------------------
Defaulting container name to alpine-img.
Use 'kubectl describe pod/vpn-gateway-nsc-d545dc984-dttmf -n nsm-system' to see all of the containers in this pod.
Unable to use a TTY - input is not a terminal or the right kind of file
1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN qlen 1
link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
inet 127.0.0.1/8 scope host lo
valid_lft forever preferred_lft forever
125: eth0@if126: <BROADCAST,MULTICAST,UP,LOWER_UP,M-DOWN> mtu 1376 qdisc noqueue state UP
link/ether 82:90:28:93:d4:2f brd ff:ff:ff:ff:ff:ff
inet 192.168.192.4/16 brd 192.168.255.255 scope global eth0
valid_lft forever preferred_lft forever
131: nsm0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UNKNOWN qlen 1000
link/ether d2:f3:bd:e5:84:86 brd ff:ff:ff:ff:ff:ff
inet 172.16.1.1/30 brd 172.16.1.3 scope global nsm0
valid_lft forever preferred_lft forever
+++++++==ERROR==ERROR=============================================================================+++++
All check OK. NSC vpn-gateway-nsc-d545dc984-dttmf behaving as expected.
.mk/k8s.mk:463: recipe for target 'k8s-check' failed
make: *** [k8s-check] Error 1
error running command: failed to run make k8s-check ExitCode: -1
```

TTY is not supported on clusters and we don't need this mode to check output of the command.

---
`$ ping 172.16.1.2 -c 1` failed
`$ wget -O /dev/null --timeout 3 172.16.1.2:80` success

Probably we faced with some arp issues, so maybe makes sense to increase attempts in order to check it.

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [ ] Covered by existing integration testing
- [ ] Added integration testing to cover
- [ ] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
