### PR TITLE
Adjust retest unit tests for concurency (goroutine)

### DIFF
--- a/test/cloudtest/pkg/tests/retest_test.go
+++ b/test/cloudtest/pkg/tests/retest_test.go
@@ -72,10 +72,9 @@ func TestRestartRequest(t *testing.T) {
 	logKeeper.CheckMessagesOrder(t, []string{
 		"Starting TestRequestRestart",
 		"Re schedule task TestRequestRestart reason: rerun-request",
-		"Starting TestRequestRestart",
-		"Re schedule task TestRequestRestart reason: rerun-request",
 		"Test TestRequestRestart retry count 2 exceed: err",
 	})
+	g.Expect(logKeeper.MessageCount("Re schedule task TestRequestRestart reason: rerun-request")).To(Equal(2))
 }
 
 func TestRestartRetestDestroyCluster(t *testing.T) {
@@ -180,15 +179,12 @@ func TestRestartRequestRestartCluster(t *testing.T) {
 
 	logKeeper.CheckMessagesOrder(t, []string{
 		"Starting TestRequestRestart",
-		"Warmup cluster operations: [a_provider-1] timeout: 1s",
 		"Reached a limit of re-tests per cluster instance",
 		"Destroying cluster",
-		"Re schedule task TestRequestRestart reason: rerun-request",
 		"Starting cluster ",
-		"Starting TestRequestRestart",
-		"Re schedule task TestRequestRestart reason: rerun-request",
 		"Test TestRequestRestart retry count 3 exceed: err: failed to run go test",
 	})
+	g.Expect(logKeeper.MessageCount("Re schedule task TestRequestRestart reason: rerun-request")).To(Equal(3))
 }
 
 func TestRestartRequestSkip(t *testing.T) {
@@ -241,9 +237,8 @@ func TestRestartRequestSkip(t *testing.T) {
 	logKeeper.CheckMessagesOrder(t, []string{
 		"Starting TestRequestRestart",
 		"Re schedule task TestRequestRestart reason: rerun-request",
-		"Starting TestRequestRestart",
-		"Re schedule task TestRequestRestart reason: rerun-request",
 		"Test TestRequestRestart retry count 2 exceed: err",
 		"Re schedule task TestRequestRestart reason: skipped",
 	})
+	g.Expect(logKeeper.MessageCount("Re schedule task TestRequestRestart reason: rerun-request")).To(Equal(2))
 }

--- a/test/cloudtest/pkg/utils/utils.go
+++ b/test/cloudtest/pkg/utils/utils.go
@@ -70,6 +70,19 @@ func (lk *logKeeper) GetMessages() []string {
 	return messages
 }
 
+// MessageCount - how many times a message is present in log
+func (lk *logKeeper) MessageCount(message string) (count int) {
+	if message == "" {
+		return 0
+	}
+	for _, entry := range lk.loghook.AllEntries() {
+		if strings.Contains(entry.Message, message) {
+			count++
+		}
+	}
+	return
+}
+
 // CheckMessagesOrder - checks that messages are present in log in given oreder.
 func (lk *logKeeper) CheckMessagesOrder(t *testing.T, messages []string) bool {
 	if len(messages) == 0 {
@@ -82,7 +95,7 @@ func (lk *logKeeper) CheckMessagesOrder(t *testing.T, messages []string) bool {
 	for _, entry := range lk.loghook.AllEntries() {
 		msgs = append(msgs, fmt.Sprintf("\"%s\",\n", entry.Message))
 		if ind < len(messages) && strings.Contains(entry.Message, messages[ind]) {
-			matched = append(matched, fmt.Sprintf("'%s' contains in '%s'", messages[ind], entry.Message))
+			matched = append(matched, fmt.Sprintf("'%s' found in '%s'\n", messages[ind], entry.Message))
 			ind++
 			lastMatched = len(msgs) - 1
 			if ind == len(messages) {


### PR DESCRIPTION
The order of log messages can change because the code producing them is executed in concurrent goroutines. 

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [x] Covered by existing integration testing
- [ ] Added integration testing to cover
- [ ] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
