### PR TITLE
Use eval in for-each-module.sh

### DIFF
--- a/scripts/for-each-module.sh
+++ b/scripts/for-each-module.sh
@@ -1,10 +1,14 @@
 #!/bin/bash
 
-CMD=$*
+# A script to run through all the modules and execute the supplied command(s)
+# The name of the module can be accessed in the command sith _MODULE_ variable.
+# Example: for-each-module.sh echo \$_MODULE_
+
+CMD="$*"
 res=0
 
 while read -r f; do
-    ( d=$(dirname "$f") && pushd "$d" && $CMD; ) || res=1
+    ( d=$(dirname "$f") && pushd "$d" && export _MODULE_=${d#\.\/} && eval "$CMD"; ) || res=1
 done <<< "$(find . -name 'go.mod' -not -path './*vendor*/*')"
 
 exit $res


### PR DESCRIPTION
## Description

Use the POSIX `eval` when invoking the command as specified
as an argument to ./scripts/for-each-module.sh. This ensures
better command handling and the ability to use the module name
in the command. 

Example:
```bash
./scripts/for-each-module.sh "eval 'echo  \${d#\.\/}'"
```

## Motivation and Context
To improve the capabilities of our modules tooling.

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [ ] Covered by existing integration testing
- [ ] Added integration testing to cover
- [x] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
