### PR TITLE
cloudtest: set default container tag to 'master'

### DIFF
--- a/test/kubetest/pods/versioning.go
+++ b/test/kubetest/pods/versioning.go
@@ -30,7 +30,7 @@ import (
 const (
 	containerRepoEnv                   = "CONTAINER_REPO"
 	containerTagEnv                    = "CONTAINER_TAG"
-	containerTagDefault                = "latest"
+	containerTagDefault                = "master"
 	containerForcePullEnv              = "CONTAINER_FORCE_PULL"
 	jaegerVersionEnv      utils.EnvVar = "JAEGER_IMAGE_VERSION"
 	containerRepoDefault               = "networkservicemesh"
@@ -38,7 +38,7 @@ const (
 )
 
 var containerRepo = ""
-var containerTag = "latest"
+var containerTag = containerTagDefault
 var containerForcePull = false
 var jaegerVersion = ""
 


### PR DESCRIPTION
To match the default container tag in k8s.mk (CONTAINER_TAG)

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [x] Covered by existing integration testing
- [ ] Added integration testing to cover
- [x] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
