### PR TITLE
Add skip for TestNsmCorednsNotBreakDefaultK8sDNS if cluster dns not works

### DIFF
--- a/test/integration/basic_dns_test.go
+++ b/test/integration/basic_dns_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/networkservicemesh/networkservicemesh/test/kubetest"
 	"github.com/networkservicemesh/networkservicemesh/test/kubetest/pods"
+	"github.com/sirupsen/logrus"
 )
 
 func TestBasicDns(t *testing.T) {
@@ -115,7 +116,12 @@ func TestNsmCorednsNotBreakDefaultK8sDNS(t *testing.T) {
 	assert.Expect(err).To(gomega.BeNil())
 	defer kubetest.MakeLogsSnapshot(k8s, t)
 
-	kubetest.DeployICMP(k8s, configs[0].Node, "icmp-responder", defaultTimeout)
+	nse := kubetest.DeployICMP(k8s, configs[0].Node, "icmp-responder", defaultTimeout)
 	nsc := kubetest.DeployMonitoringNSCAndCoredns(k8s, configs[0].Node, "nsc", defaultTimeout)
+
+	if !kubetest.NSLookup(k8s, nse, "kubernetes.default") {
+		logrus.Info("Cluster DNS not works")
+		t.SkipNow()
+	}
 	assert.Expect(kubetest.NSLookup(k8s, nsc, "kubernetes.default")).Should(gomega.BeTrue())
 }

--- a/test/integration/basic_dns_test.go
+++ b/test/integration/basic_dns_test.go
@@ -7,9 +7,10 @@ import (
 
 	"github.com/onsi/gomega"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/networkservicemesh/networkservicemesh/test/kubetest"
 	"github.com/networkservicemesh/networkservicemesh/test/kubetest/pods"
-	"github.com/sirupsen/logrus"
 )
 
 func TestBasicDns(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: denis-tingajkin <denis.tingajkin@xored.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
https://github.com/networkservicemesh/networkservicemesh/issues/1731

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [ ] Covered by existing integration testing
- [ ] Added integration testing to cover
- [ ] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
