### PR TITLE
Fix golangci linter downloading on CI

### DIFF
--- a/.mk/code_analysis.mk
+++ b/.mk/code_analysis.mk
@@ -1,10 +1,11 @@
 .PHONY: lint-fix
+
 lint-fix:
 	LOG_LEVEL=error GO111MODULE=on ./scripts/for-each-module.sh "golangci-lint run --new-from-rev=origin/master --fix"
 
 .PHONY: lint-install
 lint-install:
-	GO111MODULE=on go get github.com/golangci/golangci-lint/cmd/golangci-lint@v1.21
+	./scripts/lint-download.sh
 
 .PHONY: lint-check-diff
 lint-check-diff:

--- a/scripts/lint-download.sh
+++ b/scripts/lint-download.sh
@@ -1,11 +1,17 @@
 #!/bin/bash
-version=1.20.0
+version=v1.21.0
+
+function get_linter() {
+    echo "Installing golangci-lint: ${1}"
+    wget -O - -q ${1} | sh -s -- ${version}
+    sudo cp ./bin/golangci-lint "$(go env GOPATH)"/bin/
+    sudo rm -rf ./bin/golangci-lint
+}
+
 {
-    wget -O - -q https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- v${version}
-    sudo cp ./bin/golangci-lint "$(go env GOPATH)"/bin/
+  get_linter https://install.goreleaser.com/github.com/golangci/golangci-lint.sh
 } || {
-    wget -O - -q https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- v${version}
-    sudo cp ./bin/golangci-lint "$(go env GOPATH)"/bin/
+  get_linter https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh
 } || {
-    make lint-install 1.21.0
+  GO111MODULE=on go get github.com/golangci/golangci-lint/cmd/golangci-lint@${version}
 }


### PR DESCRIPTION
Signed-off-by: Denis Tingajkin <denis.tingajkin@xored.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description


## Motivation and Context
Sometimes golangci linter can not be installed on CI https://circleci.com/gh/networkservicemesh/networkservicemesh/115503?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-checks-link.
Root cause: typo in the case with install linter via `go get`. (It uses if can't download from other places) 

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [ ] Covered by existing integration testing
- [ ] Added integration testing to cover
- [X] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
