### PR TITLE
Fix #1872 Check only for all packets loss

### DIFF
--- a/test/integration/recover_death_handling_test.go
+++ b/test/integration/recover_death_handling_test.go
@@ -77,7 +77,7 @@ func testDie(t *testing.T, killSrc bool, nodesCount int) {
 
 	pingResponse, errOut, err := k8s.Exec(nsc, nsc.Spec.Containers[0].Name, "ping", "172.16.1.2", "-A", "-c", "5")
 	g.Expect(err).To(BeNil())
-	g.Expect(strings.Contains(pingResponse, "5 packets transmitted, 5 packets received, 0% packet loss")).To(Equal(true))
+	g.Expect(strings.Contains(pingResponse, "100% packet loss")).To(Equal(false))
 	logrus.Printf("NSC Ping is success:%s", pingResponse)
 
 	var podToKill *v1.Pod


### PR DESCRIPTION
Signed-off-by: Andrey Sobolev <haiodo@xored.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description

NSE dead handling tests check for 100% packet transmit, but it could not be true, so check for at least one packet send is more stable approach.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [x] Covered by existing integration testing
- [ ] Added integration testing to cover
- [x] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
