### PR TITLE
VNI Selection improvement for interdomain

### DIFF
--- a/controlplane/api/remote/connection/constants.go
+++ b/controlplane/api/remote/connection/constants.go
@@ -2,7 +2,9 @@ package connection
 
 // Remote connection constants
 const (
-	VXLANSrcIP = "src_ip"
-	VXLANDstIP = "dst_ip"
-	VXLANVNI   = "vni"
+	VXLANSrcIP         = "src_ip"
+	VXLANSrcOriginalIP = "orig_src_ip"
+	VXLANDstIP         = "dst_ip"
+	VXLANDstExternalIP = "ext_src_ip"
+	VXLANVNI           = "vni"
 )

--- a/controlplane/pkg/nsm/nsm_mechanims.go
+++ b/controlplane/pkg/nsm/nsm_mechanims.go
@@ -54,8 +54,27 @@ func (srv *networkServiceManager) selectRemoteMechanism(requestID string, reques
 			dpParameters := dpMechanism.GetParameters()
 
 			parameters[remote.VXLANDstIP] = dpParameters[remote.VXLANSrcIP]
+			var vni uint32
 
-			vni := srv.serviceRegistry.VniAllocator().Vni(dpParameters[remote.VXLANSrcIP], parameters[remote.VXLANSrcIP])
+			extSrcIP := parameters[remote.VXLANSrcIP]
+			extDstIP := dpParameters[remote.VXLANSrcIP]
+			srcIP := parameters[remote.VXLANSrcIP]
+			dstIP := dpParameters[remote.VXLANSrcIP]
+
+			if ip, ok := parameters[remote.VXLANSrcOriginalIP]; ok {
+				srcIP = ip
+			}
+
+			if ip, ok := parameters[remote.VXLANDstExternalIP]; ok {
+				extDstIP = ip
+			}
+
+			if extDstIP != extSrcIP {
+				vni = srv.serviceRegistry.VniAllocator().Vni(extDstIP, extSrcIP)
+			} else {
+				vni = srv.serviceRegistry.VniAllocator().Vni(dstIP, srcIP)
+			}
+
 			parameters[remote.VXLANVNI] = strconv.FormatUint(uint64(vni), 10)
 		}
 

--- a/test/integration/interdomain_vpn_test.go
+++ b/test/integration/interdomain_vpn_test.go
@@ -25,7 +25,6 @@ const (
 	InterdomainPtNum = 5 // Number of Passthrough Endpoints to deploy
 )
 
-/* Disable Firewall Remote test while vxlan has vni conflict
 func TestInterdomainVPNFirewallRemote(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skip, please run without -short")
@@ -39,7 +38,6 @@ func TestInterdomainVPNFirewallRemote(t *testing.T) {
 		"vpn-gateway-nsc-1":        0,
 	}, false)
 }
-*/
 
 func TestInterdomainVPNNSERemote(t *testing.T) {
 	if testing.Short() {


### PR DESCRIPTION
Signed-off-by: Artem Belov <artem.belov@xored.com>

## Description
Keep original src ip and external dst ip to compare ip addresses properly
Enable TestInterdomainVPNFirewallRemote which was broken because of VNI selection issue 

## Motivation and Context
#1695, #1354

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [ ] Covered by existing integration testing
- [x] Added integration testing to cover
- [ ] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
