### PR TITLE
Handle case when client connection is closed while healing

### DIFF
--- a/controlplane/pkg/nsm/nsm_heal_processor.go
+++ b/controlplane/pkg/nsm/nsm_heal_processor.go
@@ -121,11 +121,8 @@ func (p *healProcessor) CloseConnection(ctx context.Context, conn nsm.ClientConn
 
 	// Cancell context after closing.
 	defer func() {
-		var contextCancelFunc func()
-		var isHealing bool
-
 		p.healCancellersMutex.Lock()
-		contextCancelFunc, isHealing = p.healCancellers[conn.GetID()]
+		contextCancelFunc, isHealing := p.healCancellers[conn.GetID()]
 		delete(p.healCancellers, conn.GetID())
 		p.healCancellersMutex.Unlock()
 

--- a/controlplane/pkg/tests/heal_nse_test.go
+++ b/controlplane/pkg/tests/heal_nse_test.go
@@ -1,8 +1,13 @@
 package tests
 
 import (
+	"os"
 	"testing"
 	"time"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/networkservicemesh/networkservicemesh/pkg/tools"
 
 	"github.com/networkservicemesh/networkservicemesh/controlplane/api/connection/mechanisms/common"
 
@@ -109,4 +114,91 @@ func TestHealRemoteNSE(t *testing.T) {
 	clientConnection1_1 := srv.TestModel.GetClientConnection(nsmResponse.GetId())
 	g.Expect(clientConnection1_1.GetID()).To(Equal("1"))
 	g.Expect(clientConnection1_1.Xcon.Destination.GetId()).To(Equal("4"))
+}
+
+func TestDeleteNSCWhileHealLocalNSE(t *testing.T) {
+	g := NewWithT(t)
+	_ = os.Setenv(tools.InsecureEnv, "true")
+
+	storage := NewSharedStorage()
+	signalChannel := make(chan struct{})
+
+	// We need to create server with testModel in order to synchronize with healing processor.
+	srv := NewNSMDFullServerWithModel(Worker, storage, NewTestModel(signalChannel))
+	defer srv.Stop()
+
+	srv.TestModel.AddForwarder(context.Background(), testForwarder1)
+
+	nseReg := srv.registerFakeEndpointWithName("golden_network", "test", Worker, "ep1")
+	nseReg2 := srv.registerFakeEndpointWithName("golden_network", "test", Worker, "ep2")
+
+	srv.TestModel.AddEndpoint(context.Background(), nseReg)
+	srv.TestModel.AddEndpoint(context.Background(), nseReg2)
+
+	l1 := newTestConnectionModelListener()
+	srv.TestModel.AddListener(l1)
+
+	// Now we could try to connect via Client API
+	nsmClient, conn := srv.requestNSMConnection("nsm-1")
+	defer conn.Close()
+
+	request := &networkservice.NetworkServiceRequest{
+		Connection: &connection.Connection{
+			NetworkService: "golden_network",
+			Context: &connectioncontext.ConnectionContext{
+				IpContext: &connectioncontext.IPContext{
+					DstIpRequired: true,
+					SrcIpRequired: true,
+				},
+			},
+			Labels: make(map[string]string),
+		},
+		MechanismPreferences: []*connection.Mechanism{
+			{
+				Type: kernel.MECHANISM,
+				Parameters: map[string]string{
+					common.NetNsInodeKey:    "10",
+					common.InterfaceNameKey: "icmp-responder1",
+				},
+			},
+		},
+	}
+
+	timeout := time.Second * 10
+
+	logrus.Info("Before nsmClient.Request")
+	nsmResponse, err := nsmClient.Request(context.Background(), request)
+	logrus.Infof("After nsmClient.Request err = %v", err)
+	g.Expect(err).To(BeNil())
+	g.Expect(nsmResponse.GetNetworkService()).To(Equal("golden_network"))
+
+	// We need to check for cross connections.
+	clientConnection1 := srv.TestModel.GetClientConnection(nsmResponse.GetId())
+
+	// We need to inform cross connection monitor about this connection, since forwarder is fake one.
+	l1.WaitAdd(1, timeout, t)
+
+	epName := clientConnection1.Endpoint.GetNetworkServiceEndpoint().GetName()
+	_, err = srv.nseRegistry.RemoveNSE(context.Background(), &registry.RemoveNSERequest{
+		NetworkServiceEndpointName: epName,
+	})
+	if err != nil {
+		t.Fatal("Err must be nil")
+	}
+
+	srv.TestModel.DeleteEndpoint(context.Background(), epName)
+
+	clientConnection1.Xcon.Destination.State = connection.State_DOWN
+	srv.manager.GetHealProperties().HealDSTNSEWaitTimeout = time.Second * 1
+	srv.manager.Heal(context.Background(), clientConnection1, nsm.HealStateDstDown)
+
+	// Wait for healing to begin
+	<-signalChannel
+
+	srv.manager.CloseConnection(context.Background(), clientConnection1)
+
+	l1.WaitUpdate(4, timeout, t)
+
+	g.Expect(srv.TestModel.GetClientConnection(clientConnection1.ConnectionID)).To(BeNil())
+	g.Expect(srv.serviceRegistry.localTestNSE.requestHandleCounter).To(Equal(1))
 }

--- a/controlplane/pkg/tests/heal_nse_test.go
+++ b/controlplane/pkg/tests/heal_nse_test.go
@@ -124,9 +124,10 @@ func TestDeleteNSCWhileHealLocalNSE(t *testing.T) {
 
 	storage := NewSharedStorage()
 	healStartedChannel := make(chan struct{})
+	clientConnClosedChannel := make(chan struct{})
 
 	// We need to create server with testModel in order to synchronize with healing processor.
-	srv := NewNSMDFullServerWithModel(Worker, storage, NewTestModel(healStartedChannel))
+	srv := NewNSMDFullServerWithModel(Worker, storage, NewTestModel(healStartedChannel, clientConnClosedChannel))
 	defer srv.Stop()
 
 	prefixPool, err := prefix_pool.NewPrefixPool("10.20.1.0/24")
@@ -206,6 +207,8 @@ func TestDeleteNSCWhileHealLocalNSE(t *testing.T) {
 	<-healStartedChannel
 
 	srv.manager.CloseConnection(context.Background(), clientConnection1)
+
+	close(clientConnClosedChannel)
 
 	l1.WaitUpdate(4, timeout, t)
 

--- a/controlplane/pkg/tests/nsmd_local_test.go
+++ b/controlplane/pkg/tests/nsmd_local_test.go
@@ -106,7 +106,7 @@ func TestNSENoSrc(t *testing.T) {
 	srv := NewNSMDFullServer(Master, storage)
 	defer srv.Stop()
 
-	srv.serviceRegistry.localTestNSE = &nseWithOptions{
+	srv.serviceRegistry.localTestNSE.NetworkServiceClient = &nseWithOptions{
 		netns: "12",
 		//srcIp: "169083138/30",
 		dstIp: "10.20.1.2/30",
@@ -132,7 +132,7 @@ func TestNSEIPNeghtbours(t *testing.T) {
 	storage := NewSharedStorage()
 	srv := NewNSMDFullServer(Master, storage)
 	defer srv.Stop()
-	srv.serviceRegistry.localTestNSE = &nseWithOptions{
+	srv.serviceRegistry.localTestNSE.NetworkServiceClient = &nseWithOptions{
 		netns:             "12",
 		srcIp:             "10.20.1.1/30",
 		dstIp:             "10.20.1.2/30",
@@ -152,7 +152,7 @@ func TestNSEIPNeghtbours(t *testing.T) {
 	g.Expect(nsmResponse.GetNetworkService()).To(Equal("golden_network"))
 	logrus.Print("End of test")
 
-	originl, ok := srv.serviceRegistry.localTestNSE.(*nseWithOptions)
+	originl, ok := srv.serviceRegistry.localTestNSE.NetworkServiceClient.(*nseWithOptions)
 	g.Expect(ok).To(Equal(true))
 
 	g.Expect(len(originl.connection.GetContext().GetIpContext().GetIpNeighbors())).To(Equal(1))
@@ -167,7 +167,7 @@ func TestSlowNSE(t *testing.T) {
 	srv := NewNSMDFullServer(Master, storage)
 	defer srv.Stop()
 
-	srv.serviceRegistry.localTestNSE = &nseWithOptions{
+	srv.serviceRegistry.localTestNSE.NetworkServiceClient = &nseWithOptions{
 		netns: "12",
 		srcIp: "169083138/30",
 		dstIp: "169083137/30",
@@ -199,7 +199,7 @@ func TestSlowDP(t *testing.T) {
 	srv := NewNSMDFullServer(Master, storage)
 	defer srv.Stop()
 
-	srv.serviceRegistry.localTestNSE = &nseWithOptions{
+	srv.serviceRegistry.localTestNSE.NetworkServiceClient = &nseWithOptions{
 		netns: "12",
 		srcIp: "10.20.1.1/30",
 		dstIp: "10.20.1.2/30",

--- a/controlplane/pkg/tests/nsmd_local_test.go
+++ b/controlplane/pkg/tests/nsmd_local_test.go
@@ -106,7 +106,7 @@ func TestNSENoSrc(t *testing.T) {
 	srv := NewNSMDFullServer(Master, storage)
 	defer srv.Stop()
 
-	srv.serviceRegistry.localTestNSE.NetworkServiceClient = &nseWithOptions{
+	srv.serviceRegistry.localTestNSE = &nseWithOptions{
 		netns: "12",
 		//srcIp: "169083138/30",
 		dstIp: "10.20.1.2/30",
@@ -132,7 +132,7 @@ func TestNSEIPNeghtbours(t *testing.T) {
 	storage := NewSharedStorage()
 	srv := NewNSMDFullServer(Master, storage)
 	defer srv.Stop()
-	srv.serviceRegistry.localTestNSE.NetworkServiceClient = &nseWithOptions{
+	srv.serviceRegistry.localTestNSE = &nseWithOptions{
 		netns:             "12",
 		srcIp:             "10.20.1.1/30",
 		dstIp:             "10.20.1.2/30",
@@ -152,7 +152,7 @@ func TestNSEIPNeghtbours(t *testing.T) {
 	g.Expect(nsmResponse.GetNetworkService()).To(Equal("golden_network"))
 	logrus.Print("End of test")
 
-	originl, ok := srv.serviceRegistry.localTestNSE.NetworkServiceClient.(*nseWithOptions)
+	originl, ok := srv.serviceRegistry.localTestNSE.(*nseWithOptions)
 	g.Expect(ok).To(Equal(true))
 
 	g.Expect(len(originl.connection.GetContext().GetIpContext().GetIpNeighbors())).To(Equal(1))
@@ -167,7 +167,7 @@ func TestSlowNSE(t *testing.T) {
 	srv := NewNSMDFullServer(Master, storage)
 	defer srv.Stop()
 
-	srv.serviceRegistry.localTestNSE.NetworkServiceClient = &nseWithOptions{
+	srv.serviceRegistry.localTestNSE = &nseWithOptions{
 		netns: "12",
 		srcIp: "169083138/30",
 		dstIp: "169083137/30",
@@ -199,7 +199,7 @@ func TestSlowDP(t *testing.T) {
 	srv := NewNSMDFullServer(Master, storage)
 	defer srv.Stop()
 
-	srv.serviceRegistry.localTestNSE.NetworkServiceClient = &nseWithOptions{
+	srv.serviceRegistry.localTestNSE = &nseWithOptions{
 		netns: "12",
 		srcIp: "10.20.1.1/30",
 		dstIp: "10.20.1.2/30",

--- a/controlplane/pkg/tests/nsmd_registry_test.go
+++ b/controlplane/pkg/tests/nsmd_registry_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/model"
+
 	. "github.com/onsi/gomega"
 	"github.com/sirupsen/logrus"
 
@@ -54,7 +56,7 @@ func TestNSMDRestart1(t *testing.T) {
 
 	// We need to restart server
 	storage2 := NewSharedStorage()
-	srv = newNSMDFullServerAt(context.Background(), "nsm2", storage2, srv.rootDir)
+	srv = newNSMDFullServerAt(context.Background(), "nsm2", storage2, srv.rootDir, model.NewModel())
 	srv.AddFakeForwarder("test_data_plane", "tcp:some_addr")
 	endpoints2 := srv.TestModel.GetEndpointsByNetworkService("test_nse")
 

--- a/controlplane/pkg/tests/nsmd_test_utils.go
+++ b/controlplane/pkg/tests/nsmd_test_utils.go
@@ -152,7 +152,7 @@ type nsmdTestServiceRegistry struct {
 	nseRegistry             *nsmdTestServiceDiscovery
 	apiRegistry             *testApiRegistry
 	testForwarderConnection *testForwarderConnection
-	localTestNSE            networkservice.NetworkServiceClient
+	localTestNSE            *localTestNSENetworkServiceClient
 	vniAllocator            vni.VniAllocator
 	rootDir                 string
 }
@@ -193,11 +193,14 @@ func (impl *nsmdTestServiceRegistry) RemoteNetworkServiceClient(ctx context.Cont
 }
 
 type localTestNSENetworkServiceClient struct {
-	req        *networkservice.NetworkServiceRequest
-	prefixPool prefix_pool.PrefixPool
+	networkservice.NetworkServiceClient
+	req                  *networkservice.NetworkServiceRequest
+	prefixPool           prefix_pool.PrefixPool
+	requestHandleCounter int
 }
 
 func (impl *localTestNSENetworkServiceClient) Request(ctx context.Context, in *networkservice.NetworkServiceRequest, opts ...grpc.CallOption) (*connection.Connection, error) {
+	impl.requestHandleCounter++
 	impl.req = in
 	netns, _ := tools.GetCurrentNS()
 	if netns == "" {
@@ -485,10 +488,19 @@ func NewNSMDFullServer(nsmgrName string, storage *sharedStorage) *nsmdFullServer
 		panic(err)
 	}
 
-	return newNSMDFullServerAt(context.Background(), nsmgrName, storage, rootDir)
+	return newNSMDFullServerAt(context.Background(), nsmgrName, storage, rootDir, model.NewModel())
 }
 
-func newNSMDFullServerAt(ctx context.Context, nsmgrName string, storage *sharedStorage, rootDir string) *nsmdFullServerImpl {
+func NewNSMDFullServerWithModel(nsmgrName string, storage *sharedStorage, testModel model.Model) *nsmdFullServerImpl {
+	rootDir, err := ioutil.TempDir("", "nsmd_test")
+	if err != nil {
+		panic(err)
+	}
+
+	return newNSMDFullServerAt(context.Background(), nsmgrName, storage, rootDir, testModel)
+}
+
+func newNSMDFullServerAt(ctx context.Context, nsmgrName string, storage *sharedStorage, rootDir string, testModel model.Model) *nsmdFullServerImpl {
 	srv := &nsmdFullServerImpl{}
 	srv.apiRegistry = newTestApiRegistry()
 	srv.nseRegistry = newNSMDTestServiceDiscovery(srv.apiRegistry, nsmgrName, storage)
@@ -503,13 +515,14 @@ func newNSMDFullServerAt(ctx context.Context, nsmgrName string, storage *sharedS
 		apiRegistry:             srv.apiRegistry,
 		testForwarderConnection: &testForwarderConnection{},
 		localTestNSE: &localTestNSENetworkServiceClient{
-			prefixPool: prefixPool,
+			prefixPool:           prefixPool,
+			requestHandleCounter: 0,
 		},
 		vniAllocator: vni.NewVniAllocator(),
 		rootDir:      rootDir,
 	}
 
-	srv.TestModel = model.NewModel()
+	srv.TestModel = testModel
 	srv.manager = nsm.NewNetworkServiceManager(ctx, srv.TestModel, srv.serviceRegistry)
 
 	// Choose a public API listener

--- a/controlplane/pkg/tests/test_model.go
+++ b/controlplane/pkg/tests/test_model.go
@@ -1,5 +1,7 @@
 // Copyright (c) 2019 Cisco and/or its affiliates.
 //
+// SPDX-License-Identifier: Apache-2.0
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at:

--- a/controlplane/pkg/tests/test_model.go
+++ b/controlplane/pkg/tests/test_model.go
@@ -1,0 +1,50 @@
+// Copyright (c) 2019 Cisco and/or its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tests
+
+import (
+	"context"
+
+	"github.com/networkservicemesh/networkservicemesh/controlplane/pkg/model"
+)
+
+type testModel struct {
+	model.Model
+	signalCh chan struct{}
+}
+
+func NewTestModel(signalChannel chan struct{}) *testModel {
+	return &testModel{
+		Model:    model.NewModel(),
+		signalCh: signalChannel,
+	}
+}
+
+func (m *testModel) ApplyClientConnectionChanges(ctx context.Context, connectionID string, changeFunc func(*model.ClientConnection)) *model.ClientConnection {
+	rv := m.Model.ApplyClientConnectionChanges(ctx, connectionID, changeFunc)
+
+	// Check whether changeFunc changes connection state to ClientConnectionHealing. If so, signal to the channel.
+	dummyConnection := &model.ClientConnection{
+		ConnectionState: model.ClientConnectionReady,
+	}
+
+	changeFunc(dummyConnection)
+
+	if dummyConnection.ConnectionState == model.ClientConnectionHealing {
+		close(m.signalCh)
+	}
+
+	return rv
+}

--- a/controlplane/pkg/tests/test_model.go
+++ b/controlplane/pkg/tests/test_model.go
@@ -22,13 +22,13 @@ import (
 
 type testModel struct {
 	model.Model
-	signalCh chan struct{}
+	healStartedCh chan struct{}
 }
 
-func NewTestModel(signalChannel chan struct{}) *testModel {
+func NewTestModel(healStartedChannel chan struct{}) *testModel {
 	return &testModel{
-		Model:    model.NewModel(),
-		signalCh: signalChannel,
+		Model:         model.NewModel(),
+		healStartedCh: healStartedChannel,
 	}
 }
 
@@ -43,7 +43,7 @@ func (m *testModel) ApplyClientConnectionChanges(ctx context.Context, connection
 	changeFunc(dummyConnection)
 
 	if dummyConnection.ConnectionState == model.ClientConnectionHealing {
-		close(m.signalCh)
+		close(m.healStartedCh)
 	}
 
 	return rv

--- a/controlplane/pkg/tests/test_model.go
+++ b/controlplane/pkg/tests/test_model.go
@@ -22,13 +22,15 @@ import (
 
 type testModel struct {
 	model.Model
-	healStartedCh chan struct{}
+	healStartedCh      chan struct{}
+	clientConnClosedCh chan struct{}
 }
 
-func NewTestModel(healStartedChannel chan struct{}) *testModel {
+func NewTestModel(healStartedChannel chan struct{}, clientConnClosedChanel chan struct{}) *testModel {
 	return &testModel{
-		Model:         model.NewModel(),
-		healStartedCh: healStartedChannel,
+		Model:              model.NewModel(),
+		healStartedCh:      healStartedChannel,
+		clientConnClosedCh: clientConnClosedChanel,
 	}
 }
 
@@ -44,6 +46,7 @@ func (m *testModel) ApplyClientConnectionChanges(ctx context.Context, connection
 
 	if dummyConnection.ConnectionState == model.ClientConnectionHealing {
 		close(m.healStartedCh)
+		<-m.clientConnClosedCh
 	}
 
 	return rv


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Added handling of the case when client connection is closed while healing. 
Now all healing connections are stored in healProcessor, and are checked in method CloseConnection.
## Motivation and Context
There are some cases when healing continues, if client died while healing.

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [ ] Covered by existing integration testing
- [ ] Added integration testing to cover
- [x] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
