### PR TITLE
Fix make vet

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ deps:
 	@${GOGET} -u github.com/golang/protobuf/protoc-gen-go
 
 generate:
-	@${GOGENERATE} ./...
+	@./scripts/for-each-module.sh ${GOGENERATE} ./...
 
 install:
 	@${GOINSTALL} ./...
@@ -98,7 +98,7 @@ test-race:
 	@${GOTEST} -race ./... -cover
 
 vet:
-	@${GOVET} ./...
+	@./scripts/for-each-module.sh ${GOVET} ./...
 
 # Get dependency manager tool
 get-dep:

--- a/sdk/compat/networkservice_server.go
+++ b/sdk/compat/networkservice_server.go
@@ -59,11 +59,9 @@ func (s networkServiceServerAdapter) Close(ctx context.Context, conn *connection
 		return s.localServer.Close(ctx, ConnectionUnifiedToLocal(conn))
 	} else if conn.GetMechanism().GetCls() == cls.REMOTE && s.remoteServer != nil {
 		return s.remoteServer.Close(ctx, ConnectionUnifiedToRemote(conn))
-	} else {
-		return nil, errors.Errorf("No NetworkServiceServer available for Connection.GetMechanism().GetCls(): %+s", conn.GetMechanism().GetCls())
 	}
 
-	return &empty.Empty{}, nil
+	return nil, errors.Errorf("No NetworkServiceServer available for Connection.GetMechanism().GetCls(): %+s", conn.GetMechanism().GetCls())
 }
 
 func NewUnifiedNetworkServiceServerAdapter(remoteServer remote.NetworkServiceServer, localServer local.NetworkServiceServer) networkservice.NetworkServiceServer {

--- a/test/cloudtest/pkg/commands/main.go
+++ b/test/cloudtest/pkg/commands/main.go
@@ -268,7 +268,8 @@ func (ctx *executionContext) performExecution() error {
 	defer cancelFunc()
 
 	termChannel := tools.NewOSSignalChannel()
-	timectx, _ := context.WithTimeout(context.Background(), 30*time.Second)
+	timectx, cancelfunc := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancelfunc()
 
 	for len(ctx.tasks) > 0 || len(ctx.running) > 0 {
 		// WE take 1 test task from list and do execution.
@@ -287,7 +288,8 @@ func (ctx *executionContext) performExecution() error {
 			}
 		case <-timectx.Done():
 			ctx.printStatistics()
-			timectx, _ = context.WithTimeout(context.Background(), 30*time.Second)
+			timectx, cancelfunc = context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancelfunc()
 		case <-termChannel:
 			return errors.New("termination request is received")
 		case <-timeoutCtx.Done():


### PR DESCRIPTION
'vet' and 'generate' targets were not updated upon switch to multi-module architecture.
A couple of errors has sneaked into master branch since then.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [ ] Covered by existing integration testing
- [ ] Added integration testing to cover
- [ ] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
