### PR TITLE
Delete nsm custom resource when pod deleted

### DIFF
--- a/deployments/helm/nsm/templates/nsmgr.tpl
+++ b/deployments/helm/nsm/templates/nsmgr.tpl
@@ -96,6 +96,14 @@ spec:
 {{- else }}
               value: "false"
 {{- end }}
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_UID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.uid
             - name: NODE_NAME
               valueFrom:
                 fieldRef:

--- a/k8s/conf/debug/nsmgr-debug.yaml
+++ b/k8s/conf/debug/nsmgr-debug.yaml
@@ -39,6 +39,14 @@ spec:
             - name: nsm-plugin-socket
               mountPath: /var/lib/networkservicemesh/plugins
           env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_UID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.uid
             - name: NODE_NAME
               valueFrom:
                 fieldRef:

--- a/test/integration/basic_delete_nsm_custom_resource_test.go
+++ b/test/integration/basic_delete_nsm_custom_resource_test.go
@@ -1,0 +1,38 @@
+// +build basic
+
+package nsmd_integration_tests
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/networkservicemesh/networkservicemesh/test/kubetest"
+)
+
+func TestDeleteNSMCr(t *testing.T) {
+	g := NewWithT(t)
+
+	if testing.Short() {
+		t.Skip("Skip, please run without -short")
+		return
+	}
+
+	logrus.Print("Running delete NSM Custom Resource test")
+
+	k8s, err := kubetest.NewK8s(g, true)
+	g.Expect(err).To(BeNil())
+	defer k8s.Cleanup()
+
+	nodes_setup, err := kubetest.SetupNodes(k8s, 1, defaultTimeout)
+	g.Expect(err).To(BeNil())
+
+	kubetest.ExpectNSMsCountToBe(k8s, 0, 1)
+
+	logrus.Infof("Deleting NSMD")
+	k8s.DeletePods(nodes_setup[0].Nsmd)
+
+	kubetest.ExpectNSMsCountToBe(k8s, 1, 0)
+}

--- a/test/integration/basic_delete_nsm_custom_resource_test.go
+++ b/test/integration/basic_delete_nsm_custom_resource_test.go
@@ -1,3 +1,19 @@
+// Copyright (c) 2019 Cisco and/or its affiliates.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // +build basic
 
 package nsmd_integration_tests

--- a/test/kubetest/k8s.go
+++ b/test/kubetest/k8s.go
@@ -1417,6 +1417,15 @@ func (k8s *K8s) GetNSEs() ([]v1alpha1.NetworkServiceEndpoint, error) {
 	return nseList.Items, err
 }
 
+// GetNSMs returns existing 'nse' resources
+func (k8s *K8s) GetNSMList() ([]v1alpha1.NetworkServiceManager, error) {
+	nsmList, err := k8s.versionedClientSet.NetworkservicemeshV1alpha1().NetworkServiceManagers(k8s.namespace).List(metaV1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+	return nsmList.Items, err
+}
+
 // DeleteNSEs deletes 'nse' resources by names
 func (k8s *K8s) DeleteNSEs(names ...string) error {
 	nseClient := k8s.versionedClientSet.NetworkservicemeshV1alpha1().NetworkServiceEndpoints(k8s.namespace)

--- a/test/kubetest/pods/nsmd.go
+++ b/test/kubetest/pods/nsmd.go
@@ -170,6 +170,18 @@ func NSMgrPodWithConfig(name string, node *v1.Node, config *NSMgrPodConfig) *v1.
 					VolumeMounts:    []v1.VolumeMount{spireVolumeMount(), newNSMPluginMount()},
 					Env: []v1.EnvVar{
 						{
+							Name: "POD_UID",
+							ValueFrom: &v1.EnvVarSource{
+								FieldRef: &v1.ObjectFieldSelector{
+									FieldPath: "metadata.uid",
+								},
+							},
+						},
+						{
+							Name:  "POD_NAME",
+							Value: name,
+						},
+						{
 							Name:  "NODE_NAME",
 							Value: nodeName,
 						},

--- a/test/kubetest/utils.go
+++ b/test/kubetest/utils.go
@@ -949,3 +949,22 @@ func ExpectNSEsCountToBe(k8s *K8s, countWas, countExpected int) {
 	k8s.g.Expect(err).To(BeNil())
 	k8s.g.Expect(len(nses)).To(Equal(countExpected), fmt.Sprint(nses))
 }
+
+// ExpectNSMsCountToBe checks if nsms count becomes 'countExpected' after a time
+func ExpectNSMsCountToBe(k8s *K8s, countWas, countExpected int) {
+	if countWas == countExpected {
+		<-time.After(10 * time.Second)
+	} else {
+		for i := 0; i < 10; i++ {
+			if nsmList, err := k8s.GetNSMList(); err == nil && len(nsmList) == countExpected {
+				break
+			}
+			<-time.After(1 * time.Second)
+		}
+	}
+
+	nsmList, err := k8s.GetNSMList()
+
+	k8s.g.Expect(err).To(BeNil())
+	k8s.g.Expect(len(nsmList)).To(Equal(countExpected), fmt.Sprint(nsmList))
+}


### PR DESCRIPTION
Signed-off-by: Artem Belov <artem.belov@xored.com>

Delete nsm custom resource from registry when pod deleted

## Description
OwnerReferences  resource option removes child resource if parent deleted 

## Motivation and Context
#927

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [ ] Covered by existing integration testing
- [x] Added integration testing to cover
- [ ] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
