### PR TITLE
Fix image loading to vagrant via k8s-load-images

### DIFF
--- a/scripts/vagrant/env.sh
+++ b/scripts/vagrant/env.sh
@@ -1,8 +1,13 @@
 #!/bin/bash
-if [ -n "$ZSH_VERSION" ]; then
-RESOLVED_SRC="${(%):-%N}"
-else
-RESOLVED_SRC="${BASH_SOURCE[0]}"
+
+if [ -z "${CLUSTER_RULES_PREFIX}" ]; then
+  export CLUSTER_RULES_PREFIX="vagrant"
 fi
+if [ -n "$ZSH_VERSION" ]; then
+  RESOLVED_SRC="${(%):-%N}"
+else
+  RESOLVED_SRC="${BASH_SOURCE[0]}"
+fi
+
 DIR="$( cd "$( dirname "${RESOLVED_SRC}" )" >/dev/null && pwd )"
 export KUBECONFIG=${DIR}/.kube/config


### PR DESCRIPTION
Signed-off-by: Denis Tingajkin <denis.tingajkin@xored.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context

Steps to reproduce:
1) `make vagnrat-start`
2) `scripts/vagrant/env.sh`
3) `make k8s-load-images`

Actual:
```Loading image admission-webhook.tar to kind
Delegated to kind-admission-webhook-load-images
Loading image crossconnect-monitor.tar to kind
Delegated to kind-crossconnect-monitor-load-images
Loading image kernel-forwarder.tar to kind
...
```
Expected: images loading to vagrant.

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [ ] Covered by existing integration testing
- [ ] Added integration testing to cover
- [X] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
