### PR TITLE
Fix k8s-coredns-build target missing

### DIFF
--- a/.mk/k8s.mk
+++ b/.mk/k8s.mk
@@ -125,6 +125,9 @@ k8s-build: $(addsuffix -build,$(addprefix k8s-,$(DEPLOYS)))
 .PHONY: k8s-nsm-coredns-save
 k8s-nsm-coredns-save:  $(addsuffix -save,$(addprefix ${CONTAINER_BUILD_PREFIX}-,nsm-coredns))
 
+.PHONY: k8s-nsm-coredns-build
+k8s-nsm-coredns-build:  $(addsuffix -build,$(addprefix ${CONTAINER_BUILD_PREFIX}-,nsm-coredns))
+
 .PHONY: k8s-jaeger-build
 k8s-jaeger-build:
 


### PR DESCRIPTION
Signed-off-by: Radoslav Dimitrov <dimitrovr@vmware.com>

<!--- Provide a general summary of your changes in the Title above -->
There is no `k8s-coredns-build` target, leading to failure in `k8s-build`
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [ ] Covered by existing integration testing
- [ ] Added integration testing to cover
- [x] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.