### PR TITLE
Support re-deploy on CNI network errors

### DIFF
--- a/.cloudtest.yaml
+++ b/.cloudtest.yaml
@@ -11,10 +11,14 @@ import:
   - .cloudtest/azure.yaml
 
 retest:  # Allow to do test re-run if some kind of failures are detected, line CNI network plugin errors.
-  count: 3  # Allow 3 times to do restart
+  count: 5  # Allow 5 times to do restart
+  warmup-time: 15  # Put 15 seconds warmup for cluster instance to be used again.
+  allowed-retests: 2  # If cluster instance have few attempts with retest requests one after another, we need to restart cluster.
   pattern:
-    - "NetworkPlugin cni failed to set up pod"
-    - "etcdserver: request timed out, possibly due to previous leader fail"
+    - "NetworkPlugin cni failed to set up pod"    # Error in AWS dur to leak of IPs or not ability to assign them.
+    - "etcdserver: request timed out, possibly due to previous leader fail"  # Error in any could, reason unknown.
+    - "unable to establish connection to VPP (VPP API socket file /run/vpp/api.sock does not exist)"  # a VPP is not started, it will be re-started in general, but will cause test fail.
+    - "node(s) didn't have free ports for the requested pod ports"  # Could happen for interdomain
 reporting:
   junit-report: "results/junit.xml"
 executions:

--- a/.cloudtest.yaml
+++ b/.cloudtest.yaml
@@ -10,6 +10,11 @@ import:
   - .cloudtest/aws.yaml
   - .cloudtest/azure.yaml
 
+retest:  # Allow to do test re-run if some kind of failures are detected, line CNI network plugin errors.
+  count: 3  # Allow 3 times to do restart
+  pattern:
+    - "NetworkPlugin cni failed to set up pod"
+    - "etcdserver: request timed out, possibly due to previous leader fail"
 reporting:
   junit-report: "results/junit.xml"
 executions:

--- a/.mk/vagrant.mk
+++ b/.mk/vagrant.mk
@@ -53,10 +53,10 @@ vagrant-%-load-images:
 	@if [ -e "$(IMAGE_DIR)/$*.tar" ]; then \
 		cd scripts/vagrant; \
 		echo "Loading image $*.tar to master"; \
-		vagrant ssh master -c "sudo docker rmi networkservicemesh/$* -f && docker load -i /images/$*.tar" > /dev/null 2>&1; \
+		vagrant ssh master -c "sudo docker rmi networkservicemesh/$* -f >/dev/null 2>&1 && sudo docker load -i /images/$*.tar" > /dev/null 2>&1; \
 		number=1 ; while [[ $$number -le ${WORKER_COUNT} ]] ; do \
 			echo "Loading image $*.tar to worker$$number"; \
-			vagrant ssh worker$$number -c "sudo docker rmi networkservicemesh/$* -f && docker load -i /images/$*.tar" > /dev/null 2>&1; \
+			vagrant ssh worker$$number -c "sudo docker rmi networkservicemesh/$* -f >/dev/null 2>&1 && sudo docker load -i /images/$*.tar" > /dev/null 2>&1; \
 			((number++)) ; \
 		done; \
 	else \

--- a/controlplane/pkg/local/endpoint_selector_service.go
+++ b/controlplane/pkg/local/endpoint_selector_service.go
@@ -92,9 +92,11 @@ func (cce *endpointSelectorService) Request(ctx context.Context, request *networ
 		// 7.1.1 Clone Connection to support iteration via EndPoints
 		newRequest, endpoint, err := cce.prepareRequest(ctx, request, clientConnection, ignoreEndpoints)
 		if err != nil {
+			span.Finish()
 			return cce.combineErrors(span, lastError, err)
 		}
 		if err = cce.checkTimeout(parentCtx, span); err != nil {
+			span.Finish()
 			return nil, err
 		}
 

--- a/pkg/tools/spanhelper/span_helper.go
+++ b/pkg/tools/spanhelper/span_helper.go
@@ -105,13 +105,13 @@ func (s *spanHelper) LogObject(attribute string, value interface{}) {
 	}
 
 	if s.span != nil {
-		s.span.LogFields(log.Object(attribute, msg), log.String("stacktrace", string(debug.Stack())))
+		s.span.LogFields(log.Object(attribute, msg))
 	}
 	logrus.Infof(">><<%s %s=%v span=%v", getPrefix("--", traceDepth(s.ctx)), attribute, msg, s.span)
 }
 func (s *spanHelper) LogValue(attribute string, value interface{}) {
 	if s.span != nil {
-		s.span.LogFields(log.Object(attribute, value), log.String("stacktrace", string(debug.Stack())))
+		s.span.LogFields(log.Object(attribute, value))
 	}
 	logrus.Infof(">><<%s %s=%v span=%v", getPrefix("--", traceDepth(s.ctx)), attribute, value, s.span)
 }

--- a/test/cloudtest/pkg/config/config.go
+++ b/test/cloudtest/pkg/config/config.go
@@ -49,6 +49,12 @@ type ExecutionConfig struct {
 	OnFail          string   `yaml:"on_fail"`          // A script to execute against required cluster, called if task failed
 }
 
+type RetestConfig struct {
+	// Executions, every execution execute some tests agains configured set of clusters
+	Patterns     []string `yaml:"pattern"` // Restart test output pattern, to treat as a test restart request, test will be added back for execution.
+	RestartCount int      `yaml:"count"`   // Allow to restart only few times using RestartCode check.
+}
+
 type CloudTestConfig struct {
 	Version    string                   `yaml:"version"` // Provider file version, 1.0
 	Providers  []*ClusterProviderConfig `yaml:"providers"`
@@ -60,4 +66,6 @@ type CloudTestConfig struct {
 	Executions []*ExecutionConfig `yaml:"executions"`
 	Timeout    int64              `yaml:"timeout"` // Global timeout in seconds
 	Imports    []string           `yaml:"import"`  // A set of configurations for import
+
+	RetestConfig RetestConfig `yaml:"retest"`
 }

--- a/test/cloudtest/pkg/config/config.go
+++ b/test/cloudtest/pkg/config/config.go
@@ -51,8 +51,11 @@ type ExecutionConfig struct {
 
 type RetestConfig struct {
 	// Executions, every execution execute some tests agains configured set of clusters
-	Patterns     []string `yaml:"pattern"` // Restart test output pattern, to treat as a test restart request, test will be added back for execution.
-	RestartCount int      `yaml:"count"`   // Allow to restart only few times using RestartCode check.
+	Patterns         []string `yaml:"pattern"`         // Restart test output pattern, to treat as a test restart request, test will be added back for execution.
+	RestartCount     int      `yaml:"count"`           // Allow to restart only few times using RestartCode check.
+	WarmupTimeout    int      `yaml:"warmup-time"`     // A cluster instance should warmup for some time if this is happening.
+	AllowedRetests   int      `yaml:"allowed-retests"` // A number of allowed retests for cluster, if reached, cluster instance will be restarted.
+	RetestFailResult string   `yaml:"fail-result"`     // A status if all attempts are failed, usual is skipped. if value != skip, it will be failed.
 }
 
 type CloudTestConfig struct {

--- a/test/cloudtest/pkg/model/tests.go
+++ b/test/cloudtest/pkg/model/tests.go
@@ -66,6 +66,7 @@ type TestEntry struct {
 	Kind   TestEntryKind
 	Status Status
 	sync.Mutex
+	SkipMessage string
 }
 
 // GetTestConfiguration - Return list of available tests by calling of gotest --list .* $root -tag "" and parsing of output.

--- a/test/cloudtest/pkg/model/tests.go
+++ b/test/cloudtest/pkg/model/tests.go
@@ -29,6 +29,8 @@ const (
 	StatusSkipped
 	// StatusSkippedSinceNoClusters - status of test if not clusters of desired group are available.
 	StatusSkippedSinceNoClusters
+	// StatusRerunRequest - a test was requested its re-run
+	StatusRerunRequest
 )
 
 // TestEntryExecution - represent one test execution.

--- a/test/cloudtest/pkg/tests/retest_test.go
+++ b/test/cloudtest/pkg/tests/retest_test.go
@@ -1,0 +1,249 @@
+// Copyright (c) 2019 Cisco Systems, Inc and/or its affiliates.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package tests - Cloud test tests
+package tests
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	"github.com/networkservicemesh/networkservicemesh/test/cloudtest/pkg/commands"
+	"github.com/networkservicemesh/networkservicemesh/test/cloudtest/pkg/config"
+	"github.com/networkservicemesh/networkservicemesh/test/cloudtest/pkg/utils"
+)
+
+func TestRestartRequest(t *testing.T) {
+	g := NewWithT(t)
+
+	logKeeper := utils.NewLogKeeper()
+	defer logKeeper.Stop()
+
+	testConfig := &config.CloudTestConfig{
+		RetestConfig: config.RetestConfig{
+			Patterns:     []string{"#Please_RETEST#"},
+			RestartCount: 2,
+		},
+	}
+	testConfig.Timeout = 3000
+
+	tmpDir, err := ioutil.TempDir(os.TempDir(), "cloud-test-temp")
+	defer utils.ClearFolder(tmpDir, false)
+	g.Expect(err).To(BeNil())
+
+	testConfig.ConfigRoot = tmpDir
+	createProvider(testConfig, "a_provider")
+
+	testConfig.Executions = append(testConfig.Executions, &config.ExecutionConfig{
+		Name:        "simple",
+		Tags:        []string{"request_restart"},
+		Timeout:     1500,
+		PackageRoot: "./sample",
+	})
+
+	testConfig.Reporting.JUnitReportFile = JunitReport
+
+	report, err := commands.PerformTesting(testConfig, &testValidationFactory{}, &commands.Arguments{})
+	g.Expect(err.Error()).To(Equal("there is failed tests 1"))
+
+	g.Expect(report).NotTo(BeNil())
+
+	g.Expect(len(report.Suites)).To(Equal(1))
+	g.Expect(report.Suites[0].Failures).To(Equal(1))
+	g.Expect(report.Suites[0].Tests).To(Equal(2))
+	g.Expect(len(report.Suites[0].TestCases)).To(Equal(2))
+
+	logKeeper.CheckMessagesOrder(t, []string{
+		"Starting TestRequestRestart",
+		"Re schedule task TestRequestRestart reason: rerun-request",
+		"Starting TestRequestRestart",
+		"Re schedule task TestRequestRestart reason: rerun-request",
+		"Test TestRequestRestart retry count 2 exceed: err",
+	})
+}
+
+func TestRestartRetestDestroyCluster(t *testing.T) {
+	g := NewWithT(t)
+
+	logKeeper := utils.NewLogKeeper()
+	defer logKeeper.Stop()
+
+	testConfig := &config.CloudTestConfig{
+		RetestConfig: config.RetestConfig{
+			Patterns:       []string{"#Please_RETEST#"},
+			RestartCount:   3,
+			AllowedRetests: 1,
+			WarmupTimeout:  0,
+		},
+	}
+	testConfig.Timeout = 1000
+
+	tmpDir, err := ioutil.TempDir(os.TempDir(), "cloud-test-temp")
+	defer utils.ClearFolder(tmpDir, false)
+	g.Expect(err).To(BeNil())
+
+	testConfig.ConfigRoot = tmpDir
+	p := createProvider(testConfig, "a_provider")
+	p.Instances = 1
+	p.RetryCount = 1
+
+	testConfig.Executions = append(testConfig.Executions, &config.ExecutionConfig{
+		Name:        "simple",
+		Tags:        []string{"request_restart"},
+		Timeout:     1500,
+		PackageRoot: "./sample",
+	})
+
+	testConfig.Reporting.JUnitReportFile = JunitReport
+
+	report, err := commands.PerformTesting(testConfig, &testValidationFactory{}, &commands.Arguments{})
+	g.Expect(err.Error()).To(Equal("there is failed tests 1"))
+
+	g.Expect(report).NotTo(BeNil())
+
+	g.Expect(len(report.Suites)).To(Equal(1))
+	g.Expect(report.Suites[0].Failures).To(Equal(1))
+	g.Expect(report.Suites[0].Tests).To(Equal(3))
+	g.Expect(len(report.Suites[0].TestCases)).To(Equal(3))
+
+	logKeeper.CheckMessagesOrder(t, []string{
+		"Starting TestRequestRestart",
+		"Reached a limit of re-tests per cluster instance",
+		"Destroying cluster",
+		"Re schedule task TestRequestRestart reason: rerun-request",
+		"Starting cluster ",
+		"Starting TestRequestRestart",
+		"Re schedule task TestRequestRestart reason: rerun-request",
+		"Move task to skipped since no clusters could execute it: TestRequestRestart",
+	})
+}
+
+func TestRestartRequestRestartCluster(t *testing.T) {
+	g := NewWithT(t)
+
+	logKeeper := utils.NewLogKeeper()
+	defer logKeeper.Stop()
+
+	testConfig := &config.CloudTestConfig{
+		RetestConfig: config.RetestConfig{
+			Patterns:       []string{"#Please_RETEST#"},
+			RestartCount:   3,
+			AllowedRetests: 2,
+			WarmupTimeout:  1,
+		},
+	}
+	testConfig.Timeout = 1000
+
+	tmpDir, err := ioutil.TempDir(os.TempDir(), "cloud-test-temp")
+	defer utils.ClearFolder(tmpDir, false)
+	g.Expect(err).To(BeNil())
+
+	testConfig.ConfigRoot = tmpDir
+	p := createProvider(testConfig, "a_provider")
+	p.Instances = 1
+	p.RetryCount = 10
+
+	testConfig.Executions = append(testConfig.Executions, &config.ExecutionConfig{
+		Name:        "simple",
+		Tags:        []string{"request_restart"},
+		Timeout:     1500,
+		PackageRoot: "./sample",
+	})
+
+	testConfig.Reporting.JUnitReportFile = JunitReport
+
+	report, err := commands.PerformTesting(testConfig, &testValidationFactory{}, &commands.Arguments{})
+	g.Expect(err.Error()).To(Equal("there is failed tests 1"))
+
+	g.Expect(report).NotTo(BeNil())
+
+	g.Expect(len(report.Suites)).To(Equal(1))
+	g.Expect(report.Suites[0].Failures).To(Equal(1))
+	g.Expect(report.Suites[0].Tests).To(Equal(2))
+	g.Expect(len(report.Suites[0].TestCases)).To(Equal(2))
+
+	logKeeper.CheckMessagesOrder(t, []string{
+		"Starting TestRequestRestart",
+		"Warmup cluster operations: [a_provider-1] timeout: 1s",
+		"Reached a limit of re-tests per cluster instance",
+		"Destroying cluster",
+		"Re schedule task TestRequestRestart reason: rerun-request",
+		"Starting cluster ",
+		"Starting TestRequestRestart",
+		"Re schedule task TestRequestRestart reason: rerun-request",
+		"Test TestRequestRestart retry count 3 exceed: err: failed to run go test",
+	})
+}
+
+func TestRestartRequestSkip(t *testing.T) {
+	g := NewWithT(t)
+
+	logKeeper := utils.NewLogKeeper()
+	defer logKeeper.Stop()
+
+	testConfig := &config.CloudTestConfig{
+		RetestConfig: config.RetestConfig{
+			Patterns:         []string{"#Please_RETEST#"},
+			RestartCount:     2,
+			RetestFailResult: "skip",
+		},
+	}
+	testConfig.Timeout = 3000
+
+	tmpDir, err := ioutil.TempDir(os.TempDir(), "cloud-test-temp")
+	defer utils.ClearFolder(tmpDir, false)
+	g.Expect(err).To(BeNil())
+
+	testConfig.ConfigRoot = tmpDir
+	createProvider(testConfig, "a_provider")
+
+	testConfig.Executions = append(testConfig.Executions, &config.ExecutionConfig{
+		Name:        "simple",
+		Tags:        []string{"request_restart"},
+		Timeout:     1500,
+		PackageRoot: "./sample",
+	})
+
+	testConfig.Reporting.JUnitReportFile = JunitReport
+
+	report, err := commands.PerformTesting(testConfig, &testValidationFactory{}, &commands.Arguments{})
+	g.Expect(err).To(BeNil())
+
+	g.Expect(report).NotTo(BeNil())
+
+	g.Expect(len(report.Suites)).To(Equal(1))
+	g.Expect(report.Suites[0].Failures).To(Equal(0))
+	g.Expect(report.Suites[0].Tests).To(Equal(2))
+	g.Expect(len(report.Suites[0].TestCases)).To(Equal(2))
+
+	for _, tt := range report.Suites[0].TestCases {
+		if tt.Name == "_TestRequestRestart" {
+			g.Expect(tt.SkipMessage.Message).To(Equal("Test TestRequestRestart retry count 2 exceed: err: failed to run go test . -test.timeout 50m0s -count 1 --run \"^(TestRequestRestart)\\\\z\" --tags \"request_restart\" --test.v ExitCode: 1"))
+		}
+	}
+
+	logKeeper.CheckMessagesOrder(t, []string{
+		"Starting TestRequestRestart",
+		"Re schedule task TestRequestRestart reason: rerun-request",
+		"Starting TestRequestRestart",
+		"Re schedule task TestRequestRestart reason: rerun-request",
+		"Test TestRequestRestart retry count 2 exceed: err",
+		"Re schedule task TestRequestRestart reason: skipped",
+	})
+}

--- a/test/cloudtest/pkg/tests/sample/restart_restart_test.go
+++ b/test/cloudtest/pkg/tests/sample/restart_restart_test.go
@@ -1,0 +1,43 @@
+// Copyright (c) 2019 Cisco and/or its affiliates.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build request_restart
+
+// Package sample - an example tests
+package sample
+
+import (
+	"os"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	"github.com/sirupsen/logrus"
+)
+
+func TestRequestRestartPass(t *testing.T) {
+	NewWithT(t)
+	logrus.Infof("Passed")
+}
+func TestRequestRestart(t *testing.T) {
+	NewWithT(t)
+	logrus.Infof("Running Restart request test")
+	defer func() {
+		t.Logf("Exiting test with code 11")
+	}()
+
+	logrus.Infof("#Please_RETEST# 11")
+	os.Exit(11)
+}

--- a/test/cloudtest/pkg/tests/shell_provider_test.go
+++ b/test/cloudtest/pkg/tests/shell_provider_test.go
@@ -321,11 +321,11 @@ func TestUnusedClusterShutdownByMonitor(t *testing.T) {
 	g.Expect(report.Suites[0].Tests).To(Equal(3))
 	g.Expect(len(report.Suites[0].TestCases)).To(Equal(3))
 
-	g.Expect(logKeeper.CheckMessagesOrder([]string{
+	logKeeper.CheckMessagesOrder(t, []string{
 		"All tasks for cluster group a_provider are complete. Starting cluster shutdown",
 		"Destroying cluster  a_provider-",
 		"Finished test execution",
-	})).To(BeTrue())
+	})
 }
 
 func TestMultiClusterTest(t *testing.T) {
@@ -423,46 +423,6 @@ func TestGlobalTimeout(t *testing.T) {
 	g.Expect(report.Suites[0].Failures).To(Equal(1))
 	g.Expect(report.Suites[0].Tests).To(Equal(3))
 	g.Expect(len(report.Suites[0].TestCases)).To(Equal(3))
-
-	// Do assertions
-}
-
-func TestRestartRequest(t *testing.T) {
-	g := NewWithT(t)
-
-	testConfig := &config.CloudTestConfig{
-		RetestConfig: config.RetestConfig{
-			Patterns:     []string{"#Please_RETEST#"},
-			RestartCount: 2,
-		},
-	}
-	testConfig.Timeout = 3000
-
-	tmpDir, err := ioutil.TempDir(os.TempDir(), "cloud-test-temp")
-	defer utils.ClearFolder(tmpDir, false)
-	g.Expect(err).To(BeNil())
-
-	testConfig.ConfigRoot = tmpDir
-	createProvider(testConfig, "a_provider")
-
-	testConfig.Executions = append(testConfig.Executions, &config.ExecutionConfig{
-		Name:        "simple",
-		Tags:        []string{"request_restart"},
-		Timeout:     1500,
-		PackageRoot: "./sample",
-	})
-
-	testConfig.Reporting.JUnitReportFile = JunitReport
-
-	report, err := commands.PerformTesting(testConfig, &testValidationFactory{}, &commands.Arguments{})
-	g.Expect(err.Error()).To(Equal("there is failed tests 1"))
-
-	g.Expect(report).NotTo(BeNil())
-
-	g.Expect(len(report.Suites)).To(Equal(1))
-	g.Expect(report.Suites[0].Failures).To(Equal(1))
-	g.Expect(report.Suites[0].Tests).To(Equal(2))
-	g.Expect(len(report.Suites[0].TestCases)).To(Equal(2))
 
 	// Do assertions
 }

--- a/test/cloudtest/pkg/utils/process.go
+++ b/test/cloudtest/pkg/utils/process.go
@@ -8,9 +8,9 @@ import (
 	"os/exec"
 	"strings"
 
-	"github.com/pkg/errors"
-
 	"github.com/sirupsen/logrus"
+
+	"github.com/pkg/errors"
 )
 
 //ProcWrapper - A simple process wrapper
@@ -25,7 +25,11 @@ type ProcWrapper struct {
 func (w *ProcWrapper) ExitCode() int {
 	err := w.Cmd.Wait()
 	if err != nil {
+		e, ok := err.(*exec.ExitError)
 		logrus.Errorf("Error during waiting for process exit code: %v %v", w.Cmd.Args, err)
+		if ok {
+			return e.ExitCode()
+		}
 		return -1
 	}
 	return w.Cmd.ProcessState.ExitCode()

--- a/test/cloudtest/pkg/utils/process.go
+++ b/test/cloudtest/pkg/utils/process.go
@@ -26,10 +26,10 @@ func (w *ProcWrapper) ExitCode() int {
 	err := w.Cmd.Wait()
 	if err != nil {
 		e, ok := err.(*exec.ExitError)
-		logrus.Errorf("Error during waiting for process exit code: %v %v", w.Cmd.Args, err)
 		if ok {
 			return e.ExitCode()
 		}
+		logrus.Errorf("Error during waiting for process exit code: %v %v", w.Cmd.Args, err)
 		return -1
 	}
 	return w.Cmd.ProcessState.ExitCode()

--- a/test/cloudtest/pkg/utils/utils.go
+++ b/test/cloudtest/pkg/utils/utils.go
@@ -3,10 +3,11 @@ package utils
 import (
 	"crypto/rand"
 	"encoding/hex"
+	"fmt"
 	"strings"
+	"sync"
 
 	"github.com/sirupsen/logrus"
-	"github.com/sirupsen/logrus/hooks/test"
 )
 
 // Contains - check if array contains element.
@@ -31,14 +32,23 @@ func NewRandomStr(size int) string {
 }
 
 type logKeeper struct {
-	loghook *test.Hook
+	loghook *logrusHook
 }
 
 // NewLogKeeper - creates new instance of logrus log collector
 func NewLogKeeper() *logKeeper {
 	return &logKeeper{
-		loghook: test.NewGlobal(),
+		loghook: newGlobal(),
 	}
+}
+
+// GetMessages - return a string representation of all messages.
+func (lk *logKeeper) GetMessages() []string {
+	messages := []string{}
+	for _, entry := range lk.loghook.AllEntries() {
+		messages = append(messages, entry.Message+"\n")
+	}
+	return messages
 }
 
 // CheckMessagesOrder - checks that messages are present in log in given oreder.
@@ -47,7 +57,9 @@ func (lk *logKeeper) CheckMessagesOrder(messages []string) bool {
 		return false
 	}
 	ind := 0
+	msgs := []string{}
 	for _, entry := range lk.loghook.AllEntries() {
+		msgs = append(msgs, fmt.Sprintf("\"%s\",\n", entry.Message))
 		if strings.Contains(entry.Message, messages[ind]) {
 			ind++
 			if ind == len(messages) {
@@ -55,5 +67,83 @@ func (lk *logKeeper) CheckMessagesOrder(messages []string) bool {
 			}
 		}
 	}
+	logrus.Infof("Not matched: %v", msgs)
 	return false
+}
+
+func (lk *logKeeper) Stop() {
+	lk.loghook.Stop()
+}
+
+// logrusHook is a hook designed for dealing with logs in test scenarios.
+type logrusHook struct {
+	// Entries is an array of all entries that have been received by this hook.
+	// For safe access, use the AllEntries() method, rather than reading this
+	// value directly.
+	Entries []logrus.Entry
+	mu      sync.RWMutex
+	stopped bool
+
+	logrus.Hook
+}
+
+// NewGlobal installs a test hook for the global logger.
+func newGlobal() *logrusHook {
+	hook := new(logrusHook)
+	hook.stopped = false
+	logrus.AddHook(hook)
+
+	return hook
+}
+
+func (t *logrusHook) Fire(e *logrus.Entry) error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.stopped {
+		// If stopped, we do not need to capture any more events.
+		return nil
+	}
+	t.Entries = append(t.Entries, *e)
+	return nil
+}
+
+func (t *logrusHook) Levels() []logrus.Level {
+	return logrus.AllLevels
+}
+
+// LastEntry returns the last entry that was logged or nil.
+func (t *logrusHook) LastEntry() *logrus.Entry {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	i := len(t.Entries) - 1
+	if i < 0 {
+		return nil
+	}
+	return &t.Entries[i]
+}
+
+// AllEntries returns all entries that were logged.
+func (t *logrusHook) AllEntries() []*logrus.Entry {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	// Make a copy so the returned value won't race with future log requests
+	entries := make([]*logrus.Entry, len(t.Entries))
+	for i := 0; i < len(t.Entries); i++ {
+		// Make a copy, for safety
+		entries[i] = &t.Entries[i]
+	}
+	return entries
+}
+
+// Reset removes all Entries from this test hook.
+func (t *logrusHook) Reset() {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.Entries = make([]logrus.Entry, 0)
+}
+
+func (t *logrusHook) Stop() {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.stopped = true
 }

--- a/test/cloudtest/pkg/utils/utils_test.go
+++ b/test/cloudtest/pkg/utils/utils_test.go
@@ -1,0 +1,32 @@
+// Copyright (c) 2019 Cisco Systems, Inc and/or its affiliates.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package utils - Utils for cloud testing tool
+package utils
+
+import (
+	"testing"
+
+	"github.com/onsi/gomega"
+)
+
+func TestMatchPattern(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	g.Expect(MatchRetestPattern([]string{
+		"unable to establish connection to VPP (VPP API socket file /run/vpp/api.sock does not exist)",
+	}, "time=\"2019-11-22 09:28:45.55766\" level=fatal msg=\"unable to establish connection to VPP (VPP API socket file /run/vpp/api.sock does not exist)\" loc=\"vpp-agent/main.go(65)\" logger=defaultLogger")).To(gomega.Equal(true))
+}

--- a/test/integration/basic_exec_test.go
+++ b/test/integration/basic_exec_test.go
@@ -3,7 +3,12 @@
 package nsmd_integration_tests
 
 import (
+	"fmt"
 	"testing"
+
+	v1 "k8s.io/api/core/v1"
+
+	"github.com/networkservicemesh/networkservicemesh/test/cloudtest/pkg/utils"
 
 	. "github.com/onsi/gomega"
 	"github.com/sirupsen/logrus"
@@ -20,7 +25,7 @@ func TestExec(t *testing.T) {
 		return
 	}
 
-	k8s, err := kubetest.NewK8sWithoutRoles(g, false)
+	k8s, err := kubetest.NewK8sWithoutRoles(g, true)
 	defer k8s.Cleanup()
 	g.Expect(err).To(BeNil())
 	defer kubetest.MakeLogsSnapshot(k8s, t)
@@ -35,5 +40,64 @@ func TestExec(t *testing.T) {
 	logrus.Printf("NSC IP status:%s", ipResponse)
 	logrus.Printf("End of test")
 	k8s.DeletePods(alpinePod)
+}
 
+func TestExecCheckReDeploy(t *testing.T) {
+	g := NewWithT(t)
+
+	if testing.Short() {
+		t.Skip("Skip, please run without -short")
+		return
+	}
+
+	k8s, err := kubetest.NewK8sWithoutRoles(g, true)
+	defer k8s.Cleanup()
+	g.Expect(err).To(BeNil())
+	defer kubetest.MakeLogsSnapshot(k8s, t)
+
+	attempt := 0
+
+	k8s.SetDescribeHook(func(pod *v1.Pod, events []v1.Event) []v1.Event {
+		attempt += 1
+		if attempt == 1 {
+			logrus.Infof("return error msg")
+			return append(events, v1.Event{
+				InvolvedObject: v1.ObjectReference{
+					Name: pod.Name,
+					Kind: "pod",
+				},
+				Reason:  "",
+				Message: fmt.Sprintf("Some Error %s and some more error", kubetest.NetworkPluginCNIFailure),
+			})
+		}
+		logrus.Infof("normal deploy")
+		return events
+	})
+
+	k8s.Prepare("alpine-pod")
+
+	keeper := utils.NewLogKeeper()
+	defer keeper.Stop()
+
+	alpinePod := k8s.CreatePod(pods.AlpinePod("alpine-pod", nil))
+
+	logrus.Infof("Messages: %v", keeper.GetMessages())
+
+	ipResponse, errResponse, error := k8s.Exec(alpinePod, alpinePod.Spec.Containers[0].Name, "ip", "addr")
+	g.Expect(error).To(BeNil())
+	g.Expect(errResponse).To(Equal(""))
+	logrus.Printf("NSC IP status:%s", ipResponse)
+	logrus.Printf("End of test")
+
+	g.Expect(keeper.CheckMessagesOrder([]string{
+		"Creating pod alpine-pod attempt:1",
+		"Attempt to re-deploy pod alpine-pod. Reason: <nil>, Delete it",
+		"Deleting alpine-pod",
+		"The POD \"alpine-pod\" Deleted",
+		"Creating pod alpine-pod attempt:2",
+		"normal deploy",
+		"deployed: alpine-pod",
+	})).To(Equal(true))
+
+	k8s.DeletePods(alpinePod)
 }

--- a/test/integration/basic_exec_test.go
+++ b/test/integration/basic_exec_test.go
@@ -3,12 +3,7 @@
 package nsmd_integration_tests
 
 import (
-	"fmt"
 	"testing"
-
-	v1 "k8s.io/api/core/v1"
-
-	"github.com/networkservicemesh/networkservicemesh/test/cloudtest/pkg/utils"
 
 	. "github.com/onsi/gomega"
 	"github.com/sirupsen/logrus"
@@ -39,65 +34,5 @@ func TestExec(t *testing.T) {
 	g.Expect(errResponse).To(Equal(""))
 	logrus.Printf("NSC IP status:%s", ipResponse)
 	logrus.Printf("End of test")
-	k8s.DeletePods(alpinePod)
-}
-
-func TestExecCheckReDeploy(t *testing.T) {
-	g := NewWithT(t)
-
-	if testing.Short() {
-		t.Skip("Skip, please run without -short")
-		return
-	}
-
-	k8s, err := kubetest.NewK8sWithoutRoles(g, true)
-	defer k8s.Cleanup()
-	g.Expect(err).To(BeNil())
-	defer kubetest.MakeLogsSnapshot(k8s, t)
-
-	attempt := 0
-
-	k8s.SetDescribeHook(func(pod *v1.Pod, events []v1.Event) []v1.Event {
-		attempt += 1
-		if attempt == 1 {
-			logrus.Infof("return error msg")
-			return append(events, v1.Event{
-				InvolvedObject: v1.ObjectReference{
-					Name: pod.Name,
-					Kind: "pod",
-				},
-				Reason:  "",
-				Message: fmt.Sprintf("Some Error %s and some more error", kubetest.NetworkPluginCNIFailure),
-			})
-		}
-		logrus.Infof("normal deploy")
-		return events
-	})
-
-	k8s.Prepare("alpine-pod")
-
-	keeper := utils.NewLogKeeper()
-	defer keeper.Stop()
-
-	alpinePod := k8s.CreatePod(pods.AlpinePod("alpine-pod", nil))
-
-	logrus.Infof("Messages: %v", keeper.GetMessages())
-
-	ipResponse, errResponse, error := k8s.Exec(alpinePod, alpinePod.Spec.Containers[0].Name, "ip", "addr")
-	g.Expect(error).To(BeNil())
-	g.Expect(errResponse).To(Equal(""))
-	logrus.Printf("NSC IP status:%s", ipResponse)
-	logrus.Printf("End of test")
-
-	g.Expect(keeper.CheckMessagesOrder([]string{
-		"Creating pod alpine-pod attempt:1",
-		"Attempt to re-deploy pod alpine-pod. Reason: <nil>, Delete it",
-		"Deleting alpine-pod",
-		"The POD \"alpine-pod\" Deleted",
-		"Creating pod alpine-pod attempt:2",
-		"normal deploy",
-		"deployed: alpine-pod",
-	})).To(Equal(true))
-
 	k8s.DeletePods(alpinePod)
 }

--- a/test/integration/usecase_vpn_test.go
+++ b/test/integration/usecase_vpn_test.go
@@ -5,6 +5,7 @@ package nsmd_integration_tests
 import (
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -128,65 +129,78 @@ func testVPN(t *testing.T, ptnum, nodesCount int, affinity map[string]int, verbo
 		srcIP, dstIP = "100::1", "100::2"
 	}
 
-	s1 = time.Now()
-	node := affinity["vppagent-firewall-nse-1"]
-	logrus.Infof("Starting VPPAgent Firewall NSE on node: %d", node)
-	_, err = k8s.CreateConfigMap(pods.VppAgentFirewallNSEConfigMapICMPHTTP("vppagent-firewall-nse-1", k8s.GetK8sNamespace()))
-	g.Expect(err).To(BeNil())
-	vppagentFirewallNode := k8s.CreatePod(pods.VppAgentFirewallNSEPodWithConfigMap("vppagent-firewall-nse-1", &nodes[node],
-		map[string]string{
-			"ADVERTISE_NSE_NAME":   "secure-intranet-connectivity",
-			"ADVERTISE_NSE_LABELS": "app=firewall",
-			"OUTGOING_NSC_NAME":    "secure-intranet-connectivity",
-			"OUTGOING_NSC_LABELS":  "app=firewall",
-		},
-	))
-	g.Expect(vppagentFirewallNode.Name).To(Equal("vppagent-firewall-nse-1"))
-
-	k8s.WaitLogsContains(vppagentFirewallNode, "", "NSE: channel has been successfully advertised, waiting for connection from NSM...", fastTimeout)
-
-	logrus.Printf("VPN firewall started done: %v", time.Since(s1))
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		s1 = time.Now()
+		node := affinity["vppagent-firewall-nse-1"]
+		logrus.Infof("Starting VPPAgent Firewall NSE on node: %d", node)
+		_, err = k8s.CreateConfigMap(pods.VppAgentFirewallNSEConfigMapICMPHTTP("vppagent-firewall-nse-1", k8s.GetK8sNamespace()))
+		g.Expect(err).To(BeNil())
+		vppagentFirewallNode := k8s.CreatePod(pods.VppAgentFirewallNSEPodWithConfigMap("vppagent-firewall-nse-1", &nodes[node],
+			map[string]string{
+				"ADVERTISE_NSE_NAME":   "secure-intranet-connectivity",
+				"ADVERTISE_NSE_LABELS": "app=firewall",
+				"OUTGOING_NSC_NAME":    "secure-intranet-connectivity",
+				"OUTGOING_NSC_LABELS":  "app=firewall",
+			},
+		))
+		g.Expect(vppagentFirewallNode.Name).To(Equal("vppagent-firewall-nse-1"))
+		k8s.WaitLogsContains(vppagentFirewallNode, "", "NSE: channel has been successfully advertised, waiting for connection from NSM...", fastTimeout)
+		logrus.Printf("VPN firewall started done: %v", time.Since(s1))
+	}()
 
 	for i := 1; i <= ptnum; i++ {
 		s1 = time.Now()
 		id := strconv.Itoa(i)
-		node = affinity["vppagent-passthrough-nse"]
-		logrus.Infof("Starting VPPAgent Passthrough NSE on node: %d", node)
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			node := affinity["vppagent-passthrough-nse"]
+			logrus.Infof("Starting VPPAgent Passthrough NSE on node: %d", node)
 
-		vppagentPassthroughNode := k8s.CreatePod(pods.VppAgentFirewallNSEPod("vppagent-passthrough-nse-"+id, &nodes[node],
-			map[string]string{
-				"ADVERTISE_NSE_NAME":   "secure-intranet-connectivity",
-				"ADVERTISE_NSE_LABELS": "app=passthrough-" + id,
-				"OUTGOING_NSC_NAME":    "secure-intranet-connectivity",
-				"OUTGOING_NSC_LABELS":  "app=passthrough-" + id,
-			},
-		))
-		g.Expect(vppagentPassthroughNode.Name).To(Equal("vppagent-passthrough-nse-" + id))
+			vppagentPassthroughNode := k8s.CreatePod(pods.VppAgentFirewallNSEPod("vppagent-passthrough-nse-"+id, &nodes[node],
+				map[string]string{
+					"ADVERTISE_NSE_NAME":   "secure-intranet-connectivity",
+					"ADVERTISE_NSE_LABELS": "app=passthrough-" + id,
+					"OUTGOING_NSC_NAME":    "secure-intranet-connectivity",
+					"OUTGOING_NSC_LABELS":  "app=passthrough-" + id,
+				},
+			))
+			g.Expect(vppagentPassthroughNode.Name).To(Equal("vppagent-passthrough-nse-" + id))
 
-		k8s.WaitLogsContains(vppagentPassthroughNode, "", "NSE: channel has been successfully advertised, waiting for connection from NSM...", fastTimeout)
+			k8s.WaitLogsContains(vppagentPassthroughNode, "", "NSE: channel has been successfully advertised, waiting for connection from NSM...", fastTimeout)
 
-		logrus.Printf("VPN passthrough started done: %v", time.Since(s1))
+			logrus.Printf("VPN passthrough started done: %v", time.Since(s1))
+		}()
 	}
 
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		s1 = time.Now()
+		node := affinity["vpn-gateway-nse-1"]
+		logrus.Infof("Starting VPN Gateway NSE on node: %d", node)
+		vpnGatewayPodNode := k8s.CreatePod(pods.VPNGatewayNSEPod("vpn-gateway-nse-1", &nodes[node],
+			map[string]string{
+				"ADVERTISE_NSE_NAME":   "secure-intranet-connectivity",
+				"ADVERTISE_NSE_LABELS": "app=vpn-gateway",
+				"IP_ADDRESS":           addressPool,
+			},
+		))
+		g.Expect(vpnGatewayPodNode).ToNot(BeNil())
+		g.Expect(vpnGatewayPodNode.Name).To(Equal("vpn-gateway-nse-1"))
+
+		k8s.WaitLogsContains(vpnGatewayPodNode, "vpn-gateway", "NSE: channel has been successfully advertised, waiting for connection from NSM...", fastTimeout)
+
+		logrus.Printf("VPN Gateway started done: %v", time.Since(s1))
+	}()
+
+	wg.Wait()
+
 	s1 = time.Now()
-	node = affinity["vpn-gateway-nse-1"]
-	logrus.Infof("Starting VPN Gateway NSE on node: %d", node)
-	vpnGatewayPodNode := k8s.CreatePod(pods.VPNGatewayNSEPod("vpn-gateway-nse-1", &nodes[node],
-		map[string]string{
-			"ADVERTISE_NSE_NAME":   "secure-intranet-connectivity",
-			"ADVERTISE_NSE_LABELS": "app=vpn-gateway",
-			"IP_ADDRESS":           addressPool,
-		},
-	))
-	g.Expect(vpnGatewayPodNode).ToNot(BeNil())
-	g.Expect(vpnGatewayPodNode.Name).To(Equal("vpn-gateway-nse-1"))
-
-	k8s.WaitLogsContains(vpnGatewayPodNode, "vpn-gateway", "NSE: channel has been successfully advertised, waiting for connection from NSM...", fastTimeout)
-
-	logrus.Printf("VPN Gateway started done: %v", time.Since(s1))
-
-	s1 = time.Now()
-	node = affinity["vpn-gateway-nsc-1"]
+	node := affinity["vpn-gateway-nsc-1"]
 	nscPodNode := k8s.CreatePod(pods.NSCPod("vpn-gateway-nsc-1", &nodes[node],
 		map[string]string{
 			"OUTGOING_NSC_NAME": "secure-intranet-connectivity",

--- a/test/kubetest/k8s.go
+++ b/test/kubetest/k8s.go
@@ -351,8 +351,6 @@ type K8s struct {
 	sa                 []string
 	g                  *WithT
 	cleanupFunc        func()
-
-	describeHook func(*v1.Pod, []v1.Event) []v1.Event
 }
 
 type spanRecord struct {
@@ -565,9 +563,6 @@ func (k8s *K8s) describePod(pod *v1.Pod) []v1.Event {
 		if pod.UID == events.Items[i].InvolvedObject.UID {
 			result = append(result, events.Items[i])
 		}
-	}
-	if k8s.describeHook != nil {
-		return k8s.describeHook(pod, result)
 	}
 	return result
 }
@@ -1489,11 +1484,6 @@ func (k8s *K8s) DeleteNetworkServices(names ...string) error {
 	return nil
 }
 
-//SetDescribeHook - set hook to update events, require to test logic.
-func (k8s *K8s) SetDescribeHook(hook func(*v1.Pod, []v1.Event) []v1.Event) {
-	k8s.describeHook = hook
-}
-
 //IsNetworkProblem - return error if pod has deploy network problems detected in events.
 func (k8s *K8s) IsNetworkProblem(pod *v1.Pod) error {
 	// Check if we have CNI issue and try to re-create pod.
@@ -1501,7 +1491,7 @@ func (k8s *K8s) IsNetworkProblem(pod *v1.Pod) error {
 	for index := range events {
 		msg := &events[index]
 		if k8s.isNetworkProblemEvent(msg) {
-			return errors.Errorf("pod %s deploy error: %v.", pod.Name, msg)
+			return errors.Errorf("pod %s deploy error: %v.", pod.Name, msg.Message)
 		}
 	}
 	return nil

--- a/test/kubetest/utils.go
+++ b/test/kubetest/utils.go
@@ -704,7 +704,7 @@ func waitWebhookPod(k8s *K8s, name string, timeout time.Duration) *v1.Pod {
 			for i := 0; i < len(list); i++ {
 				p := &list[i]
 				if strings.Contains(p.Name, name) {
-					result, err := blockUntilPodReady(k8s.clientset, timeout, p)
+					result, err := k8s.blockUntilPodReady(k8s.clientset, timeout, p)
 					k8s.g.Expect(err).Should(BeNil())
 					return result
 				}


### PR DESCRIPTION
Signed-off-by: Andrey Sobolev <haiodo@xored.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description

Our test framework should detect a CNI network plugin problems during deploy of pods and try to re-deploy if this situation is detected.

## Motivation and Context

Tests could fail because of CNI plugin failed to assign IP address, we need to retry pod deploy in such situations.

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [x] Covered by existing integration testing
- [x] Added integration testing to cover
- [ ] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
