### PR TITLE
Fix typos in spire setup for vagrant and kind

### DIFF
--- a/.cloudtest/kind.yaml
+++ b/.cloudtest/kind.yaml
@@ -19,5 +19,5 @@ providers:
       config: make kind-config-location
       prepare: |
         make k8s-load-images
-        make spire-start
+        make spire-install
         make k8s-config

--- a/.cloudtest/vagrant.yaml
+++ b/.cloudtest/vagrant.yaml
@@ -20,6 +20,6 @@ providers:
       config: make vagrant-config-location
       prepare: |
         make k8s-load-images
-        make spire-start
+        make spire-install
         make k8s-config
       stop: make vagrant-suspend


### PR DESCRIPTION
replace non-existent target 'spire-start' with 'spire-install'

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [ ] Covered by existing integration testing
- [ ] Added integration testing to cover
- [x] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
