### PR TITLE
Fix tests failing when executed command timed out

### DIFF
--- a/test/kubetest/k8s_exec.go.go
+++ b/test/kubetest/k8s_exec.go.go
@@ -79,6 +79,7 @@ func (o *K8s) doExec(pod *v1.Pod, container string, command ...string) (string, 
 		err = exec.Stream(options)
 	}()
 	if !waitTimeout(fmt.Sprintf("Exec %v:%v cmdline: %v", pod.Name, container, command), &wg, podExecTimeout) {
+		err = fmt.Errorf("timed out executing command %v in pod %v", command, pod.Name)
 		logrus.Errorf("Failed to do exec. Timeout")
 	}
 


### PR DESCRIPTION
Signed-off-by: Artem Belov <artem.belov@xored.com>

## Description
Return error from doExec if executed command timed out

## Motivation and Context
doExec does not return error if executed command timed out. It does not affect on test result

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [ ] Covered by existing integration testing
- [ ] Added integration testing to cover
- [x] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
