### PR TITLE
Admin-webhook: add pod DNS serverlist passthrough env var

### DIFF
--- a/deployments/helm/nsm/charts/admission-webhook/templates/admission-webhook-secret.tpl
+++ b/deployments/helm/nsm/charts/admission-webhook/templates/admission-webhook-secret.tpl
@@ -48,6 +48,10 @@ spec:
             - name: JAEGER_AGENT_PORT
               value: "6831"
 {{- end }}
+{{- if .Values.global.ExtraDnsServers }}
+            - name: UPDATE_API_DEFAULT_DNS_SERVER
+              value: {{ .Values.global.ExtraDnsServers | quote }}
+{{- end }}
           volumeMounts:
             - name: webhook-certs
               mountPath: /etc/webhook/certs

--- a/deployments/helm/nsm/values.yaml
+++ b/deployments/helm/nsm/values.yaml
@@ -26,3 +26,6 @@ spire:
 global:
   # set to true to enable Jaeger tracing for NSM components
   JaegerTracing: false
+
+  # List of (extra) DNS nameservers to query
+  #ExtraDnsServers: "10.96.0.10 8.8.8.8"

--- a/k8s/cmd/admission-webhook/patches.go
+++ b/k8s/cmd/admission-webhook/patches.go
@@ -47,6 +47,10 @@ func createDNSPatch(tuple *podSpecAndMeta, annotationValue string) (patch []patc
 					Limits: corev1.ResourceList{
 						"networkservicemesh.io/socket": resource.MustParse("1"),
 					},
+					{
+						Name:  nsmcorednsenv.DefaultDNSServerIPList.Name(),
+						Value: nsmcorednsenv.DefaultDNSServerIPList.GetStringOrDefault("10.96.0.10"),
+					},
 				},
 			},
 		})...)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
When using the admission-webhook there is no way to currently set the list of DNS servers for the nsm-coredns sidecar.  This change adds the ability via passing through an env var in the admission-webhook to the injected nsm-coredns sidecars. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [ ] Covered by existing integration testing
- [ ] Added integration testing to cover
- [X] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
