### PR TITLE
Fix: Cloudtest sometimes does not save shell script's stdout/stderr

### DIFF
--- a/test/cloudtest/pkg/utils/shell_utils.go
+++ b/test/cloudtest/pkg/utils/shell_utils.go
@@ -191,11 +191,10 @@ func RunCommand(context context.Context, cmd, dir string, logger func(str string
 	builder := strings.Builder{}
 	var wg sync.WaitGroup
 	wg.Add(2)
-
 	processOutput(proc.Stdout, writer, logger, "StdOut", &builder, returnStdout, &wg)
 	processOutput(proc.Stderr, writer, logger, "StdErr", nil, false, &wg)
-	code := proc.ExitCode()
 	wg.Wait()
+	code := proc.ExitCode()
 	if code != 0 {
 		return "", fmt.Errorf("failed to run %v ExitCode: %v", finalCmd, code)
 	}

--- a/test/cloudtest/pkg/utils/shell_utils_test.go
+++ b/test/cloudtest/pkg/utils/shell_utils_test.go
@@ -1,0 +1,21 @@
+package utils
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/onsi/gomega"
+)
+
+func TestProcessOutputShouldNotLostOutput(t *testing.T) {
+	assert := gomega.NewWithT(t)
+	const expected = "output..."
+	for i := 0; i < 1000; i++ {
+		output, err := RunCommand(context.Background(), fmt.Sprintf("echo \"%v\"", expected), "", func(s string) {}, bufio.NewWriter(&strings.Builder{}), nil, nil, true)
+		assert.Expect(err).Should(gomega.BeNil())
+		assert.Expect(strings.TrimSpace(output)).Should(gomega.Equal(expected))
+	}
+}

--- a/test/cloudtest/pkg/utils/shell_utils_test.go
+++ b/test/cloudtest/pkg/utils/shell_utils_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/onsi/gomega"
 )
@@ -13,7 +14,8 @@ import (
 func TestProcessOutputShouldNotLostOutput(t *testing.T) {
 	assert := gomega.NewWithT(t)
 	const expected = "output..."
-	for i := 0; i < 1000; i++ {
+	start := time.Now()
+	for time.Now().Sub(start) < time.Second {
 		output, err := RunCommand(context.Background(), fmt.Sprintf("echo \"%v\"", expected), "", func(s string) {}, bufio.NewWriter(&strings.Builder{}), nil, nil, true)
 		assert.Expect(err).Should(gomega.BeNil())
 		assert.Expect(strings.TrimSpace(output)).Should(gomega.Equal(expected))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
In the investigation of failing https://circleci.com/gh/networkservicemesh/networkservicemesh/105477 I found that sometimes cloudtest shell script result can be not saved.  
Root cause: we using async read from stdout/stderr and in the case when the command exits we can lose the output.

## Motivation and Context
https://circleci.com/gh/networkservicemesh/networkservicemesh/105477

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [ ] Covered by existing integration testing
- [X] Added unit testing to cover
- [X] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
