### PR TITLE
Metrics: Exclude case when interface is created and removed within polling timeout

### DIFF
--- a/test/integration/basic_monitor_crossconnect_metrics_test.go
+++ b/test/integration/basic_monitor_crossconnect_metrics_test.go
@@ -35,6 +35,7 @@ func TestSimpleMetrics(t *testing.T) {
 		{
 			ForwarderVariables: map[string]string{
 				common.ForwarderMetricsEnabledKey:       "true",
+				"DEBUG_IFSTATES":                        "true",
 				common.ForwarderMetricsRequestPeriodKey: requestPeriod.String(),
 			},
 			Variables: pods.DefaultNSMD(),
@@ -50,10 +51,10 @@ func TestSimpleMetrics(t *testing.T) {
 
 	metricsCh := metricsFromEventCh(eventCh)
 	nsc := kubetest.DeployNSC(k8s, nodes[0].Node, "nsc1", defaultTimeout)
-
-	response, _, err := k8s.Exec(nsc, nsc.Spec.Containers[0].Name, "ping", "172.16.1.2", "-A", "-c", "4")
-	logrus.Infof("response = %v", response)
-	g.Expect(err).To(BeNil())
+	for i := 0; i < 10; i++ {
+		response, _, _ := k8s.Exec(nsc, nsc.Spec.Containers[0].Name, "ping", "172.16.1.2", "-A", "-c", "4")
+		logrus.Infof("response = %v", response)
+	}
 	<-time.After(requestPeriod * 5)
 	k8s.DeletePods(nsc)
 	select {


### PR DESCRIPTION


Signed-off-by: denis-tingajkin <denis.tingajkin@xored.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
1) Expand VPP Agent logs for stats
2) Exclude case when an interface is created and removed within polling timeout https://github.com/ligato/vpp-agent/issues/1537#issuecomment-545464108

## Motivation and Context
https://github.com/networkservicemesh/networkservicemesh/issues/1673

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [ ] Covered by existing integration testing
- [ ] Added integration testing to cover
- [ ] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
