### PR TITLE
Fix: Invalid memory address or nil pointer dereference on networkServiceManager.getEndpoint

### DIFF
--- a/controlplane/pkg/nsm/nsm.go
+++ b/controlplane/pkg/nsm/nsm.go
@@ -324,7 +324,10 @@ func (srv *networkServiceManager) getEndpoint(ctx context.Context, networkServic
 		endpoints, err := discovery.FindNetworkService(span.Context(), &registry.FindNetworkServiceRequest{
 			NetworkServiceName: networkServiceName,
 		})
-		span.LogError(err)
+		if err != nil {
+			span.LogError(err)
+			return endpoint
+		}
 		for _, ep := range endpoints.NetworkServiceEndpoints {
 			if xcon.GetRemoteDestination() != nil && ep.GetName() == xcon.GetRemoteDestination().GetNetworkServiceEndpointName() {
 				endpoint = &registry.NSERegistration{


### PR DESCRIPTION
Signed-off-by: Denis Tingajkin <denis.tingajkin@xored.com>


## Description
<!--- Describe your changes in detail -->

## Motivation and Context
https://github.com/networkservicemesh/networkservicemesh/issues/1914

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [ ] Covered by existing integration testing
- [ ] Added integration testing to cover
- [X] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
