### PR TITLE
Add context to the request for registry service clients

### DIFF
--- a/controlplane/pkg/nsm/nse_manager.go
+++ b/controlplane/pkg/nsm/nse_manager.go
@@ -45,7 +45,7 @@ func (nsem *nseManager) getEndpoint(ctx context.Context, requestConnection conne
 	}
 
 	// Get endpoints, do it every time since we do not know if list are changed or not.
-	discoveryClient, err := nsem.serviceRegistry.DiscoveryClient()
+	discoveryClient, err := nsem.serviceRegistry.DiscoveryClient(context.Background())
 	if err != nil {
 		logrus.Error(err)
 		return nil, err

--- a/controlplane/pkg/nsm/nsm.go
+++ b/controlplane/pkg/nsm/nsm.go
@@ -699,7 +699,7 @@ func (srv *networkServiceManager) RestoreConnections(xcons []*crossconnect.Cross
 
 			dp := srv.model.GetDataplane(dataplane)
 
-			discovery, err := srv.serviceRegistry.DiscoveryClient()
+			discovery, err := srv.serviceRegistry.DiscoveryClient(context.Background())
 			if err != nil {
 				logrus.Errorf("Failed to find NSE to recovery: %v", err)
 			}

--- a/controlplane/pkg/nsm/nsm_heal_processor.go
+++ b/controlplane/pkg/nsm/nsm_heal_processor.go
@@ -330,7 +330,7 @@ func (p *healProcessor) nseIsSameAndAvailable(ctx context.Context, endpointName 
 }
 
 func (p *healProcessor) waitNSE(ctx context.Context, cc *model.ClientConnection, endpointName, networkService string, nseValidator nseValidator) bool {
-	discoveryClient, err := p.serviceRegistry.DiscoveryClient()
+	discoveryClient, err := p.serviceRegistry.DiscoveryClient(context.Background())
 	if err != nil {
 		logrus.Errorf("Failed to connect to Registry... %v", err)
 		// Still try to recovery

--- a/controlplane/pkg/nsm/nsm_heal_processor_test.go
+++ b/controlplane/pkg/nsm/nsm_heal_processor_test.go
@@ -265,7 +265,7 @@ type serviceRegistryStub struct {
 	serviceregistry.ServiceRegistry
 }
 
-func (stub *serviceRegistryStub) DiscoveryClient() (registry.NetworkServiceDiscoveryClient, error) {
+func (stub *serviceRegistryStub) DiscoveryClient(ctx context.Context) (registry.NetworkServiceDiscoveryClient, error) {
 	return stub.discoveryClient, stub.error
 }
 

--- a/controlplane/pkg/nsmd/nsmd.go
+++ b/controlplane/pkg/nsmd/nsmd.go
@@ -230,13 +230,13 @@ func (nsm *nsmServer) restoreClients(clients []string) []string {
 }
 
 func (nsm *nsmServer) restoreEndpoints(nses map[string]nseregistry.NSEEntry, registeredNSEs map[string]string) (map[string]nseregistry.NSEEntry, error) {
-	discoveryClient, err := nsm.serviceRegistry.DiscoveryClient()
+	discoveryClient, err := nsm.serviceRegistry.DiscoveryClient(context.Background())
 	if err != nil {
 		logrus.Errorf("Failed to get DiscoveryClient: %v", err)
 		return nil, err
 	}
 
-	registryClient, err := nsm.serviceRegistry.NseRegistryClient()
+	registryClient, err := nsm.serviceRegistry.NseRegistryClient(context.Background())
 	if err != nil {
 		logrus.Errorf("Failed to get RegistryClient: %v", err)
 		return nil, err
@@ -370,7 +370,7 @@ func (nsm *nsmServer) DeleteEndpointWithBrokenConnection(endpoint *model.Endpoin
 		}
 	}
 
-	client, err := nsm.serviceRegistry.NseRegistryClient()
+	client, err := nsm.serviceRegistry.NseRegistryClient(context.Background())
 	if err != nil {
 		return err
 	}
@@ -465,7 +465,7 @@ func (nsm *nsmServer) StartDataplaneRegistratorServer() error {
 }
 
 func setLocalNSM(model model.Model, serviceRegistry serviceregistry.ServiceRegistry) (*registry.NetworkServiceEndpointList, error) {
-	client, err := serviceRegistry.NsmRegistryClient()
+	client, err := serviceRegistry.NsmRegistryClient(context.Background())
 	if err != nil {
 		err = fmt.Errorf("Failed to get RegistryClient: %s", err)
 		return nil, err

--- a/controlplane/pkg/nsmd/registry.go
+++ b/controlplane/pkg/nsmd/registry.go
@@ -48,7 +48,7 @@ func (es *registryServer) RegisterNSE(ctx context.Context, request *registry.NSE
 
 	// Check if there is already Network Service Endpoint object with the same name, if there is
 	// success will be returned to NSE, since it is a case of NSE pod coming back up.
-	client, err := es.nsm.serviceRegistry.NseRegistryClient()
+	client, err := es.nsm.serviceRegistry.NseRegistryClient(context.Background())
 	if err != nil {
 		err = fmt.Errorf("attempt to connect to upstream registry failed with: %v", err)
 		logrus.Error(err)
@@ -104,7 +104,7 @@ func (es *registryServer) RemoveNSE(ctx context.Context, request *registry.Remov
 	// TODO make sure we track which registry server we got the RegisterNSE from so we can only allow a deletion
 	// of what you advertised
 	logrus.Infof("Received Endpoint Remove request: %+v", request)
-	client, err := es.nsm.serviceRegistry.NseRegistryClient()
+	client, err := es.nsm.serviceRegistry.NseRegistryClient(context.Background())
 	if err != nil {
 		err = fmt.Errorf("attempt to pass through from nsm to upstream registry failed with: %v", err)
 		logrus.Error(err)

--- a/controlplane/pkg/serviceregistry/serviceregistry.go
+++ b/controlplane/pkg/serviceregistry/serviceregistry.go
@@ -28,9 +28,9 @@ A method to obtain different connectivity mechanism for parts of model
 type ServiceRegistry interface {
 	GetPublicAPI() string
 
-	DiscoveryClient() (registry.NetworkServiceDiscoveryClient, error)
-	NseRegistryClient() (registry.NetworkServiceRegistryClient, error)
-	NsmRegistryClient() (registry.NsmRegistryClient, error)
+	DiscoveryClient(ctx context.Context) (registry.NetworkServiceDiscoveryClient, error)
+	NseRegistryClient(ctx context.Context) (registry.NetworkServiceRegistryClient, error)
+	NsmRegistryClient(ctx context.Context) (registry.NsmRegistryClient, error)
 
 	Stop()
 	NSMDApiClient() (nsmdapi.NSMDClient, *grpc.ClientConn, error)

--- a/controlplane/pkg/tests/nsmd_test_utils.go
+++ b/controlplane/pkg/tests/nsmd_test_utils.go
@@ -352,15 +352,15 @@ func (impl *nsmdTestServiceRegistry) GetPublicAPI() string {
 	return fmt.Sprintf("%s:%d", "127.0.0.1", impl.apiRegistry.nsmdPublicPort)
 }
 
-func (impl *nsmdTestServiceRegistry) DiscoveryClient() (registry.NetworkServiceDiscoveryClient, error) {
+func (impl *nsmdTestServiceRegistry) DiscoveryClient(ctx context.Context) (registry.NetworkServiceDiscoveryClient, error) {
 	return impl.nseRegistry, nil
 }
 
-func (impl *nsmdTestServiceRegistry) NseRegistryClient() (registry.NetworkServiceRegistryClient, error) {
+func (impl *nsmdTestServiceRegistry) NseRegistryClient(ctx context.Context) (registry.NetworkServiceRegistryClient, error) {
 	return impl.nseRegistry, nil
 }
 
-func (impl *nsmdTestServiceRegistry) NsmRegistryClient() (registry.NsmRegistryClient, error) {
+func (impl *nsmdTestServiceRegistry) NsmRegistryClient(ctx context.Context) (registry.NsmRegistryClient, error) {
 	return impl.nseRegistry, nil
 }
 

--- a/k8s/pkg/proxyregistryserver/discovery.go
+++ b/k8s/pkg/proxyregistryserver/discovery.go
@@ -54,7 +54,7 @@ func (d *discoveryService) FindNetworkService(ctx context.Context, request *regi
 		remoteRegistry := nsmd.NewServiceRegistryAt(remoteDomain + ":" + remoteNsrPort)
 		defer remoteRegistry.Stop()
 
-		discoveryClient, dErr := remoteRegistry.DiscoveryClient()
+		discoveryClient, dErr := remoteRegistry.DiscoveryClient(context.Background())
 		if dErr != nil {
 			logrus.Error(dErr)
 			return nil, dErr

--- a/k8s/pkg/registryserver/discovery.go
+++ b/k8s/pkg/registryserver/discovery.go
@@ -40,7 +40,7 @@ func (d *discoveryService) FindNetworkService(ctx context.Context, request *regi
 		remoteRegistry := nsmd.NewServiceRegistryAt(nsrURL)
 		defer remoteRegistry.Stop()
 
-		discoveryClient, err := remoteRegistry.DiscoveryClient()
+		discoveryClient, err := remoteRegistry.DiscoveryClient(context.Background())
 		if err != nil {
 			logrus.Error(err)
 			return nil, err

--- a/k8s/pkg/registryserver/nse.go
+++ b/k8s/pkg/registryserver/nse.go
@@ -14,7 +14,8 @@ import (
 )
 
 const (
-	NodeNameLabelKey = "nodeName"
+	// ForwardingTimeout - Timeout waiting for Proxy NseRegistryClient
+	ForwardingTimeout = 15 * time.Second
 )
 
 type nseRegistryService struct {

--- a/test/integration/basic_nsmd_k8s_test.go
+++ b/test/integration/basic_nsmd_k8s_test.go
@@ -53,7 +53,7 @@ func TestNSMDDRegistryNSE(t *testing.T) {
 
 	serviceRegistry := nsmd2.NewServiceRegistryAt(fmt.Sprintf("localhost:%d", fwd.ListenPort))
 
-	discovery, err := serviceRegistry.DiscoveryClient()
+	discovery, err := serviceRegistry.DiscoveryClient(context.Background())
 	g.Expect(err).To(BeNil())
 	req := &registry.FindNetworkServiceRequest{
 		NetworkServiceName: "my_service",
@@ -66,7 +66,7 @@ func TestNSMDDRegistryNSE(t *testing.T) {
 
 	// Lets register few hundred NSEs and check how it works.
 
-	registryClient, err := serviceRegistry.NseRegistryClient()
+	registryClient, err := serviceRegistry.NseRegistryClient(context.Background())
 	g.Expect(err).To(BeNil())
 
 	nses := []string{}
@@ -155,13 +155,13 @@ func TestUpdateNSM(t *testing.T) {
 
 	serviceRegistry := nsmd2.NewServiceRegistryAt(fmt.Sprintf("localhost:%d", fwd.ListenPort))
 
-	discovery, err := serviceRegistry.DiscoveryClient()
+	discovery, err := serviceRegistry.DiscoveryClient(context.Background())
 	g.Expect(err).To(BeNil())
 
-	nseRegistryClient, err := serviceRegistry.NseRegistryClient()
+	nseRegistryClient, err := serviceRegistry.NseRegistryClient(context.Background())
 	g.Expect(err).To(BeNil())
 
-	nsmRegistryClient, err := serviceRegistry.NsmRegistryClient()
+	nsmRegistryClient, err := serviceRegistry.NsmRegistryClient(context.Background())
 	g.Expect(err).To(BeNil())
 
 	networkService := "icmp-responder"
@@ -358,13 +358,13 @@ func TestLostUpdate(t *testing.T) {
 
 	sr1, closeFunc := kubetest.ServiceRegistryAt(k8s, nsmgr1)
 
-	nsmRegistryClient, err := sr1.NsmRegistryClient()
+	nsmRegistryClient, err := sr1.NsmRegistryClient(context.Background())
 	g.Expect(err).To(BeNil())
 
-	discovery, err := sr1.DiscoveryClient()
+	discovery, err := sr1.DiscoveryClient(context.Background())
 	g.Expect(err).To(BeNil())
 
-	nseRegistryClient, err := sr1.NseRegistryClient()
+	nseRegistryClient, err := sr1.NseRegistryClient(context.Background())
 	g.Expect(err).To(BeNil())
 
 	networkService := "icmp-responder"
@@ -397,10 +397,10 @@ func TestLostUpdate(t *testing.T) {
 	sr2, closeFunc2 := kubetest.ServiceRegistryAt(k8s, nsmgr2)
 	defer closeFunc2()
 
-	discovery2, err := sr2.DiscoveryClient()
+	discovery2, err := sr2.DiscoveryClient(context.Background())
 	g.Expect(err).To(BeNil())
 
-	nseRegistryClient2, err := sr2.NseRegistryClient()
+	nseRegistryClient2, err := sr2.NseRegistryClient(context.Background())
 	g.Expect(err).To(BeNil())
 
 	nseResp, err = nseRegistryClient2.RegisterNSE(context.Background(), &registry.NSERegistration{
@@ -434,7 +434,7 @@ func TestRegistryConcurrentModification(t *testing.T) {
 	sr1, closeFunc := kubetest.ServiceRegistryAt(k8s, nsmgr1)
 	defer closeFunc()
 
-	nsmRegistryClient, err := sr1.NsmRegistryClient()
+	nsmRegistryClient, err := sr1.NsmRegistryClient(context.Background())
 	g.Expect(err).To(BeNil())
 
 	n := 30

--- a/test/kubetest/utils.go
+++ b/test/kubetest/utils.go
@@ -1,6 +1,7 @@
 package kubetest
 
 import (
+	"context"
 	"crypto/rsa"
 	"crypto/x509"
 	"encoding/pem"
@@ -879,10 +880,10 @@ func ServiceRegistryAt(k8s *K8s, nsmgr *v1.Pod) (serviceregistry.ServiceRegistry
 func PrepareRegistryClients(k8s *K8s, nsmd *v1.Pod) (registry.NetworkServiceRegistryClient, registry.NsmRegistryClient, func()) {
 	serviceRegistry, closeFunc := ServiceRegistryAt(k8s, nsmd)
 
-	nseRegistryClient, err := serviceRegistry.NseRegistryClient()
+	nseRegistryClient, err := serviceRegistry.NseRegistryClient(context.Background())
 	k8s.g.Expect(err).To(BeNil())
 
-	nsmRegistryClient, err := serviceRegistry.NsmRegistryClient()
+	nsmRegistryClient, err := serviceRegistry.NsmRegistryClient(context.Background())
 	k8s.g.Expect(err).To(BeNil())
 
 	return nseRegistryClient, nsmRegistryClient, closeFunc


### PR DESCRIPTION
Signed-off-by: Artem Belov <artem.belov@xored.com>

## Description
Refactoring service registry - adding context to the registry clients

## Motivation and Context
There is no way to cancel request (we were using context.Background())
May be required for the new features. 

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [ ] Covered by existing integration testing
- [ ] Added integration testing to cover
- [x] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
