### PR TITLE
Do not measure image pulling time for TestNSMDDeploy

### DIFF
--- a/test/integration/basic_nsmd_deploy_time_test.go
+++ b/test/integration/basic_nsmd_deploy_time_test.go
@@ -37,6 +37,11 @@ func TestNSMDDeploy(t *testing.T) {
 	g.Expect(err).To(BeNil())
 	k8s.DescribePod(node.Nsmd)
 	k8s.DescribePod(node.Forwarder)
+	nsmdPullingImageTime := k8s.GetPullingImagesDuration(node.Nsmd)
+	forwarderPullingImageTime := k8s.GetPullingImagesDuration(node.Forwarder)
+	logrus.Infof("NSMD pulling image time: %v", nsmdPullingImageTime)
+	logrus.Infof("VPPAgent Forwarder pulling image time: %v", forwarderPullingImageTime)
+	deploy -= nsmdPullingImageTime + forwarderPullingImageTime
 	destroy := measureTime(k8s.Cleanup)
 
 	logrus.Infof("Pods deploy time: %v", deploy)


### PR DESCRIPTION
Signed-off-by: Denis Tingajkin <denis.tingajkin@xored.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
In the [last PR](https://github.com/networkservicemesh/networkservicemesh/pull/1794) related to TestNSMDDeploy was improved logging. 
With new logs was found the root cause: sometimes on test time k8s pulling the image. 
We do not need to measure this time in the test.

```
time="2019-11-05T05:48:18Z" level=info msg="Pod nsmgr-aks-nodepool1-65165126-vmss000000 event: {\"metadata\":{\"name\":\"nsmgr-aks-nodepool1-65165126-vmss000000.15d42e213ed0e019\",\"namespace\":\"nsm-system-zjngh\",\"selfLink\":\"/api/v1/namespaces/nsm-system-zjngh/events/nsmgr-aks-nodepool1-65165126-vmss000000.15d42e213ed0e019\",\"uid\":\"d94340cf-ff8f-11e9-9f0b-0aa9205ebeef\",\"resourceVersion\":\"1904\",\"creationTimestamp\":\"2019-11-05T05:48:10Z\"},\"involvedObject\":{\"kind\":\"Pod\",\"namespace\":\"nsm-system-zjngh\",\"name\":\"nsmgr-aks-nodepool1-65165126-vmss000000\",\"uid\":\"b9bed2e5-ff8f-11e9-9f0b-0aa9205ebeef\",\"apiVersion\":\"v1\",\"resourceVersion\":\"1820\",\"fieldPath\":\"spec.containers{nsmd-k8s}\"},\"reason\":\"Pulling\",\"message\":\"pulling image \\\"networkservicemeshci/nsmd-k8s:ci_1be30d47-a0ab-48e8-a7a6-70eca6267607_83fda81b\\\"\",\"source\":{\"component\":\"kubelet\",\"host\":\"aks-nodepool1-65165126-vmss000000\"},\"firstTimestamp\":\"2019-11-05T05:48:10Z\",\"lastTimestamp\":\"2019-11-05T05:48:10Z\",\"count\":1,\"type\":\"Normal\",\"eventTime\":null,\"reportingComponent\":\"\",\"reportingInstance\":\"\"}"
```

## Motivation and Context
https://github.com/networkservicemesh/networkservicemesh/issues/1784
https://circleci.com/gh/networkservicemesh/networkservicemesh/113923?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-checks-link

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [ ] Covered by existing integration testing
- [ ] Added integration testing to cover
- [ ] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
