### PR TITLE
update ParseProc to use scanner instead of reader

### DIFF
--- a/dataplane/pkg/common/egress_interface.go
+++ b/dataplane/pkg/common/egress_interface.go
@@ -60,24 +60,17 @@ func findDefaultGateway4() (string, net.IP, error) {
 	}
 	defer f.Close()
 
-	reader := bufio.NewReader(f)
-	return parseProcFile(reader)
+	scanner := bufio.NewScanner(f)
+	return parseProcFile(scanner)
 }
 
-func parseProcFile(reader *bufio.Reader) (string, net.IP, error) {
-	for {
-		line, err := reader.ReadString('\n')
-		if err != nil {
-			if err != io.EOF {
-				break
-			}
+func parseProcFile(scanner *bufio.Scanner) (string, net.IP, error) {
+	for scanner.Scan() {
+		if err := scanner.Err(); err != nil  {
 			logrus.Errorf("Failed to read routes files: %v", err)
 			break
 		}
-		if line == "" {
-			break
-		}
-		line = strings.TrimSpace(line)
+		line := strings.TrimSpace(scanner.Text())
 		parts := strings.Split(line, "\t")
 
 		if strings.TrimSpace(parts[1]) == "00000000" {

--- a/dataplane/pkg/common/egress_interface.go
+++ b/dataplane/pkg/common/egress_interface.go
@@ -66,7 +66,7 @@ func findDefaultGateway4() (string, net.IP, error) {
 
 func parseProcFile(scanner *bufio.Scanner) (string, net.IP, error) {
 	for scanner.Scan() {
-		if err := scanner.Err(); err != nil  {
+		if err := scanner.Err(); err != nil {
 			logrus.Errorf("Failed to read routes files: %v", err)
 			break
 		}

--- a/dataplane/pkg/common/egress_interface.go
+++ b/dataplane/pkg/common/egress_interface.go
@@ -71,14 +71,16 @@ func parseProcFile(scanner *bufio.Scanner) (string, net.IP, error) {
 			break
 		}
 		line := strings.TrimSpace(scanner.Text())
-		parts := strings.Split(line, "\t")
+		if len(line) > 0 {
+			parts := strings.Split(line, "\t")
 
-		if strings.TrimSpace(parts[1]) == "00000000" {
-			outgoingInterface := strings.TrimSpace(parts[0])
-			defaultGateway := strings.TrimSpace(parts[2])
-			ip := parseGatewayIP(defaultGateway)
-			logrus.Printf("Found default gateway %v outgoing: %v", ip.String(), outgoingInterface)
-			return outgoingInterface, ip, nil
+			if strings.TrimSpace(parts[1]) == "00000000" {
+				outgoingInterface := strings.TrimSpace(parts[0])
+				defaultGateway := strings.TrimSpace(parts[2])
+				ip := parseGatewayIP(defaultGateway)
+				logrus.Printf("Found default gateway %v outgoing: %v", ip.String(), outgoingInterface)
+				return outgoingInterface, ip, nil
+			}
 		}
 	}
 

--- a/dataplane/pkg/common/egress_interface.go
+++ b/dataplane/pkg/common/egress_interface.go
@@ -71,19 +71,18 @@ func parseProcFile(scanner *bufio.Scanner) (string, net.IP, error) {
 			break
 		}
 		line := strings.TrimSpace(scanner.Text())
-		if len(line) > 0 {
-			parts := strings.Split(line, "\t")
-
-			if strings.TrimSpace(parts[1]) == "00000000" {
-				outgoingInterface := strings.TrimSpace(parts[0])
-				defaultGateway := strings.TrimSpace(parts[2])
-				ip := parseGatewayIP(defaultGateway)
-				logrus.Printf("Found default gateway %v outgoing: %v", ip.String(), outgoingInterface)
-				return outgoingInterface, ip, nil
-			}
+		if len(line) == 0 {
+			continue
+		}
+		parts := strings.Split(line, "\t")
+		if strings.TrimSpace(parts[1]) == "00000000" {
+			outgoingInterface := strings.TrimSpace(parts[0])
+			defaultGateway := strings.TrimSpace(parts[2])
+			ip := parseGatewayIP(defaultGateway)
+			logrus.Printf("Found default gateway %v outgoing: %v", ip.String(), outgoingInterface)
+			return outgoingInterface, ip, nil
 		}
 	}
-
 	return "", nil, errors.New("Failed to locate default route...")
 }
 

--- a/dataplane/pkg/common/egress_interface_test.go
+++ b/dataplane/pkg/common/egress_interface_test.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	"bufio"
+	"bytes"
 	"strings"
 	"testing"
 
@@ -16,15 +17,25 @@ func TestParseDefaultGateway(t *testing.T) {
 	logrus.Printf("Value %v", gw.String())
 	g.Expect(gw.String(), "172.17.0.1")
 }
+func TestParseProcBlankLine(t *testing.T) {
+	g := NewWithT(t)
 
+	s := bufio.NewScanner(bytes.NewBuffer([]byte{0x0a}))
+	eth0, gw, err := parseProcFile(s)
+	g.Expect(err.Error()).To(Not(BeNil()))
+	g.Expect(eth0).To(Equal(""))
+	g.Expect(gw).To(BeNil())
+}
 func TestParseProcContent(t *testing.T) {
 	g := NewWithT(t)
 
-	r := bufio.NewReader(strings.NewReader("Iface	Destination	Gateway 	Flags	RefCnt	Use	Metric	Mask		MTU	Window	IRTT\n" +
+	s := bufio.NewScanner(strings.NewReader("Iface	Destination	Gateway 	Flags	RefCnt	Use	Metric	Mask		MTU	Window	IRTT\n" +
 		"eth0	00000000	010011AC	0003	0	0	0	00000000	0	0	0\n" +
-		"eth0	000011AC	00000000	0001	0	0	0	0000FFFF	0	0	0\n"))
+		"eth0	000011AC	00000000	0001	0	0	0	0000FFFF	0	0	0\n" +
+		"\n"+
+		"eth1	000011AB	00000000	0004	0	0	0	0000BBBB	0	0	0\n"))
 
-	eth0, gw, err := parseProcFile(r)
+	eth0, gw, err := parseProcFile(s)
 	g.Expect(err).To(BeNil())
 	logrus.Printf("Value %v", gw.String())
 	g.Expect(gw.String()).To(Equal("172.17.0.1"))
@@ -33,11 +44,11 @@ func TestParseProcContent(t *testing.T) {
 func TestParseProcWrongContent(t *testing.T) {
 	g := NewWithT(t)
 
-	r := bufio.NewReader(strings.NewReader("Iface	Destination	Gateway 	Flags	RefCnt	Use	Metric	Mask		MTU	Window	IRTT\n" +
+	s := bufio.NewScanner(strings.NewReader("Iface	Destination	Gateway 	Flags	RefCnt	Use	Metric	Mask		MTU	Window	IRTT\n" +
 		"eth0	00000001	010011AC	0003	0	0	0	00000000	0	0	0\n" +
 		"eth0	000011AC	00000000	0001	0	0	0	0000FFFF	0	0	0\n"))
 
-	eth0, gw, err := parseProcFile(r)
+	eth0, gw, err := parseProcFile(s)
 	g.Expect(err.Error()).To(Equal("Failed to locate default route..."))
 	logrus.Printf("Value %v", gw.String())
 	g.Expect(eth0).To(Equal(""))

--- a/dataplane/pkg/common/egress_interface_test.go
+++ b/dataplane/pkg/common/egress_interface_test.go
@@ -17,6 +17,7 @@ func TestParseDefaultGateway(t *testing.T) {
 	logrus.Printf("Value %v", gw.String())
 	g.Expect(gw.String(), "172.17.0.1")
 }
+
 func TestParseProcBlankLine(t *testing.T) {
 	g := NewWithT(t)
 
@@ -26,6 +27,7 @@ func TestParseProcBlankLine(t *testing.T) {
 	g.Expect(eth0).To(Equal(""))
 	g.Expect(gw).To(BeNil())
 }
+
 func TestParseProcContent(t *testing.T) {
 	g := NewWithT(t)
 

--- a/dataplane/pkg/common/egress_interface_test.go
+++ b/dataplane/pkg/common/egress_interface_test.go
@@ -32,7 +32,7 @@ func TestParseProcContent(t *testing.T) {
 	s := bufio.NewScanner(strings.NewReader("Iface	Destination	Gateway 	Flags	RefCnt	Use	Metric	Mask		MTU	Window	IRTT\n" +
 		"eth0	00000000	010011AC	0003	0	0	0	00000000	0	0	0\n" +
 		"eth0	000011AC	00000000	0001	0	0	0	0000FFFF	0	0	0\n" +
-		"\n"+
+		"\n" +
 		"eth1	000011AB	00000000	0004	0	0	0	0000BBBB	0	0	0\n"))
 
 	eth0, gw, err := parseProcFile(s)


### PR DESCRIPTION
Signed-off-by: Wayne <wayne@flickswitch.co.za>

User Scanner instead of reader.

## Description
refactored ParseProc, updated tests

## Motivation and Context
[Issue](https://github.com/networkservicemesh/networkservicemesh/issues/1614)

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [x] Covered by existing integration testing
- [x] Added integration testing to cover
- [ ] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
