### PR TITLE
Optimize cloudtest output

### DIFF
--- a/test/cloudtest/pkg/commands/main.go
+++ b/test/cloudtest/pkg/commands/main.go
@@ -288,7 +288,7 @@ func (ctx *executionContext) performExecution() error {
 			}
 		case <-timectx.Done():
 			ctx.printStatistics()
-			timectx, cancelfunc = context.WithTimeout(context.Background(), 30*time.Second)
+			timectx, cancelfunc = context.WithTimeout(context.Background(), 1*time.Minute)
 			defer cancelfunc()
 		case <-termChannel:
 			return errors.New("termination request is received")
@@ -375,9 +375,9 @@ func (ctx *executionContext) processTaskUpdate(event operationEvent) {
 		logrus.Infof("Complete task: %s Status: %v on cluster: %s, Elapsed: %v (%d) Remaining: %v (%d)",
 			event.task.test.Name,
 			statusName(event.task.test.Status),
-			event.task.clusterTaskID, elapsed,
+			event.task.clusterTaskID, elapsed.Round(time.Second),
 			len(ctx.completed),
-			time.Duration(len(ctx.tasks)+len(ctx.running))*oneTask,
+			(time.Duration(len(ctx.tasks)+len(ctx.running)) * oneTask).Round(time.Second),
 			len(ctx.running)+len(ctx.tasks))
 
 		for ind, cl := range event.task.clusters {
@@ -455,7 +455,7 @@ func (ctx *executionContext) printStatistics() {
 	elapsedRunning = time.Since(ctx.clusterReadyTime)
 	running := ""
 	for _, r := range ctx.running {
-		running += fmt.Sprintf("\t\t%s on cluster %v elapsed: %v\n", r.test.Name, r.clusterTaskID, time.Since(r.test.Started))
+		running += fmt.Sprintf("\t\t%s on cluster %v elapsed: %v\n", r.test.Name, r.clusterTaskID, time.Since(r.test.Started).Round(time.Second))
 	}
 	ctx.RUnlock()
 
@@ -471,7 +471,7 @@ func (ctx *executionContext) printStatistics() {
 		ctx.RLock()
 		for _, inst := range cl.instances {
 			_, _ = clustersMsg.WriteString(fmt.Sprintf("\t\t\t%s %v uptime: %v\n", inst.id, fromClusterState(inst.state),
-				time.Since(inst.startTime)))
+				time.Since(inst.startTime).Round(time.Second)))
 		}
 		ctx.RUnlock()
 	}
@@ -479,7 +479,7 @@ func (ctx *executionContext) printStatistics() {
 	remaining := ""
 	if len(ctx.completed) > 0 {
 		oneTask := elapsed / time.Duration(len(ctx.completed))
-		remaining = fmt.Sprintf("%v", time.Duration(len(ctx.tasks)+len(ctx.running))*oneTask)
+		remaining = fmt.Sprintf("%v", (time.Duration(len(ctx.tasks)+len(ctx.running)) * oneTask).Round(time.Second))
 	}
 
 	successTests := 0
@@ -506,8 +506,8 @@ func (ctx *executionContext) printStatistics() {
 	}
 
 	logrus.Infof("Statistics:" +
-		fmt.Sprintf("\n\tElapsed total: %v", elapsed) +
-		fmt.Sprintf("\n\tTests time: %v", elapsedRunning) +
+		fmt.Sprintf("\n\tElapsed total: %v", elapsed.Round(time.Second)) +
+		fmt.Sprintf("\n\tTests time: %v", elapsedRunning.Round(time.Second)) +
 		fmt.Sprintf("\n\tTasks  Completed: %d", len(ctx.completed)) +
 		fmt.Sprintf("\n\t		Remaining: %v (%d).\n", remaining, len(ctx.running)+len(ctx.tasks)) +
 		fmt.Sprintf("%s%s", running, clustersMsg.String()) +

--- a/test/cloudtest/pkg/providers/packet/packet_provider.go
+++ b/test/cloudtest/pkg/providers/packet/packet_provider.go
@@ -257,7 +257,7 @@ func (pi *packetInstance) waitDevicesStartup(context context.Context) error {
 			msg := fmt.Sprintf("Checking status %v %v %v", key, d.ID, updatedDevice.State)
 			_, _ = writer.WriteString(msg)
 			_ = writer.Flush()
-			logrus.Infof("%v-%v", pi.id, msg)
+			logrus.Infof("%v-Checking status %v", pi.id, updatedDevice.State)
 		}
 		if len(alive) == len(pi.devices) {
 			pi.devices = alive
@@ -306,7 +306,7 @@ func (pi *packetInstance) createDevice(devCfg *config.DeviceConfig) (*packngo.De
 	var response *packngo.Response
 	device, response, err = pi.client.Devices.Create(devReq)
 	msg := fmt.Sprintf("HostName=%v\n%v - %v", hostName, response, err)
-	logrus.Infof(fmt.Sprintf("%s-%v", pi.id, msg))
+	logrus.Infof(fmt.Sprintf("%s-%v (err: %v)", pi.id, hostName, err))
 	pi.manager.AddLog(pi.id, fmt.Sprintf("create-device-%s", devCfg.Name), msg)
 	return device, err
 }
@@ -341,7 +341,7 @@ func (pi *packetInstance) findFacilities() ([]string, error) {
 		}
 	}
 	msg := fmt.Sprintf("List of facilities: %v %v", facilities, response)
-	logrus.Infof(msg)
+	//logrus.Infof(msg)
 	_, _ = out.WriteString(msg)
 	pi.manager.AddLog(pi.id, "list-facilities", out.String())
 
@@ -431,7 +431,7 @@ func (pi *packetInstance) Destroy(timeout time.Duration) error {
 		}
 		msg := fmt.Sprintf("Devices destroy complete %v", pi.devices)
 		_, _ = logFile.WriteString(msg)
-		logrus.Infof("Destroy Complete: %v", msg)
+		logrus.Infof("Destroy Complete: %v", pi.id)
 	}
 	return nil
 }
@@ -518,7 +518,7 @@ func (pi *packetInstance) createKey(keyFile string) ([]string, error) {
 	}
 	createMsg := fmt.Sprintf("Create key %v %v %v", sshKey, responseMsg, err)
 	_, _ = out.WriteString(createMsg)
-	logrus.Infof("%s-%v", pi.id, createMsg)
+	logrus.Infof("%s-Create key $v (%v)", pi.id, sshKey.ID, sshKey.Key)
 
 	keyIds := []string{}
 	if sshKey == nil {

--- a/test/cloudtest/pkg/providers/packet/packet_provider.go
+++ b/test/cloudtest/pkg/providers/packet/packet_provider.go
@@ -518,7 +518,7 @@ func (pi *packetInstance) createKey(keyFile string) ([]string, error) {
 	}
 	createMsg := fmt.Sprintf("Create key %v %v %v", sshKey, responseMsg, err)
 	_, _ = out.WriteString(createMsg)
-	logrus.Infof("%s-Create key $v (%v)", pi.id, sshKey.ID, sshKey.Key)
+	logrus.Infof("%s-Create key %v (%v)", pi.id, sshKey.ID, sshKey.Key)
 
 	keyIds := []string{}
 	if sshKey == nil {

--- a/test/cloudtest/pkg/shell/shell_manager.go
+++ b/test/cloudtest/pkg/shell/shell_manager.go
@@ -86,7 +86,7 @@ func (si *shellInterface) runCmd(context context.Context, operation string, scri
 		logrus.Infof("%s: %s => %s", operation, si.id, cmd)
 
 		logger := func(s string) {
-			logrus.Infof("%s: %s -> %v", si.id, operation, s)
+			// logrus.Infof("%s: %s -> %v", si.id, operation, s)
 		}
 		stdOut, err := utils.RunCommand(context, cmd, "", logger, writer, cmdEnv, si.finalArgs, returnResult)
 		if err != nil {


### PR DESCRIPTION
Signed-off-by: Artem Belov <artem.belov@xored.com>

## Description
Remove some output info which has duplications in log files
Optimize Duration print format
Print less statistics info

## Motivation and Context
 Only the last 400000 characters are displayed in circleci log. Optimizing cloudtest output help to get more information while testing is in progress

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [ ] Covered by existing integration testing
- [ ] Added integration testing to cover
- [ ] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
