### PR TITLE
fix for-each-module script to return proper exit code

### DIFF
--- a/scripts/for-each-module.sh
+++ b/scripts/for-each-module.sh
@@ -1,20 +1,10 @@
 #!/bin/bash
 
+CMD=$*
 res=0
-cmd=$1
 
-exec_command () {
-    d=$(dirname "$0")
-    pushd "$d" || exit 1
-    
-    if ! $1; then
-        res=1
-    fi
-
-    popd || exit 1
-}
-
-export -f exec_command
-find . -path "*vendor" -prune -o -name "go.mod" \( -exec bash -c "exec_command \"${cmd}\" " {} \; \)
+while read -r f; do
+    ( d=$(dirname "$f") && pushd "$d" && $CMD; ) || res=1
+done <<< "$(find . -path "*vendor" -prune -o -name 'go.mod')"
 
 exit $res


### PR DESCRIPTION
Signed-off-by: Alexander Yustus <alexander.yustus@xored.com>

<!--- Provide a general summary of your changes in the Title above -->
command execution happens inside a subshell, so changing 'res' variable doesn't do the work.

## Description
<!--- Describe your changes in detail -->
Do command invocation inside main shell

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [x] Covered by existing integration testing
- [ ] Added integration testing to cover
- [x] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

