### PR TITLE
Make helm chart consistent with makefile for spire usage

### DIFF
--- a/deployments/helm/nsm/values.yaml
+++ b/deployments/helm/nsm/values.yaml
@@ -9,7 +9,7 @@ tag: master
 pullPolicy: IfNotPresent
 
 forwardingPlane: vpp
-insecure: false
+insecure: true
 
 vpp:
   image: vppagent-dataplane
@@ -21,7 +21,7 @@ kernel:
     requestsCPU: 1m
 
 spire:
-  enabled: true
+  enabled: false
 
 global:
   # set to true to enable Jaeger tracing for NSM components


### PR DESCRIPTION
Right now the Makefile disables spire and sets insecure=true
The helm chart does the opposite.

In case #1756 doesn't pass CI, we need to make sure our helm charts
work out of the box.



<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [ ] Covered by existing integration testing
- [ ] Added integration testing to cover
- [ ] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.