### PR TITLE
Exclude vendor folder for script 'for-each-module'

### DIFF
--- a/scripts/for-each-module.sh
+++ b/scripts/for-each-module.sh
@@ -15,6 +15,6 @@ exec_command () {
 }
 
 export -f exec_command
-find . -name "go.mod" -exec bash -c "exec_command \"${cmd}\" " {} \;
+find . -name "go.mod" -or -iname "vendor*" -exec bash -c "exec_command \"${cmd}\" " {} \;
 
 exit $res

--- a/scripts/for-each-module.sh
+++ b/scripts/for-each-module.sh
@@ -15,6 +15,6 @@ exec_command () {
 }
 
 export -f exec_command
-find . -name "go.mod" -or -iname "vendor*" -exec bash -c "exec_command \"${cmd}\" " {} \;
+find . -name "go.mod" -o -iname "vendor*" \( -exec bash -c "exec_command \"${cmd}\" " {} \; \)
 
 exit $res


### PR DESCRIPTION
Signed-off-by: denis-tingajkin <denis.tingajkin@xored.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
If each module has a vendor folder then script for-each-module.sh will visit all vendor modules...

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [ ] Covered by existing integration testing
- [ ] Added integration testing to cover
- [ ] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
