### PR TITLE
cloudtest: command line options enhancements

### DIFF
--- a/.cloudtest.yaml
+++ b/.cloudtest.yaml
@@ -24,6 +24,9 @@ retest:  # Allow to do test re-run if some kind of failures are detected, line C
     - "unable to establish connection to VPP (VPP API socket file /run/vpp/api.sock does not exist)"  # a VPP is not started, it will be re-started in general, but will cause test fail.
     # Sometimes (rarely) docker registry is unavailable for a moment
     - "Error response from daemon: Get https://.*docker.io/.*: dial tcp: lookup registry"
+
+tests-per-cluster-instance: 20  # Argument to calculate the number of clusters = <total-tests> / <tests-per-cluster-instance>
+
 reporting:
   junit-report: "results/junit.xml"
 health-check:

--- a/.cloudtest/packet.yaml
+++ b/.cloudtest/packet.yaml
@@ -14,8 +14,6 @@ providers:
       - CLUSTER_NAME=$(cluster-name)-$(date)-${CIRCLE_BUILD_NUM}-$(rands10)
       - CA_DIR=./deployments/helm/nsm/charts/spire/
     env-check:
-      - PACKET_AUTH_TOKEN
-      - PACKET_PROJECT_ID
       - CIRCLE_BUILD_NUM
     packet:
       ssh-key: sshkey.pub   # A key name relative to $(tempdir) or absolute

--- a/test/cloudtest/pkg/commands/main.go
+++ b/test/cloudtest/pkg/commands/main.go
@@ -155,6 +155,16 @@ func CloudTestRun(cmd *cloudTestCmd) {
 		os.Exit(1)
 	}
 
+	if len(testConfig.OnlyRun) > 0 {
+		logrus.Infof("Imposing top-level 'only-run' tests to all executions: %v", testConfig.OnlyRun)
+		for _, e := range testConfig.Executions {
+			if len(e.OnlyRun) > 0 {
+				logrus.Warningf("Overwriting non-empty 'only-run' on execution '%s'", e.Name)
+			}
+			e.OnlyRun = testConfig.OnlyRun
+		}
+	}
+
 	// Process config imports
 	err = performImport(testConfig)
 	if err != nil {

--- a/test/cloudtest/pkg/commands/main.go
+++ b/test/cloudtest/pkg/commands/main.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"math"
 	"math/rand"
 	"os"
 	"strings"
@@ -1219,6 +1220,10 @@ func (ctx *executionContext) createClusters() error {
 				tasks:     map[string]*testTask{},
 				completed: map[string]*testTask{},
 			}
+			testsPerInstance := int(math.Min(float64(ctx.cloudTestConfig.TestsPerClusterInstance), 20))
+			// initial value of cl.Instances is treated as allowed maximum
+			cl.Instances = int(math.Ceil(math.Min(float64(testCount)/float64(testsPerInstance), float64(cl.Instances))))
+			logrus.Infof("Creating %d instances of '%s' cluster to run %d test(s)", cl.Instances, cl.Name, testCount)
 			for i := 0; i < cl.Instances; i++ {
 				cluster, err := provider.CreateCluster(cl, ctx.factory, ctx.manager, ctx.arguments.instanceOptions)
 				if err != nil {

--- a/test/cloudtest/pkg/config/config.go
+++ b/test/cloudtest/pkg/config/config.go
@@ -85,7 +85,8 @@ type CloudTestConfig struct {
 		Enabled  bool  `yaml:"enabled"`  // A way to disable printing of statistics
 	} `yaml:"statistics"` // Statistics options
 
-	ShuffleTests bool `yaml:"shuffle-enabled"` // Shuffle tests before assignement
+	ShuffleTests bool     `yaml:"shuffle-enabled"` // Shuffle tests before assignement
+	OnlyRun      []string `yaml:"only-run"`        // If non-empty, only run the listed tests
 }
 
 // NewCloudTestConfig - creates a test config with some default values specified.

--- a/test/cloudtest/pkg/config/config.go
+++ b/test/cloudtest/pkg/config/config.go
@@ -88,6 +88,8 @@ type CloudTestConfig struct {
 
 	ShuffleTests bool     `yaml:"shuffle-enabled"` // Shuffle tests before assignement
 	OnlyRun      []string `yaml:"only-run"`        // If non-empty, only run the listed tests
+
+	TestsPerClusterInstance int `yaml:"tests-per-cluster-instance"` // Number of tests per cluster instance
 }
 
 // NewCloudTestConfig - creates a test config with some default values specified.

--- a/test/cloudtest/pkg/config/config.go
+++ b/test/cloudtest/pkg/config/config.go
@@ -49,6 +49,7 @@ type ExecutionConfig struct {
 	OnFail          string   `yaml:"on_fail"`          // A script to execute against required cluster, called if task failed
 
 	ConcurrencyRetry int64 `yaml:"test-retry-count"` // A count of times, same test will be executed to find concurrency issues
+	TestsFound       int   `yaml:"-"`                // Number of tests found for the config
 }
 
 type RetestConfig struct {

--- a/test/cloudtest/pkg/providers/packet/packet_provider.go
+++ b/test/cloudtest/pkg/providers/packet/packet_provider.go
@@ -691,21 +691,8 @@ func (p *packetProvider) ValidateConfig(config *config.ClusterProviderConfig) er
 		return errors.New("invalid start script")
 	}
 
-	for _, envVar := range config.EnvCheck {
-		envValue := os.Getenv(envVar)
-		if envValue == "" {
-			return errors.Errorf("environment variable are not specified %s Required variables: %v", envValue, config.EnvCheck)
-		}
-	}
-
-	envValue := os.Getenv("PACKET_AUTH_TOKEN")
-	if envValue == "" {
-		return errors.New("environment variable are not specified PACKET_AUTH_TOKEN")
-	}
-
-	envValue = os.Getenv("PACKET_PROJECT_ID")
-	if envValue == "" {
-		return errors.New("environment variable are not specified PACKET_AUTH_TOKEN")
+	if err := utils.CheckEnvironmentVariables(append(config.EnvCheck, "PACKET_AUTH_TOKEN", "PACKET_PROJECT_ID")); err != nil {
+		return err
 	}
 
 	return nil

--- a/test/cloudtest/pkg/providers/shell/shell_provider.go
+++ b/test/cloudtest/pkg/providers/shell/shell_provider.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"math/rand"
-	"os"
 	"path"
 	"strings"
 	"sync"
@@ -360,11 +359,8 @@ func (p *shellProvider) ValidateConfig(config *config.ClusterProviderConfig) err
 		return errors.New("invalid shutdown script location")
 	}
 
-	for _, envVar := range config.EnvCheck {
-		envValue := os.Getenv(envVar)
-		if envValue == "" {
-			return errors.Errorf("environment variable are not specified %s Required variables: %v", envValue, config.EnvCheck)
-		}
+	if err := utils.CheckEnvironmentVariables(config.EnvCheck); err != nil {
+		return err
 	}
 
 	return nil

--- a/test/cloudtest/pkg/tests/shell_provider_test.go
+++ b/test/cloudtest/pkg/tests/shell_provider_test.go
@@ -165,7 +165,7 @@ func TestRequireEnvVars(t *testing.T) {
 	report, err := commands.PerformTesting(testConfig, &testValidationFactory{}, &commands.Arguments{})
 	logrus.Error(err.Error())
 	g.Expect(err.Error()).To(Equal(
-		"Failed to create cluster instance. Error environment variable are not specified  Required variables: [KUBECONFIG QWE]"))
+		"Failed to create cluster instance. Error required variable(s) missing/empty: KUBECONFIG, QWE"))
 
 	g.Expect(report).To(BeNil())
 	// Do assertions

--- a/test/cloudtest/pkg/utils/utils.go
+++ b/test/cloudtest/pkg/utils/utils.go
@@ -21,11 +21,13 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"fmt"
+	"os"
 	"regexp"
 	"strings"
 	"sync"
 	"testing"
 
+	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -207,4 +209,20 @@ func MatchRetestPattern(patterns []string, line string) bool {
 		}
 	}
 	return false
+}
+
+// CheckEnvironmentVariables checks that variables are not empty
+func CheckEnvironmentVariables(varNames []string) error {
+	empties := []string{}
+	for _, envVar := range varNames {
+		envValue := os.Getenv(envVar)
+		if envValue == "" {
+			empties = append(empties, envVar)
+		}
+	}
+	if len(empties) > 0 {
+		return errors.Errorf("required variable(s) missing/empty: %v", strings.Join(empties, ", "))
+	}
+
+	return nil
 }


### PR DESCRIPTION
- global option for cloudtest utility to run only tests that specified, in order of priority:
  -- by name(s) as positional command line parameters
  -- only-run filed of cloudtest config 

- automatic number of clusters instances: the number of instances for each provider is calculated using 'tests-per-cluster-instance' parameter in config and number of tests involving the provider. providers.instances field is now interpreted as maximum allowed number of instances to start.

- 'kind' and 'tags' options to select tests based on provider's kind and test's tags

## Description
<!--- Describe your changes in detail -->

## Motivation and Context

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [x] Covered by existing integration testing
- [ ] Added integration testing to cover
- [x] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!---
/cloudtest -c packet 
/cloudtest -t interdomain
/cloudtest TestPass
-->