### PR TITLE
Improve DNS documentation

### DIFF
--- a/docs/spec/dns-integration.md
+++ b/docs/spec/dns-integration.md
@@ -11,9 +11,7 @@ Overview
 
 The DNS integration capability is performed by running a DNS server co-resident with the application pod that can direct requests to multiple DNS servers. The DNS servers that should be sent requests is controlled by the NSEs that create connections into that application pod.  If the NSEs populate the DNSContext with a DNS server appropriate for this connection then additional containers in the application pod will ensure those DNS servers are consulted. The additional containers are nsm-coredns and nsm-dns-monitor.  They can be inserted directly or via the admission webhook.  The nsm-coredns container is responsible for handling the DNS resolution mechanics. The nsm-dns-monitor container is responsible for updating the configuration that the nsm-coredns container acts on based on DNS information in the connection contexts provided by the NSEs.
 
-The NSM provided SDK provides a capability to read environmental varibles to determine additional DNS servers and domains that should be added to the DNScontext.  These variables are: DNS_SEARCH_DOMAINS and DNS_SERVER_IPS.
-
-Note:  Some of the additional DNS configuration capabilites K8s offers are overridden adn not availabel when these additional containers are inserted.
+The NSM endpoint SDK provides two functions `NewAddDNSConfigs` and  `NewAddDnsConfigDstIp` to update the connection context so the nsm-dns-monitor can update the coredns configuration.
 
 Implementation details (optional)
 ---------------------------------
@@ -97,12 +95,8 @@ See an example of usage `nsm-dns-monitor` in `test/applications/cmd/monitoring-d
 To inject the `nsm-coredns` and `nsm-dns-monitor` containers into a client's pod during deployment, you can simply deploy the [admission webhook](https://github.com/networkservicemesh/networkservicemesh/blob/master/docs/spec/admission.md). `Admission webhook` will automatically append the DNS specific containers to your `Network Service Client`.  When using the admission webhook there is no way to disable the insertion of these additional containers.
 
 ## NSE Requirements
-In order for the application pod to try multiple DNS servers the NSEs must populate the DNScontext.   The SDK provides a means to populate the DNScontext based on environmental variables provided to the NSE container. These variables are: DNS_SEARCH_DOMAINS and DNS_SERVER_IPS.  The [icmp-responer](test/applications/cmd/icmp-responder-nse/main.go) has an example implementation.
-
-
-Disabling NSM DNS resolution
-----------------------------
-TODO
+In order for the application pod to try multiple DNS servers the NSEs must populate the DNScontext.
+The SDK provides functions that the NSE can call to populate the DNScontext.  An example on how this is done using environmental variables is available here: [icmp-responder](test/applications/cmd/icmp-responder-nse/main.go). The environmental variables used are DNS_SEARCH_DOMAINS and DNS_SERVER_IPS.
 
 Example usage (optional)
 ------------------------

--- a/docs/spec/dns-integration.md
+++ b/docs/spec/dns-integration.md
@@ -4,23 +4,32 @@ DNS Integration for NSM
 Specification
 -------------
 
-Network Service Mesh needs to be able to provide a workload with DNS service from Network Services Without breaking K8s DNS
+Network Service Mesh needs to be able to provide a workload with DNS resolution for Network Services without breaking the DNS resolution K8s natively provides.
+
+Overview
+--------
+
+The DNS integration capability is performed by running a DNS server co-resident with the application pod that can direct requests to multiple DNS servers. The DNS servers that should be sent requests is controlled by the NSEs that create connections into that application pod.  If the NSEs populate the DNSContext with a DNS server appropriate for this connection then additional containers in the application pod will ensure those DNS servers are consulted. The additional containers are nsm-coredns and nsm-dns-monitor.  They can be inserted directly or via the admission webhook.  The nsm-coredns container is responsible for handling the DNS resolution mechanics. The nsm-dns-monitor container is responsible for updating the configuration that the nsm-coredns container acts on based on DNS information in the connection contexts provided by the NSEs.
+
+The NSM provided SDK provides a capability to read environmental varibles to determine additional DNS servers and domains that should be added to the DNScontext.  These variables are: DNS_SEARCH_DOMAINS and DNS_SERVER_IPS.
+
+Note:  Some of the additional DNS configuration capabilites K8s offers are overridden adn not availabel when these additional containers are inserted.
 
 Implementation details (optional)
 ---------------------------------
 
 ### nsm-coredns
-`nsm-corends` is a docker image based on [coredns](https://github.com/coredns/coredns.io/blob/master/content/manual/what.md). The difference with the original `coredns` in the set of plug-ins. 
-The image uses only next `coredns` plugins:
+`nsm-corends` is a docker image based on [coredns](https://github.com/coredns/coredns.io/blob/master/content/manual/what.md). The difference with the original `coredns` is the set of plug-ins.
+The image uses only these `coredns` plugins:
 * `bind`
 * `hosts`
 * `log`
 
-Also, it includes special custom plugin `fanout` (see below).	
+Also, it includes a `fanout` plugin defined in the NSM tree (see below).	
 ### Fanout plugin
-`fanout` is custom [plugin for coredns](https://coredns.io/manual/plugins/).
-The fanout plugin re-uses already opened sockets to the upstreams. It supports TCP and DNS-over-TLS and uses in-band health checking. 
-For each incoming DNS query that hits the CoreDNS fanout plugin, it will be replicated in parallel to each listed IP. The first non-negative response from any of the queried DNS Servers will be forwarded as a response to the request.
+`fanout` is a custom [plugin for coredns](https://coredns.io/manual/plugins/).
+The fanout plugin re-uses already opened sockets to the upstreams. It supports TCP and DNS-over-TLS and uses in-band health checking.  The config provided to nsm-coredns may include multiple IPs based on the services a pod attachs to.
+Each incoming DNS query that hits the CoreDNS fanout plugin will be replicated in parallel to each listed IP (i.e. the DNS servers). The first non-negative response from any of the queried DNS Servers will be forwarded as a response to the application's DNS request.
 
 ### Using nsm-coredns as the default name server for the pod
 1) Deploy configmap with corefile content.
@@ -71,7 +80,7 @@ spec:
 ...
 ```
 ### nsm-dns-monitor
-For add to `Network Service Client` possible to dynamically update `DNSConfigs` from connections, you could use nsm-dns-monitor. For example:
+To dynamically update a `Network Service Client's` `DNSConfigs` based on connections, you could use nsm-dns-monitor. For example:
 ```
 func main() {
         ...
@@ -81,11 +90,19 @@ func main() {
         ...
 }
 ``` 
-Make sure that your pod colocated with `nsm-coredns` and `nsm-coredns` has [environment variable](https://github.com/networkservicemesh/networkservicemesh/blob/master/docs/env.md) `USE_UPDATE_API=true`.
-See at example of usage `nsm-dns-monitor` in `test/applications/cmd/monitoring-dns-nsc`
+Make sure that your application pod includes the `nsm-coredns` and `nsm-coredns` containers and has [environment variable](https://github.com/networkservicemesh/networkservicemesh/blob/master/docs/env.md) `USE_UPDATE_API=true`.
+See an example of usage `nsm-dns-monitor` in `test/applications/cmd/monitoring-dns-nsc`
 
-### Using nsm-coredns and nsm-dns-monitor without changes client's deployment configuration
-For injection `nsm-coredns` and `nsm-dns-monitor` containers into client's POD on deploy step, you can simply deploy the [admission webhook](https://github.com/networkservicemesh/networkservicemesh/blob/master/docs/spec/admission.md). In this case, you do not need to make any additional changes to the configuration of your deployments. `Admission webhook` will automatically append DNS specific containers to your `Network Service Client`.
+### Using nsm-coredns and nsm-dns-monitor without changing the client's deployment configuration
+To inject the `nsm-coredns` and `nsm-dns-monitor` containers into a client's pod during deployment, you can simply deploy the [admission webhook](https://github.com/networkservicemesh/networkservicemesh/blob/master/docs/spec/admission.md). `Admission webhook` will automatically append the DNS specific containers to your `Network Service Client`.  When using the admission webhook there is no way to disable the insertion of these additional containers.
+
+## NSE Requirements
+In order for the application pod to try multiple DNS servers the NSEs must populate the DNScontext.   The SDK provides a means to populate the DNScontext based on environmental variables provided to the NSE container. These variables are: DNS_SEARCH_DOMAINS and DNS_SERVER_IPS.  The [icmp-responer](test/applications/cmd/icmp-responder-nse/main.go) has an example implementation.
+
+
+Disabling NSM DNS resolution
+----------------------------
+TODO
 
 Example usage (optional)
 ------------------------

--- a/docs/spec/dns-integration.md
+++ b/docs/spec/dns-integration.md
@@ -1,4 +1,4 @@
-DNS Integration for NSM
+DNS integration for NSM
 ============================
 
 Specification
@@ -9,7 +9,7 @@ Network Service Mesh needs to be able to provide a workload with DNS resolution 
 Overview
 --------
 
-The DNS integration capability is performed by running a DNS server co-resident with the application pod that can direct requests to multiple DNS servers. The DNS servers that should be sent requests is controlled by the NSEs that create connections into that application pod.  If the NSEs populate the DNSContext with a DNS server appropriate for this connection then additional containers in the application pod will ensure those DNS servers are consulted. The additional containers are nsm-coredns and nsm-dns-monitor.  They can be inserted directly or via the admission webhook.  The nsm-coredns container is responsible for handling the DNS resolution mechanics. The nsm-dns-monitor container is responsible for updating the configuration that the nsm-coredns container acts on based on DNS information in the connection contexts provided by the NSEs.
+The DNS integration capability is performed by running a DNS server co-resident with the application pod that can direct requests to multiple DNS servers. The DNS servers that should be sent requests are controlled by the NSEs that create connections into that application pod.  If the NSEs populate the DNSContext with a DNS server appropriate for this connection then additional containers in the application pod will ensure those DNS servers are consulted. The additional containers are nsm-coredns and nsm-dns-monitor.  They can be inserted directly or via the admission webhook.  The nsm-coredns container is responsible for handling the DNS resolution mechanics. The nsm-dns-monitor container is responsible for updating the configuration that the nsm-coredns container acts on based on DNS information in the connection contexts provided by the NSEs.
 
 The NSM endpoint SDK provides two functions `NewAddDNSConfigs` and  `NewAddDnsConfigDstIp` to update the connection context so the nsm-dns-monitor can update the coredns configuration.
 
@@ -96,7 +96,7 @@ To inject the `nsm-coredns` and `nsm-dns-monitor` containers into a client's pod
 
 ## NSE Requirements
 In order for the application pod to try multiple DNS servers the NSEs must populate the DNScontext.
-The SDK provides functions that the NSE can call to populate the DNScontext.  An example on how this is done using environmental variables is available here: [icmp-responder](test/applications/cmd/icmp-responder-nse/main.go). The environmental variables used are DNS_SEARCH_DOMAINS and DNS_SERVER_IPS.
+The SDK provides functions that the NSE can call to populate the DNScontext.  An example of how this is done using environmental variables is available here: [icmp-responder](test/applications/cmd/icmp-responder-nse/main.go). The environmental variables used are DNS_SEARCH_DOMAINS and DNS_SERVER_IPS.
 
 Example usage (optional)
 ------------------------


### PR DESCRIPTION
This commit improves the DNS integration
documentation focusing on how the user can enable
the capability.

Signed-off-by: john-a-joyce <joycej@cisco.com>


## Description
This is a documentation only change.   It provides more detail on all the components in the 
DNS integration path.  It adds more information on the role of the NSE in DNS integration
and includes the key user config options of setting NSE environmental variables to trigger
updates of the DNS configuration in the application pod.  

## Motivation and Context
The key user steps to set environmental variables was missing. 

## How Has This Been Tested?
Documentation only. 
- [ ] Covered by existing integration testing
- [ ] Added integration testing to cover
- [ ] Tested locally
- [x] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
Documentation. 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
