### PR TITLE
Expose Discovery Service to NSCs.

### DIFF
--- a/controlplane/pkg/nsmd/discovery.go
+++ b/controlplane/pkg/nsmd/discovery.go
@@ -1,0 +1,39 @@
+// Copyright (c) 2019 Cisco Systems, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package nsmd
+
+import (
+	"context"
+
+	"github.com/networkservicemesh/networkservicemesh/controlplane/api/registry"
+	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/serviceregistry"
+)
+
+type networkServiceDiscoveryServer struct {
+	serviceRegistry serviceregistry.ServiceRegistry
+}
+
+func NewNetworkServiceDiscoveryServer(serviceRegistry serviceregistry.ServiceRegistry) registry.NetworkServiceDiscoveryServer {
+	return &networkServiceDiscoveryServer{serviceRegistry: serviceRegistry}
+}
+
+func (n networkServiceDiscoveryServer) FindNetworkService(ctx context.Context, find *registry.FindNetworkServiceRequest) (*registry.FindNetworkServiceResponse, error) {
+	client, err := n.serviceRegistry.DiscoveryClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return client.FindNetworkService(ctx, find)
+}

--- a/controlplane/pkg/nsmd/workspace.go
+++ b/controlplane/pkg/nsmd/workspace.go
@@ -57,6 +57,7 @@ type Workspace struct {
 	locationProvider serviceregistry.WorkspaceLocationProvider
 	localRegistry    *nseregistry.NSERegistry
 	ctx              context.Context
+	discoveryServer  registry.NetworkServiceDiscoveryServer
 }
 
 // NewWorkSpace - constructs a new workspace.
@@ -117,6 +118,7 @@ func NewWorkSpace(ctx context.Context, nsm *nsmServer, name string, restore bool
 func registerWorkspaceServices(span spanhelper.SpanHelper, w *Workspace, nsm *nsmServer) {
 	span.Logger().Infof("Creating new NetworkServiceRegistryServer")
 	w.registryServer = NewRegistryServer(nsm, w)
+	w.discoveryServer = NewNetworkServiceDiscoveryServer(nsm.serviceRegistry)
 
 	span.Logger().Infof("Creating new MonitorConnectionServer")
 	w.monitorConnectionServer = connectionMonitor.NewMonitorServer("LocalConnection")
@@ -129,6 +131,8 @@ func registerWorkspaceServices(span spanhelper.SpanHelper, w *Workspace, nsm *ns
 
 	span.Logger().Infof("Registering NetworkServiceRegistryServer with registerServer")
 	registry.RegisterNetworkServiceRegistryServer(w.grpcServer, w.registryServer)
+	span.Logger().Infof("Registering NetworkServiceDiscoveryServer with discoveryServer")
+	registry.RegisterNetworkServiceDiscoveryServer(w.grpcServer, w.discoveryServer)
 	span.Logger().Infof("Registering NetworkServiceServer with registerServer")
 	unified.RegisterNetworkServiceServer(w.grpcServer, w.networkServiceServer)
 	span.Logger().Infof("Registering MonitorConnectionServer with registerServer")


### PR DESCRIPTION
There will be occasions when NSCs (particularly those which are also NSEs) may need
to make more sophisticated and programatic decisions than can be expressed in the NS resource
about Endpoint Selection.  This allows them to discover the NSEs to which to apply that criteria.



<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [ ] Covered by existing integration testing
- [ ] Added integration testing to cover
- [ ] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.