### PR TITLE
Disable aws-azure interdomain tests

### DIFF
--- a/.cloudtest.yaml
+++ b/.cloudtest.yaml
@@ -98,24 +98,6 @@ executions:
       - KUBECONFIG_CLUSTER_2
     on_fail: |
       make k8s-delete-nsm-namespaces
-  - name: "Interdomain tests aws-azure"
-    env:
-      - STORE_POD_LOGS_IN_FILES=true
-      - STORE_POD_LOGS_DIR=/home/circleci/project/.tests/cloud_test/$(cluster-name)
-      - INSECURE=true
-    tags:
-      - interdomain
-    root: ./test/integration
-    timeout: 600
-    cluster-count: 2
-    cluster-selector:
-      - aws
-      - azure
-    kubernetes-env:
-      - KUBECONFIG_CLUSTER_1
-      - KUBECONFIG_CLUSTER_2
-    on_fail: |
-      make k8s-delete-nsm-namespaces
   - name: "Example-helm-vpn"
     kind: shell
     timeout: 300


### PR DESCRIPTION
Signed-off-by: Artem Belov <artem.belov@xored.com>

## Description
There is an issue with resolving Proxy NSMD service address on AWS cluster

## Motivation and Context
The most Interdomain tests fails on aws cluster #1603

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [ ] Covered by existing integration testing
- [ ] Added integration testing to cover
- [ ] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
