### PR TITLE
fix cloudtest crash caused by ignoring test's Skipped state

### DIFF
--- a/test/cloudtest/pkg/commands/main.go
+++ b/test/cloudtest/pkg/commands/main.go
@@ -307,6 +307,10 @@ func (ctx *executionContext) assignTasks() {
 		// Check if we have cluster we could assign.
 		newTasks := []*testTask{}
 		for _, task := range ctx.tasks {
+			if task.test.Status == model.StatusSkipped {
+				logrus.Infof("Ignoring skipped task:  %s", task.test.Name)
+				continue
+			}
 			clustersAvailable, clustersToUse, assigned := ctx.selectClusterForTask(task)
 			if assigned {
 				// Start task execution.
@@ -569,8 +573,10 @@ func (ctx *executionContext) createTasks() {
 			}
 		}
 
-		if task != nil && len(task.clusters) < test.ExecutionConfig.ClusterCount {
-			logrus.Errorf("not all clusters are defined for test %v %v", test.Name, task)
+		if task == nil {
+			logrus.Errorf("%s: no clusters defined of required %v", test.Name, selector)
+		} else if len(task.clusters) < test.ExecutionConfig.ClusterCount {
+			logrus.Errorf("%s: not all clusters defined of required %v", test.Name, selector)
 			task.test.Status = model.StatusSkipped
 		}
 	}


### PR DESCRIPTION
it happens when one of the required by a test clusters is disabled, test gets 'Skipped' state in createTasks(), but the state is then ignored by assignTasks(), then a crash happens in executeTask():

`panic: runtime error: index out of range [1] with length 1

goroutine 3833 [running]:
github.com/networkservicemesh/networkservicemesh/test/cloudtest/pkg/commands.(*executionContext).executeTask.func1(0xc0002a0fc0, 0xc0003ee1e0, 0xc00093f260, 0x1, 0x1, 0x163dde0, 0xc000bd8d08, 0xc0002bd328, 0x5, 0x1644ce0, ...)
	/home/circleci/project/test/cloudtest/pkg/commands/main.go:693 +0x166b
created by github.com/networkservicemesh/networkservicemesh/test/cloudtest/pkg/commands.(*executionContext).executeTask
	/home/circleci/project/test/cloudtest/pkg/commands/main.go:660 +0x16e
`

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [ ] Covered by existing integration testing
- [ ] Added integration testing to cover
- [ ] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
