### PR TITLE
Add wait for default service account on creating nsm service accounts

### DIFF
--- a/test/kubetest/k8s.go
+++ b/test/kubetest/k8s.go
@@ -42,11 +42,11 @@ import (
 
 const (
 	// PodStartTimeout - Default pod startup time
-	PodStartTimeout  = 3 * time.Minute
-	podDeleteTimeout = 15 * time.Second
-	podExecTimeout   = 1 * time.Minute
-	podGetLogTimeout = 1 * time.Minute
-	roleWaitTimeout  = 1 * time.Minute
+	PodStartTimeout    = 3 * time.Minute
+	podDeleteTimeout   = 15 * time.Second
+	podExecTimeout     = 1 * time.Minute
+	podGetLogTimeout   = 1 * time.Minute
+	accountWaitTimeout = 1 * time.Minute
 )
 
 const (
@@ -441,8 +441,8 @@ func NewK8sWithoutRolesForConfig(g *WithT, prepare bool, kubeconfigPath string) 
 		logrus.Printf("Cleanup done: %v", time.Since(start))
 	}
 
-	_, err = client.CreateServiceAccounts()
-	g.Expect(err).To(BeNil())
+	client.CreateServiceAccounts()
+
 	return &client, nil
 }
 
@@ -1230,31 +1230,73 @@ func (k8s *K8s) CreateTestNamespace(namespace string) (string, error) {
 }
 
 // CreateServiceAccounts create service accounts with passed names
-func (k8s *K8s) CreateServiceAccounts() ([]*v1.ServiceAccount, error) {
-	rv := make([]*v1.ServiceAccount, 0, len(k8s.sa))
-	for _, n := range k8s.sa {
-		sa, err := k8s.clientset.CoreV1().ServiceAccounts(k8s.namespace).Create(&v1.ServiceAccount{
-			ObjectMeta: metaV1.ObjectMeta{
-				Name: n,
-			},
-		})
-		if err != nil {
-			return nil, err
-		}
-
-		for len(sa.Secrets) == 0 {
-			sa, err = k8s.clientset.CoreV1().ServiceAccounts(k8s.namespace).Get(n, metaV1.GetOptions{})
+func (k8s *K8s) CreateServiceAccounts() {
+	accountsCount := len(k8s.sa) + 1 //1 means default acc
+	errs := make(chan error, accountsCount)
+	for i := range k8s.sa {
+		index := i
+		go func() {
+			n := k8s.sa[index]
+			sa, err := k8s.clientset.CoreV1().ServiceAccounts(k8s.namespace).Create(&v1.ServiceAccount{
+				ObjectMeta: metaV1.ObjectMeta{
+					Name: n,
+				},
+			})
 			if err != nil {
-				return nil, err
+				errs <- err
+				return
 			}
-			logrus.Info(sa)
-			<-time.After(10 * time.Millisecond)
-		}
-
-		rv = append(rv, sa)
+			err = waitFor(accountWaitTimeout, func() bool {
+				sa, getErr := k8s.clientset.CoreV1().ServiceAccounts(k8s.namespace).Get(n, metaV1.GetOptions{})
+				if getErr != nil {
+					logrus.Errorf("An error during get service account: %v, err: %v", sa.Name, getErr.Error())
+					return false
+				}
+				logrus.Info(sa)
+				return len(sa.Secrets) != 0
+			})
+			if err != nil {
+				err = errors.Wrapf(err, "account: %v, secrets == 0", sa.Name)
+			}
+			errs <- err
+		}()
 	}
 
-	return rv, nil
+	go func() {
+		err := waitFor(accountWaitTimeout, func() bool {
+			_, getErr := k8s.clientset.CoreV1().ServiceAccounts(k8s.namespace).Get(pods.DefaultAccount, metaV1.GetOptions{})
+			if getErr != nil {
+				logrus.Errorf("An error during get service account: %v, err: %v", pods.DefaultAccount, getErr.Error())
+			}
+			return getErr == nil
+		})
+		if err != nil {
+			err = errors.Wrapf(err, "account: %v, can not create", pods.DefaultAccount)
+		}
+		errs <- err
+	}()
+	for i := 0; i < accountsCount; i++ {
+		err := <-errs
+		if err != nil {
+			logrus.Error(err)
+			k8s.g.Expect(true).Should(BeFalse())
+		}
+	}
+}
+
+func waitFor(timeout time.Duration, condition func() bool) error {
+	timeoutCh := time.After(timeout)
+	for {
+		select {
+		case <-timeoutCh:
+			return errors.New("time out for wait condition true")
+		default:
+			if condition() {
+				return nil
+			}
+			<-time.After(100 * time.Millisecond)
+		}
+	}
 }
 
 // DeleteServiceAccounts deletes passed service accounts from cluster
@@ -1302,9 +1344,6 @@ func (k8s *K8s) GetK8sNamespace() string {
 
 // CreateRoles create roles
 func (k8s *K8s) CreateRoles(rolesList ...string) ([]nsmrbac.Role, error) {
-	timeout := time.Duration(len(rolesList)) * roleWaitTimeout
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
-	defer cancel()
 	createdRoles := []nsmrbac.Role{}
 	for _, kind := range rolesList {
 		role := nsmrbac.Roles[kind](nsmrbac.RoleNames[kind], k8s.GetK8sNamespace())
@@ -1319,11 +1358,6 @@ func (k8s *K8s) CreateRoles(rolesList ...string) ([]nsmrbac.Role, error) {
 			defer wg.Done()
 			if err := role.Create(k8s.clientset); err != nil {
 				logrus.Errorf("failed creating role: %v %v", role, err)
-				roleError = err
-				return
-			}
-			if err := role.Wait(ctx, k8s.clientset); err != nil {
-				logrus.Errorf("failed waiting role: %v %v", role, err)
 				roleError = err
 				return
 			}

--- a/test/kubetest/k8s.go
+++ b/test/kubetest/k8s.go
@@ -1231,8 +1231,8 @@ func (k8s *K8s) CreateTestNamespace(namespace string) (string, error) {
 
 // CreateServiceAccounts create service accounts with passed names
 func (k8s *K8s) CreateServiceAccounts() {
-	accountsCount := len(k8s.sa) + 1 //1 means default acc
-	errs := make(chan error, accountsCount)
+	accountCount := len(k8s.sa) + 1 //1 means default acc
+	errs := make(chan error, accountCount)
 	for i := range k8s.sa {
 		index := i
 		go func() {
@@ -1275,7 +1275,7 @@ func (k8s *K8s) CreateServiceAccounts() {
 		}
 		errs <- err
 	}()
-	for i := 0; i < accountsCount; i++ {
+	for i := 0; i < accountCount; i++ {
 		err := <-errs
 		if err != nil {
 			logrus.Error(err)

--- a/test/kubetest/pods/common.go
+++ b/test/kubetest/pods/common.go
@@ -6,6 +6,8 @@ import (
 )
 
 const (
+	//DefaultAccount creates on namespace creating
+	DefaultAccount = "default"
 	// EnvForwardingPlane is the environment variable for configuring the forwarding plane
 	EnvForwardingPlane = "FORWARDING_PLANE"
 	// EnvForwardingPlaneVPP is the VPP forwarding plane


### PR DESCRIPTION
Signed-off-by: Denis Tingajkin <denis.tingajkin@xored.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
The previous fix(https://github.com/networkservicemesh/networkservicemesh/pull/1655) was broken after landing https://github.com/networkservicemesh/networkservicemesh/pull/1380, [line](https://github.com/networkservicemesh/networkservicemesh/blob/master/test/kubetest/rbac/cluster_roles.go#L217). 
Root cause: not good fixing, do not wait for service accounts on creating role bindings.

## Motivation and Context
https://114224-127937836-gh.circle-artifacts.com/0/home/circleci/project/.tests/cloud_test/aws-3_azure-5/001-TestInterdomainNSEHealRemote-run.log

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [ ] Covered by existing integration testing
- [ ] Added integration testing to cover
- [X] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
