### PR TITLE
Add only-run to cloudtest

### DIFF
--- a/test/cloudtest/pkg/commands/main.go
+++ b/test/cloudtest/pkg/commands/main.go
@@ -1056,7 +1056,17 @@ func (ctx *executionContext) findGoTest(executionConfig *config.ExecutionConfig)
 	for _, t := range execTests {
 		t.Kind = model.TestEntryKindGoTest
 		t.ExecutionConfig = executionConfig
-		result = append(result, t)
+		match := true
+		for _, v := range executionConfig.OnlyRun {
+			match = false
+			if v == t.Name {
+				match = true
+				break
+			}
+		}
+		if match {
+			result = append(result, t)
+		}
 	}
 	return result, nil
 }

--- a/test/cloudtest/pkg/config/config.go
+++ b/test/cloudtest/pkg/config/config.go
@@ -37,6 +37,7 @@ type ExecutionConfig struct {
 	Kind            string   `yaml:"kind"`             // Execution kind, default is 'gotest', 'shell' could be used for pure shell tests.
 	Name            string   `yaml:"name"`             // Execution name
 	Tags            []string `yaml:"tags"`             // A list of tags for this configured execution.
+	OnlyRun         []string `yaml:"only-run"`         // If non-empty, only run the listed tests
 	PackageRoot     string   `yaml:"root"`             // A package root for this test execution, default .
 	Timeout         int64    `yaml:"timeout"`          // Invidiaul test timeout, "60" passed to gotest, in seconds
 	ExtraOptions    []string `yaml:"extra-options"`    // Extra options to pass to gotest


### PR DESCRIPTION
If you add only-run to .cloudtest configuration it will only run the listed tests.

Super useful for running a small subset of tests that are failing in order to debug quickly.



<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [ ] Covered by existing integration testing
- [ ] Added integration testing to cover
- [ ] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.