### PR TITLE
Update helm chart to use release namespace

### DIFF
--- a/deployments/helm/nsm-monitoring/templates/skydive.tpl
+++ b/deployments/helm/nsm-monitoring/templates/skydive.tpl
@@ -113,7 +113,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: skydive-agent-config-file
-  namespace: nsm-system
+  namespace: {{ .Release.Namespace }}
 data:
   skydive.yml: |
     logging:


### PR DESCRIPTION
Signed-off-by: Wayne <wayne@flickswitch.co.za>

## Description
Update skydive helm chart to use Release.namespace, instead of hardcoded namespace nsm-system

## Motivation and Context
Deploying helm chart in other namespaces does not work.

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [ ] Covered by existing integration testing
- [ ] Added integration testing to cover
- [x] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
