### PR TITLE
Circleci - wait for spire build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -320,6 +320,7 @@ workflows:
             - build-vppagent-dataplane-dev
             - build-kernel-forwarding-plane
             - build-nsm-coredns
+            - build-spire-registration
 
 # Integration testing
       - integration-tests:


### PR DESCRIPTION
Signed-off-by: Artem Belov <artem.belov@xored.com>

## Description
Wait for spire build before start integration testing

## Motivation and Context
Helm cannot start spire pods ("ImagePullBackOff") and shows:
`Error: release spire failed: timed out waiting for the condition`

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [x] Covered by existing integration testing
- [ ] Added integration testing to cover
- [ ] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
