### PR TITLE
Use better commit id

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,7 +62,7 @@ jobs:
       - run: mkdir -p ~/junit/
       - run:
           command: |
-            export COMMIT="ci_${CIRCLE_BUILD_NUM}_${CIRCLE_SHA1:8:8}"
+            export COMMIT="ci_${CIRCLE_WORKFLOW_ID}_${CIRCLE_SHA1:8:8}"
             export CONTAINER_TAG="${COMMIT}"
             export CONTAINER_REPO="networkservicemeshci"
             export CONTAINER_FORCE_PULL="true"
@@ -133,14 +133,14 @@ jobs:
       - run:
           name: Downloading go deps
           command: |
-            export COMMIT="ci_${CIRCLE_BUILD_NUM}_${CIRCLE_SHA1:8:8}"
+            export COMMIT="ci_${CIRCLE_WORKFLOW_ID}_${CIRCLE_SHA1:8:8}"
             export CONTAINER_TAG="${COMMIT}"
             ./scripts/go-mod-download.sh
           no_output_timeout: 40m
       - run:
           name: Running integration tests
           command: |
-            export COMMIT="ci_${CIRCLE_BUILD_NUM}_${CIRCLE_SHA1:8:8}"
+            export COMMIT="ci_${CIRCLE_WORKFLOW_ID}_${CIRCLE_SHA1:8:8}"
             export CONTAINER_TAG="${COMMIT}"
             export REPO="networkservicemeshci"
             export CONTAINER_REPO=${REPO}
@@ -177,7 +177,7 @@ jobs:
           docker_layer_caching: true
       - run:
           command: |
-            export COMMIT="ci_${CIRCLE_BUILD_NUM}_${CIRCLE_SHA1:8:8}"
+            export COMMIT="ci_${CIRCLE_WORKFLOW_ID}_${CIRCLE_SHA1:8:8}"
             export TAG="${COMMIT}"
             export CONTAINER_REPO="networkservicemeshci"
             make docker-<< parameters.container >>-build
@@ -205,7 +205,7 @@ jobs:
           docker_layer_caching: true
       - run:
           command: |
-            export COMMIT="ci_${CIRCLE_BUILD_NUM}_${CIRCLE_SHA1:8:8}"
+            export COMMIT="ci_${CIRCLE_WORKFLOW_ID}_${CIRCLE_SHA1:8:8}"
             export PULL_TAG="${COMMIT}"
             export TAG="<< parameters.tag >>"
             export REPO="networkservicemesh"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,7 +62,7 @@ jobs:
       - run: mkdir -p ~/junit/
       - run:
           command: |
-            export COMMIT="${CIRCLE_SHA1:8:8}"
+            export COMMIT="ci_${CIRCLE_BUILD_NUM}_${CIRCLE_SHA1:8:8}"
             export CONTAINER_TAG="${COMMIT}"
             export CONTAINER_REPO="networkservicemeshci"
             export CONTAINER_FORCE_PULL="true"
@@ -133,17 +133,18 @@ jobs:
       - run:
           name: Downloading go deps
           command: |
-            export COMMIT="${CIRCLE_SHA1:8:8}"
+            export COMMIT="ci_${CIRCLE_BUILD_NUM}_${CIRCLE_SHA1:8:8}"
             export CONTAINER_TAG="${COMMIT}"
             ./scripts/go-mod-download.sh
           no_output_timeout: 40m
       - run:
           name: Running integration tests
           command: |
-            export COMMIT="${CIRCLE_SHA1:8:8}"
+            export COMMIT="ci_${CIRCLE_BUILD_NUM}_${CIRCLE_SHA1:8:8}"
             export CONTAINER_TAG="${COMMIT}"
             export REPO="networkservicemeshci"
             export CONTAINER_REPO=${REPO}
+            echo "CONTAINER_REPO=${CONTAINER_REPO} COMMIT=${COMMIT}"
             if [ "${CIRCLE_BRANCH}" == "master" ]; then
               export STORE_LOGS_IN_ANY_CASES=true
             fi
@@ -176,7 +177,7 @@ jobs:
           docker_layer_caching: true
       - run:
           command: |
-            export COMMIT="${CIRCLE_SHA1:8:8}"
+            export COMMIT="ci_${CIRCLE_BUILD_NUM}_${CIRCLE_SHA1:8:8}"
             export TAG="${COMMIT}"
             export CONTAINER_REPO="networkservicemeshci"
             make docker-<< parameters.container >>-build
@@ -204,7 +205,7 @@ jobs:
           docker_layer_caching: true
       - run:
           command: |
-            export COMMIT="${CIRCLE_SHA1:8:8}"
+            export COMMIT="ci_${CIRCLE_BUILD_NUM}_${CIRCLE_SHA1:8:8}"
             export PULL_TAG="${COMMIT}"
             export TAG="<< parameters.tag >>"
             export REPO="networkservicemesh"


### PR DESCRIPTION
Signed-off-by: Andrey Sobolev <haiodo@xored.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description

Helm could interpret passed commit id as not valid number, causing spire to not be uploaded properly.

${CIRCLE_SHA1:8:8} == 33207503
--set org=“networkservicemeshci”,tag=“33207503"
And helm some how intepreter it as value “3.3207503e+07”, 


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [x] Covered by existing integration testing
- [ ] Added integration testing to cover
- [ ] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
