### PR TITLE
Fix k8s-check due to wrong client/endpoint naming

### DIFF
--- a/scripts/nsc_ping_all.sh
+++ b/scripts/nsc_ping_all.sh
@@ -4,9 +4,9 @@ kubectl="kubectl -n ${NSM_NAMESPACE:-default}"
 
 #  Ping all the things!
 EXIT_VAL=0
-for nsc in $(${kubectl} get pods -o=name | grep -E "alpine-nsc|vppagent-nsc" | sed 's@.*/@@'); do
+for nsc in $(${kubectl} get pods -o=name | grep -E "icmp-responder-nsc|vpp-icmp-responder-nsc" | sed 's@.*/@@'); do
     echo "===== >>>>> PROCESSING ${nsc}  <<<<< ==========="
-    if [[ ${nsc} == vppagent-* ]]; then
+    if [[ ${nsc} == vpp-* ]]; then
         for ip in $(${kubectl} exec "${nsc}" -- vppctl show int addr | grep L3 | awk '{print $2}'); do
             if [[ "${ip}" == 172.16.1.* ]];then
                 lastSegment=$(echo "${ip}" | cut -d . -f 4 | cut -d / -f 1)
@@ -17,7 +17,7 @@ for nsc in $(${kubectl} get pods -o=name | grep -E "alpine-nsc|vppagent-nsc" | s
                 lastSegment=$(echo "${ip}" | cut -d . -f 4 | cut -d / -f 1)
                 nextOp=$((lastSegment + 1))
                 targetIp="10.30.1.${nextOp}"
-                endpointName="vppagent-icmp-responder-nse"
+                endpointName="vpp-icmp-responder-nse"
             fi
 
             if [ -n "${targetIp}" ]; then
@@ -48,7 +48,7 @@ for nsc in $(${kubectl} get pods -o=name | grep -E "alpine-nsc|vppagent-nsc" | s
                 lastSegment=$(echo "${ip}" | cut -d . -f 4 | cut -d / -f 1)
                 nextOp=$((lastSegment + 1))
                 targetIp="10.30.1.${nextOp}"
-                endpointName="vppagent-icmp-responder-nse"
+                endpointName="vpp-icmp-responder-nse"
             fi
 
             if [ -n "${targetIp}" ]; then
@@ -70,7 +70,7 @@ for nsc in $(${kubectl} get pods -o=name | grep -E "alpine-nsc|vppagent-nsc" | s
         echo "NSC ${nsc} failed to connect to an icmp-responder NetworkService"
         ${kubectl} get pod "${nsc}" -o wide
         echo "POD ${nsc} Network dump -------------------------------"
-        if [[ ${nsc} == vppagent-* ]]; then
+        if [[ ${nsc} == vpp-* ]]; then
             ${kubectl} exec "${nsc}" -- vppctl show int
             ${kubectl} exec "${nsc}" -- vppctl show int addr
             ${kubectl} exec "${nsc}" -- vppctl show memif


### PR DESCRIPTION
Client/endpoint namings were not updated in the nsc_ping_all.sh script
causing the k8s-check target to fail/do nothing.

Signed-off-by: Radoslav Dimitrov <dimitrovr@vmware.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [ ] Covered by existing integration testing
- [ ] Added integration testing to cover
- [ ] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
