### PR TITLE
Change reference to master in examples docs

### DIFF
--- a/docs/examples/icmp-responder.md
+++ b/docs/examples/icmp-responder.md
@@ -41,5 +41,5 @@ kubectl get pods | grep icmp-responder
 To see the icmp-responder example in action, you can run:
 
 ```bash
-curl -s https://raw.githubusercontent.com/networkservicemesh/networkservicemesh/master/scripts/nsc_ping_all.sh | bash
+curl -s https://raw.githubusercontent.com/networkservicemesh/networkservicemesh/release-0.2/scripts/nsc_ping_all.sh | bash
 ```

--- a/docs/examples/vpn.md
+++ b/docs/examples/vpn.md
@@ -147,5 +147,5 @@ kubectl get pods
 To see the vpn example in action, you can run:
 
 ```bash
-curl -s https://raw.githubusercontent.com/networkservicemesh/networkservicemesh/master/scripts/verify_vpn_gateway.sh | bash
+curl -s https://raw.githubusercontent.com/networkservicemesh/networkservicemesh/release-0.2/scripts/verify_vpn_gateway.sh | bash
 ```

--- a/docs/examples/vpp-icmp-example.md
+++ b/docs/examples/vpp-icmp-example.md
@@ -43,5 +43,5 @@ kubectl get pods | grep vpp-icmp-responder
 To see the vpp-icmp-responder example in action, you can run:
 
 ```bash
-curl -s https://raw.githubusercontent.com/networkservicemesh/networkservicemesh/master/scripts/nsc_ping_all.sh | bash
+curl -s https://raw.githubusercontent.com/networkservicemesh/networkservicemesh/release-0.2/scripts/nsc_ping_all.sh | bash
 ```


### PR DESCRIPTION
The examples docs refer to `master/scripts/nsc_ping_all.sh`, which
might be changed in `master`. Replace it with
`release-0.2/scripts/nsc_ping_all.sh` instead.

Signed-off-by: Nikolay Nikolaev <nnikolay@nnikolay-a01.vmware.com>