### PR TITLE
Broken connections handling fix

### DIFF
--- a/controlplane/pkg/nsm/nsm_heal_processor.go
+++ b/controlplane/pkg/nsm/nsm_heal_processor.go
@@ -356,12 +356,6 @@ func (p *healProcessor) nseIsNewAndAvailable(ctx context.Context, endpointName s
 		return false
 	}
 
-	// Check local only if not waiting for specific NSE.
-	if p.model.GetNsm().GetName() == reg.GetNetworkServiceManager().GetName() {
-		// Another local endpoint is found, success.
-		return true
-	}
-
 	// Check remote is accessible.
 	if p.nseManager.CheckUpdateNSE(ctx, reg) {
 		logrus.Infof("NSE is available and Remote NSMD is accessible. %s.", reg.NetworkServiceManager.Url)

--- a/controlplane/pkg/nsmd/nsmd.go
+++ b/controlplane/pkg/nsmd/nsmd.go
@@ -410,16 +410,10 @@ func (nsm *nsmServer) deleteEndpointWithClient(ctx context.Context, name string,
 	return nil
 }
 
-// DeleteEndpointWithBrokenConnection deletes endpoint if it has no active connections
+// DeleteEndpointWithBrokenConnection deletes endpoint from the model and k8s-registry
 func (nsm *nsmServer) DeleteEndpointWithBrokenConnection(ctx context.Context, endpoint *model.Endpoint) error {
 	span := spanhelper.FromContext(ctx, "DeleteEndpointWithBrokenConnection")
 	defer span.Finish()
-	// If endpoint has active client connection, it should be handled by MonitorNetNsInodeServer
-	for _, clientConnection := range nsm.model.GetAllClientConnections() {
-		if endpoint.EndpointName() == clientConnection.Endpoint.GetNetworkServiceEndpoint().GetName() {
-			return nil
-		}
-	}
 
 	client, err := nsm.serviceRegistry.NseRegistryClient(span.Context())
 	if err != nil {

--- a/test/integration/basic_delete_dirty_nse_test.go
+++ b/test/integration/basic_delete_dirty_nse_test.go
@@ -64,5 +64,5 @@ func TestDeleteDirtyNSEWithClient(t *testing.T) {
 
 	k8s.DeletePods(nsePod)
 
-	kubetest.ExpectNSEsCountToBe(k8s, 1, 1)
+	kubetest.ExpectNSEsCountToBe(k8s, 1, 0)
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Removed code in method `DeleteEndpointWithBrokenConnection`, which skips deleting endpoint when it has active client connection. 
It was expected that `MonitorNetNsInodeServer` handles that case, but this logic wasn't implemented. 
So when endpoint has no handlers to cleanup itself from the registry once it's killed, it will never be deleted from the registry. 
Also we had  `TestDeleteDirtyNSEWithClient` to test case, but it was invalid, so I fixed it too.  

## Motivation and Context
#1898 

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [ ] Covered by existing integration testing
- [x] Added integration testing to cover
- [x] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
