### PR TITLE
Cleanup cloudtest messages

### DIFF
--- a/test/cloudtest/pkg/commands/main.go
+++ b/test/cloudtest/pkg/commands/main.go
@@ -345,7 +345,7 @@ func (ctx *executionContext) assignTasks() {
 func (ctx *executionContext) performClusterUpdate(event operationEvent) {
 	ctx.Lock()
 	defer ctx.Unlock()
-	logrus.Infof("Instance for cluster %s is updated %v", event.clusterInstance.group.config.Name, event.clusterInstance)
+	logrus.Infof("Cluster instance %s is updated: %v", event.clusterInstance.id, event.clusterInstance)
 	if event.clusterInstance.taskCancel != nil && event.clusterInstance.state == clusterCrashed {
 		// We have task running on cluster
 		event.clusterInstance.taskCancel()
@@ -470,7 +470,7 @@ func (ctx *executionContext) printStatistics() {
 		_, _ = clustersMsg.WriteString(fmt.Sprintf("\t\tCluster: %v Tasks left: %v\n", cl.config.Name, len(cl.tasks)))
 		ctx.RLock()
 		for _, inst := range cl.instances {
-			_, _ = clustersMsg.WriteString(fmt.Sprintf("\t\t\t%s %v uptime: %v\n", inst.id, fromClusterState(inst.state),
+			_, _ = clustersMsg.WriteString(fmt.Sprintf("\t\t\t%s: %v, uptime: %v\n", inst.id, fromClusterState(inst.state),
 				time.Since(inst.startTime).Round(time.Second)))
 		}
 		ctx.RUnlock()
@@ -893,7 +893,7 @@ func (ctx *executionContext) monitorCluster(context context.Context, ci *cluster
 	for {
 		err := ci.instance.CheckIsAlive()
 		if err != nil {
-			logrus.Errorf("Failed to interact with cluster %v %v", ci.id, err)
+			logrus.Errorf("Failed to interact with %s: %v", ci.id, err)
 			ctx.destroyCluster(ci, true, false)
 			break
 		}
@@ -908,7 +908,7 @@ func (ctx *executionContext) monitorCluster(context context.Context, ci *cluster
 				kind:            eventClusterUpdate,
 				clusterInstance: ci,
 			}
-			logrus.Infof("cluster started...")
+			logrus.Infof("Cluster instance started: %s", ci.id)
 		}
 		checks++
 		select {

--- a/test/cloudtest/pkg/commands/main.go
+++ b/test/cloudtest/pkg/commands/main.go
@@ -437,7 +437,7 @@ func (ctx *executionContext) selectClusterForTask(task *testTask) (int, []*clust
 				clustersToUse = append(clustersToUse, ci)
 				// We need to remove task from list
 				groupAssigned = true
-			case clusterBusy, clusterStarting:
+			case clusterBusy, clusterStarting, clusterStopping:
 				groupAvailable = true
 			}
 		}

--- a/test/cloudtest/pkg/commands/main.go
+++ b/test/cloudtest/pkg/commands/main.go
@@ -52,6 +52,7 @@ const (
 	clusterReady
 	clusterBusy
 	clusterStarting
+	clusterStopping
 	clusterCrashed
 	clusterNotAvailable
 	clusterShutdown
@@ -530,6 +531,8 @@ func fromClusterState(state clusterState) string {
 		return "not available"
 	case clusterStarting:
 		return "starting"
+	case clusterStopping:
+		return "stopping"
 	case clusterShutdown:
 		return "shutdown"
 	}
@@ -925,7 +928,7 @@ func (ctx *executionContext) destroyCluster(ci *clusterInstance, sendUpdate, for
 		return nil
 	}
 	ctx.Lock()
-	ci.state = clusterBusy
+	ci.state = clusterStopping
 	if ci.cancelMonitor != nil {
 		ci.cancelMonitor()
 	}

--- a/test/cloudtest/pkg/commands/main.go
+++ b/test/cloudtest/pkg/commands/main.go
@@ -268,8 +268,10 @@ func (ctx *executionContext) performExecution() error {
 	defer cancelFunc()
 
 	termChannel := tools.NewOSSignalChannel()
-	timectx, cancelfunc := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancelfunc()
+	defer ctx.printStatistics()
+
+	statTicker := time.NewTicker(60 * time.Second)
+	defer statTicker.Stop()
 
 	for len(ctx.tasks) > 0 || len(ctx.running) > 0 {
 		// WE take 1 test task from list and do execution.
@@ -281,23 +283,20 @@ func (ctx *executionContext) performExecution() error {
 			switch event.kind {
 			case eventClusterUpdate:
 				ctx.performClusterUpdate(event)
-				ctx.printStatistics()
 			case eventTaskUpdate:
 				// Remove from running onces.
 				ctx.processTaskUpdate(event)
 			}
-		case <-timectx.Done():
-			ctx.printStatistics()
-			timectx, cancelfunc = context.WithTimeout(context.Background(), 1*time.Minute)
-			defer cancelfunc()
 		case <-termChannel:
 			return errors.New("termination request is received")
 		case <-timeoutCtx.Done():
-			ctx.printStatistics()
 			return errors.Errorf("global timeout elapsed: %v seconds", ctx.cloudTestConfig.Timeout)
+		case <-statTicker.C:
+			ctx.printStatistics()
 		}
 	}
-	logrus.Infof("Completed tasks %v Tasks left: %v", len(ctx.completed), len(ctx.tasks))
+
+	logrus.Info("Finished test execution")
 	return nil
 }
 
@@ -374,15 +373,11 @@ func (ctx *executionContext) processTaskUpdate(event operationEvent) {
 		ctx.Lock()
 		ctx.completed = append(ctx.completed, event.task)
 		ctx.Unlock()
-		elapsed := time.Since(ctx.startTime)
-		oneTask := elapsed / time.Duration(len(ctx.completed))
-		logrus.Infof("Complete task: %s Status: %v on cluster: %s, Elapsed: %v (%d) Remaining: %v (%d)",
+		logrus.Infof("Completed %s on %s, %s, runtime: %v",
 			event.task.test.Name,
+			event.task.clusterTaskID,
 			statusName(event.task.test.Status),
-			event.task.clusterTaskID, elapsed.Round(time.Second),
-			len(ctx.completed),
-			(time.Duration(len(ctx.tasks)+len(ctx.running)) * oneTask).Round(time.Second),
-			len(ctx.running)+len(ctx.tasks))
+			event.task.test.Duration.Round(time.Second))
 
 		for ind, cl := range event.task.clusters {
 			delete(cl.tasks, event.task.test.Key)
@@ -459,7 +454,7 @@ func (ctx *executionContext) printStatistics() {
 	elapsedRunning = time.Since(ctx.clusterReadyTime)
 	running := ""
 	for _, r := range ctx.running {
-		running += fmt.Sprintf("\t\t%s on cluster %v elapsed: %v\n", r.test.Name, r.clusterTaskID, time.Since(r.test.Started).Round(time.Second))
+		running += fmt.Sprintf("\t\t%s on %v, %v\n", r.test.Name, r.clusterTaskID, time.Since(r.test.Started).Round(time.Second))
 	}
 	ctx.RUnlock()
 
@@ -513,7 +508,7 @@ func (ctx *executionContext) printStatistics() {
 		fmt.Sprintf("\n\tElapsed total: %v", elapsed.Round(time.Second)) +
 		fmt.Sprintf("\n\tTests time: %v", elapsedRunning.Round(time.Second)) +
 		fmt.Sprintf("\n\tTasks  Completed: %d", len(ctx.completed)) +
-		fmt.Sprintf("\n\t		Remaining: %v (%d).\n", remaining, len(ctx.running)+len(ctx.tasks)) +
+		fmt.Sprintf("\n\t       Remaining: %d (~%v)\n", len(ctx.running)+len(ctx.tasks), remaining) +
 		fmt.Sprintf("%s%s", running, clustersMsg.String()) +
 		fmt.Sprintf("\n\tStatus  Passed: %d"+
 			"\n\tStatus  Failed: %d%v"+
@@ -658,11 +653,11 @@ func (ctx *executionContext) startTask(task *testTask, instances []*clusterInsta
 		return errors.New("invalid task runner")
 	}
 
-	ctx.executeTask(task, clusterConfigs, file, ids, runner, timeout, instances, err, fileName)
+	ctx.executeTask(task, clusterConfigs, file, runner, timeout, instances, err, fileName)
 	return nil
 }
 
-func (ctx *executionContext) executeTask(task *testTask, clusterConfigs []string, file io.Writer, ids string, runner runners.TestRunner, timeout time.Duration, instances []*clusterInstance, err error, fileName string) {
+func (ctx *executionContext) executeTask(task *testTask, clusterConfigs []string, file io.Writer, runner runners.TestRunner, timeout time.Duration, instances []*clusterInstance, err error, fileName string) {
 	go func() {
 		testDelay := func() int {
 			first := true
@@ -710,8 +705,9 @@ func (ctx *executionContext) executeTask(task *testTask, clusterConfigs []string
 
 		writer := bufio.NewWriter(file)
 
-		logrus.Infof(fmt.Sprintf("Running test %s on cluster's %v \n", task.test.Name, ids))
-		_, _ = writer.WriteString(fmt.Sprintf("Running test %s on cluster's %v \n", task.test.Name, ids))
+		msg := fmt.Sprintf("Starting %s on %v\n", task.test.Name, task.clusterTaskID)
+		logrus.Info(msg)
+		_, _ = writer.WriteString(msg)
 		_, _ = writer.WriteString(fmt.Sprintf("Command line %v\nenv==%v \n\n", runner.GetCmdLine(), env))
 		_ = writer.Flush()
 		timeoutCtx, cancel := context.WithTimeout(context.Background(), timeout)

--- a/test/cloudtest/pkg/tests/shell_provider_test.go
+++ b/test/cloudtest/pkg/tests/shell_provider_test.go
@@ -324,7 +324,7 @@ func TestUnusedClusterShutdownByMonitor(t *testing.T) {
 	g.Expect(logKeeper.CheckMessagesOrder([]string{
 		"All tasks for cluster group a_provider are complete. Starting cluster shutdown",
 		"Destroying cluster  a_provider-",
-		"Completed tasks 6 Tasks left: 0",
+		"Finished test execution",
 	})).To(BeTrue())
 }
 


### PR DESCRIPTION
* Remove multiple chaotic calls to printStistics() during clusters startup
* Remove statistics from 'test complete' message

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [x] Covered by existing integration testing
- [ ] Added integration testing to cover
- [ ] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
