### PR TITLE
Do not search jaeger spans on CI

### DIFF
--- a/test/kubetest/k8s.go
+++ b/test/kubetest/k8s.go
@@ -18,6 +18,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/networkservicemesh/networkservicemesh/pkg/tools/jaeger"
+	jaeger_env "github.com/networkservicemesh/networkservicemesh/test/kubetest/jaeger"
 
 	. "github.com/onsi/gomega"
 	"github.com/sirupsen/logrus"
@@ -304,7 +305,7 @@ type spanRecord struct {
 }
 
 func (k8s *K8s) reportSpans() {
-	if !jaeger.IsOpentracingEnabled() {
+	if !jaeger.IsOpentracingEnabled() || jaeger_env.StoreJaegerTraces.GetBooleanOrDefault(false) {
 		return
 	}
 	logrus.Infof("Finding spans")


### PR DESCRIPTION
Signed-off-by: denis-tingajkin <denis.tingajkin@xored.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
Disable the span searching to speedup CI.

Currently, on CI we searching jaeger spans and storing jaeger traces.
We do not need to search spans if we store jaeger traces.

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [ ] Covered by existing integration testing
- [ ] Added integration testing to cover
- [ ] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
