### PR TITLE
Kind uses context now, drop KUBECONFIG

### DIFF
--- a/.cloudtest/kind.yaml
+++ b/.cloudtest/kind.yaml
@@ -16,7 +16,6 @@ providers:
         make kind-config
         make kind-start
       stop: make kind-stop
-      config: make kind-config-location
       prepare: |
         make k8s-load-images
         make spire-install

--- a/.mk/kind.mk
+++ b/.mk/kind.mk
@@ -30,13 +30,8 @@ kind-start: kind-config
 	@kind get clusters | grep nsm  >/dev/null 2>&1 && exit 0 || \
 		( kind create cluster --name="$(KIND_CLUSTER_NAME)" --config ./scripts/kind.yaml --wait 120s && \
 		until \
-			KUBECONFIG="$$(kind get kubeconfig-path --name="$(KIND_CLUSTER_NAME)")" \
 			kubectl taint node $(KIND_CLUSTER_NAME)-control-plane node-role.kubernetes.io/master:NoSchedule- ; \
 		do echo "Waiting for the cluster to come up" && sleep 3; done )
-
-.PHONY: kind-config-location
-kind-config-location:
-	@kind get kubeconfig-path --name="$(KIND_CLUSTER_NAME)"
 
 .PHONY: kind-stop
 kind-stop:

--- a/.mk/kind.mk
+++ b/.mk/kind.mk
@@ -28,7 +28,7 @@ kind-install:
 .PHONY: kind-start
 kind-start: kind-config
 	@kind get clusters | grep nsm  >/dev/null 2>&1 && exit 0 || \
-		( kind create cluster --name="$(KIND_CLUSTER_NAME)" --config ./scripts/kind.yaml && \
+		( kind create cluster --name="$(KIND_CLUSTER_NAME)" --config ./scripts/kind.yaml --wait 120s && \
 		until \
 			KUBECONFIG="$$(kind get kubeconfig-path --name="$(KIND_CLUSTER_NAME)")" \
 			kubectl taint node $(KIND_CLUSTER_NAME)-control-plane node-role.kubernetes.io/master:NoSchedule- ; \

--- a/docs/guide-build.md
+++ b/docs/guide-build.md
@@ -45,7 +45,6 @@ Network Service Mesh provides a handy [Kind](https://github.com/kubernetes-sigs/
 ```bash
 make k8s-save                                                # build and save the NSM docker containers
 make kind-start                                              # start up an nsm cluster named kind
-export KUBECONFIG="$(kind get kubeconfig-path --name="nsm")" # Point kubectl at your kind instance
 make k8s-load-images                                         # load NSM docker containers into kind
 make helm-init                                               # initialize helm
 make helm-install-nsm                                        # install the nsm infrastructure

--- a/docs/guide-kind.md
+++ b/docs/guide-kind.md
@@ -20,22 +20,32 @@ To start a `kind` cluster, just run the below command from root networkserviceme
 ```shell
 $ make kind-start
 Creating cluster "nsm" ...
- ✓ Ensuring node image (kindest/node:v1.13.3) 🖼
- ✓ Preparing nodes 📦📦📦
- ✓ Creating kubeadm config 📜
+ ✓ Ensuring node image (kindest/node:v1.16.3) 🖼
+ ✓ Preparing nodes 📦
+ ✓ Writing configuration 📜
  ✓ Starting control-plane 🕹️
+ ✓ Installing CNI 🔌
+ ✓ Installing StorageClass 💾
  ✓ Joining worker nodes 🚜
-Cluster creation complete. You can now use the cluster with:
+ ✓ Waiting ≤ 2m0s for control-plane = Ready ⏳
+ • Ready after 7s 💚
+Set kubectl context to "kind-nsm"
+You can now use your cluster with:
 
-export KUBECONFIG="$(kind get kubeconfig-path --name="nsm")"
-kubectl cluster-info
+kubectl cluster-info --context kind-nsm
+
+Thanks for using kind! 😊
 node/nsm-control-plane untainted
 ```
 
-As seen on the last lines, to point your `kubectl` command to the new cluster one should run:
+Using `kubectl` one can verify that the context is set to `kind-nsm`.
 
 ```shell
-export KUBECONFIG="$(kind get kubeconfig-path --name="nsm")"
+$ kubectl config get-contexts
+CURRENT   NAME                 CLUSTER          AUTHINFO         NAMESPACE
+          docker-desktop       docker-desktop   docker-desktop
+          docker-for-desktop   docker-desktop   docker-desktop
+*         kind-nsm             kind-nsm         kind-nsm
 ```
 
 Deleting the cluster is as easy as:
@@ -43,6 +53,4 @@ Deleting the cluster is as easy as:
 ```shell
 $ make kind-stop
 Deleting cluster "nsm" ...
-$KUBECONFIG is still set to use $HOME/.kube/kind-config-nsm even though that file has been deleted, remember to unset it
 ```
-


### PR DESCRIPTION

## Description
Updated Kind is now using kubectl context to point to the right cluster. Drop all the oldschool `kubeconfig-path` references in the make machinery and in the docs.

## Motivation and Context
The old way of referring to the cluster is obsoleted and will be deprecated at some point. It is automatically set now, so no need to do anything for a single deployed kind cluster.

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [x] Covered by existing integration testing
- [ ] Added integration testing to cover
- [x] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
