### PR TITLE
Fix broken make scripts

### DIFF
--- a/.mk/integration.mk
+++ b/.mk/integration.mk
@@ -21,12 +21,19 @@ k8s-integration-config:
 
 .PHONY: k8s-integration-tests
 k8s-integration-tests: k8s-integration-config
-	@GO111MODULE=on NSM_NAMESPACE=${NSM_NAMESPACE_INTEGRATION} go test -v ./test/integration/... -failfast -timeout 60m -tags="basic recover usecase"
+	@pushd test && \
+	GO111MODULE=on NSM_NAMESPACE=${NSM_NAMESPACE_INTEGRATION} go test -v ./integration/... -failfast -timeout 60m -tags="basic recover usecase interdomain" && \
+    popd
+
 
 .PHONY: k8s-integration-tests-%
 k8s-integration-tests-%: k8s-integration-config
-	@GO111MODULE=on NSM_NAMESPACE=${NSM_NAMESPACE_INTEGRATION} go test -v ./test/integration/... -failfast -timeout 60m -tags="$*"
+	@pushd test && \
+    GO111MODULE=on NSM_NAMESPACE=${NSM_NAMESPACE_INTEGRATION} go test -v ./integration/... -failfast -timeout 60m -tags="$*" && \
+    popd
 
 .PHONY: k8s-integration-%-test
 k8s-integration-%-test: k8s-integration-config
-	@GO111MODULE=on BROKEN_TESTS_ENABLED=on NSM_NAMESPACE=${NSM_NAMESPACE_INTEGRATION} go test -v ./test/integration/... -failfast -timeout 60m -tags="basic recover usecase" -run $*
+	@pushd test && \
+    GO111MODULE=on BROKEN_TESTS_ENABLED=on NSM_NAMESPACE=${NSM_NAMESPACE_INTEGRATION} go test -v ./integration/... -failfast -timeout 60m -tags="basic recover usecase interdomain" -run $* && \
+    popd

--- a/.mk/k8s.mk
+++ b/.mk/k8s.mk
@@ -19,8 +19,9 @@ CLUSTER_CONFIG_CRD = crd-networkservices crd-networkserviceendpoints crd-network
 CLUSTER_CONFIG_NAMESPACE = namespace-nsm
 CLUSTER_CONFIGS = $(CLUSTER_CONFIG_ROLE) $(CLUSTER_CONFIG_CRD) $(CLUSTER_CONFIG_NAMESPACE)
 
+ifeq ($(NSM_NAMESPACE),)
 NSM_NAMESPACE = `cat "${K8S_CONF_DIR}/${CLUSTER_CONFIG_NAMESPACE}.yaml" | awk '/name:/ {print $$2}'`
-
+endif
 # All of the rules that use vagrant are intentionally written in such a way
 # That you could set the CLUSTER_RULES_PREFIX different and introduce
 # a new platform to run on with k8s by adding a new include ${method}.mk


### PR DESCRIPTION
Signed-off-by: Artem Belov <artem.belov@xored.com>

## Description
- Use system value of NSM_NAMESPACE environment if exists
- Run integration tests from test module directory

## Motivation and Context
- NSM_NAMESPACE is taken from yaml config file even if environment variable exists in system. NSM namespace could not been cleaned up after failed tests
- Integration tests cannot be runnable by make scripts

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [ ] Covered by existing integration testing
- [ ] Added integration testing to cover
- [x] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
