### PR TITLE
New junit.xml structure

### DIFF
--- a/test/cloudtest/pkg/commands/main.go
+++ b/test/cloudtest/pkg/commands/main.go
@@ -1368,7 +1368,7 @@ func (ctx *executionContext) generateJUnitReportFile() (*reporting.JUnitFile, er
 			executionTime += clusterTime
 
 			clusterSuite.Time = fmt.Sprintf("%v", clusterTime.Seconds())
-			clusterSuite.Details.FormattedTime = fmt.Sprintf("%v", clusterTime.Round(time.Second))
+			clusterSuite.TimeComment = fmt.Sprintf(reporting.TimeCommentFormat, clusterTime.Round(time.Second))
 			clusterSuite.Failures = clusterFailures
 			clusterSuite.Tests = clusterTests
 			execSuite.Suites = append(execSuite.Suites, clusterSuite)
@@ -1381,7 +1381,7 @@ func (ctx *executionContext) generateJUnitReportFile() (*reporting.JUnitFile, er
 		execSuite.Tests = executionTests
 		execSuite.Failures = executionFailures
 		execSuite.Time = fmt.Sprintf("%v", executionTime.Seconds())
-		execSuite.Details.FormattedTime = fmt.Sprintf("%v", executionTime.Round(time.Second))
+		execSuite.TimeComment = fmt.Sprintf(reporting.TimeCommentFormat, executionTime.Round(time.Second))
 		summarySuite.Suites = append(summarySuite.Suites, execSuite)
 	}
 
@@ -1396,7 +1396,7 @@ func (ctx *executionContext) generateJUnitReportFile() (*reporting.JUnitFile, er
 	}
 
 	summarySuite.Time = fmt.Sprintf("%v", totalTime.Seconds())
-	summarySuite.Details.FormattedTime = fmt.Sprintf("%v", totalTime.Round(time.Second))
+	summarySuite.TimeComment = fmt.Sprintf(reporting.TimeCommentFormat, totalTime.Round(time.Second))
 	summarySuite.Failures = totalFailures
 	summarySuite.Tests = totalTests
 	ctx.report.Suites = append(ctx.report.Suites, summarySuite)
@@ -1444,7 +1444,7 @@ func (ctx *executionContext) generateClusterFailuresReportSuite() (time.Duration
 		}
 	}
 	clusterFailuresSuite.Time = fmt.Sprintf("%v", failuresTime.Seconds())
-	clusterFailuresSuite.Details.FormattedTime = fmt.Sprintf("%v", failuresTime.Round(time.Second))
+	clusterFailuresSuite.TimeComment = fmt.Sprintf(reporting.TimeCommentFormat, failuresTime.Round(time.Second))
 	return failuresTime, clusterFailures, clusterFailuresSuite
 }
 

--- a/test/cloudtest/pkg/commands/main.go
+++ b/test/cloudtest/pkg/commands/main.go
@@ -1368,7 +1368,7 @@ func (ctx *executionContext) generateJUnitReportFile() (*reporting.JUnitFile, er
 			executionTests += clusterTests
 			executionTime += clusterTime
 
-			clusterSuite.Time = fmt.Sprintf("%v", clusterTime)
+			clusterSuite.Time = fmt.Sprintf("%v", clusterTime.Round(time.Second))
 			clusterSuite.Failures = clusterFailures
 			clusterSuite.Tests = clusterTests
 			execSuite.Suites = append(execSuite.Suites, clusterSuite)
@@ -1380,7 +1380,7 @@ func (ctx *executionContext) generateJUnitReportFile() (*reporting.JUnitFile, er
 
 		execSuite.Tests = executionTests
 		execSuite.Failures = executionFailures
-		execSuite.Time = fmt.Sprintf("%v", executionTime)
+		execSuite.Time = fmt.Sprintf("%v", executionTime.Round(time.Second))
 		summarySuite.Suites = append(summarySuite.Suites, execSuite)
 	}
 
@@ -1394,7 +1394,7 @@ func (ctx *executionContext) generateJUnitReportFile() (*reporting.JUnitFile, er
 		summarySuite.Suites = append(summarySuite.Suites, clusterFailuresSuite)
 	}
 
-	summarySuite.Time = fmt.Sprintf("%v", totalTime)
+	summarySuite.Time = fmt.Sprintf("%v", totalTime.Round(time.Second))
 	summarySuite.Failures = totalFailures
 	summarySuite.Tests = totalTests
 	ctx.report.Suites = append(ctx.report.Suites, summarySuite)
@@ -1497,8 +1497,8 @@ func (ctx *executionContext) generateClusterFailedReportEntry(inst *clusterInsta
 
 func (ctx *executionContext) generateTestCaseReport(test *testTask, totalTests int, totalTime time.Duration, failures int, suite *reporting.Suite) (int, time.Duration, int) {
 	testCase := &reporting.TestCase{
-		Name:    test.test.Key,
-		Time:    fmt.Sprintf("%vs", test.test.Duration.Seconds()),
+		Name:    test.test.Name,
+		Time:    fmt.Sprintf("%v", test.test.Duration.Seconds()),
 		Cluster: test.clusterTaskID,
 	}
 

--- a/test/cloudtest/pkg/commands/main.go
+++ b/test/cloudtest/pkg/commands/main.go
@@ -1321,9 +1321,9 @@ func (ctx *executionContext) findGoTest(executionConfig *config.ExecutionConfig)
 }
 
 func buildClusterSuiteName(clusters []*clustersGroup) string {
-	var clusterProviderNames []string
-	for _, cluster := range clusters {
-		clusterProviderNames = append(clusterProviderNames, cluster.config.Name)
+	var clusterProviderNames = make([]string, len(clusters))
+	for i := 0; i < len(clusters); i++ {
+		clusterProviderNames[i] = clusters[i].config.Name
 	}
 	return strings.Join(clusterProviderNames, "-")
 }
@@ -1344,7 +1344,6 @@ func (ctx *executionContext) generateJUnitReportFile() (*reporting.JUnitFile, er
 	totalTime := time.Duration(0)
 	// Generate suites by executions.
 	for execName, executionTasks := range executionsTests {
-
 		execSuite := &reporting.Suite{
 			Name: execName,
 		}

--- a/test/cloudtest/pkg/commands/main.go
+++ b/test/cloudtest/pkg/commands/main.go
@@ -1367,7 +1367,8 @@ func (ctx *executionContext) generateJUnitReportFile() (*reporting.JUnitFile, er
 			executionTests += clusterTests
 			executionTime += clusterTime
 
-			clusterSuite.Time = fmt.Sprintf("%v", clusterTime.Round(time.Second))
+			clusterSuite.Time = fmt.Sprintf("%v", clusterTime.Seconds())
+			clusterSuite.Details.FormattedTime = fmt.Sprintf("%v", clusterTime.Round(time.Second))
 			clusterSuite.Failures = clusterFailures
 			clusterSuite.Tests = clusterTests
 			execSuite.Suites = append(execSuite.Suites, clusterSuite)
@@ -1379,7 +1380,8 @@ func (ctx *executionContext) generateJUnitReportFile() (*reporting.JUnitFile, er
 
 		execSuite.Tests = executionTests
 		execSuite.Failures = executionFailures
-		execSuite.Time = fmt.Sprintf("%v", executionTime.Round(time.Second))
+		execSuite.Time = fmt.Sprintf("%v", executionTime.Seconds())
+		execSuite.Details.FormattedTime = fmt.Sprintf("%v", executionTime.Round(time.Second))
 		summarySuite.Suites = append(summarySuite.Suites, execSuite)
 	}
 
@@ -1393,7 +1395,8 @@ func (ctx *executionContext) generateJUnitReportFile() (*reporting.JUnitFile, er
 		summarySuite.Suites = append(summarySuite.Suites, clusterFailuresSuite)
 	}
 
-	summarySuite.Time = fmt.Sprintf("%v", totalTime.Round(time.Second))
+	summarySuite.Time = fmt.Sprintf("%v", totalTime.Seconds())
+	summarySuite.Details.FormattedTime = fmt.Sprintf("%v", totalTime.Round(time.Second))
 	summarySuite.Failures = totalFailures
 	summarySuite.Tests = totalTests
 	ctx.report.Suites = append(ctx.report.Suites, summarySuite)
@@ -1440,7 +1443,8 @@ func (ctx *executionContext) generateClusterFailuresReportSuite() (time.Duration
 			}
 		}
 	}
-	clusterFailuresSuite.Time = fmt.Sprintf("%v", failuresTime)
+	clusterFailuresSuite.Time = fmt.Sprintf("%v", failuresTime.Seconds())
+	clusterFailuresSuite.Details.FormattedTime = fmt.Sprintf("%v", failuresTime.Round(time.Second))
 	return failuresTime, clusterFailures, clusterFailuresSuite
 }
 
@@ -1484,7 +1488,7 @@ func (ctx *executionContext) generateClusterFailedReportEntry(inst *clusterInsta
 	}
 	startCase := &reporting.TestCase{
 		Name: fmt.Sprintf("Startup-%v", inst.id),
-		Time: fmt.Sprintf("%v", exec.duration),
+		Time: fmt.Sprintf("%v", exec.duration.Seconds()),
 	}
 	startCase.Failure = &reporting.Failure{
 		Type:     "ERROR",

--- a/test/cloudtest/pkg/reporting/junit.go
+++ b/test/cloudtest/pkg/reporting/junit.go
@@ -17,7 +17,7 @@ type Suite struct {
 	Name       string      `xml:"name,attr"`
 	Properties []*Property `xml:"properties>property,omitempty"`
 	TestCases  []*TestCase
-	Suite      []*Suite
+	Suites     []*Suite
 }
 
 // TestCase - TestCase
@@ -26,7 +26,7 @@ type TestCase struct {
 	Classname   string       `xml:"classname,attr"`
 	Name        string       `xml:"name,attr"`
 	Time        string       `xml:"time,attr"`
-	Cluster     string       `xml:"cluster,attr"`
+	Cluster     string       `xml:"cluster_instance,attr"`
 	SkipMessage *SkipMessage `xml:"skipped,omitempty"`
 	Failure     *Failure     `xml:"failure,omitempty"`
 }

--- a/test/cloudtest/pkg/reporting/junit.go
+++ b/test/cloudtest/pkg/reporting/junit.go
@@ -16,8 +16,15 @@ type Suite struct {
 	Time       string      `xml:"time,attr"`
 	Name       string      `xml:"name,attr"`
 	Properties []*Property `xml:"properties>property,omitempty"`
+	Details    SuiteDetails
 	TestCases  []*TestCase
 	Suites     []*Suite
+}
+
+// SuiteDetails holds additional information about test suite.
+type SuiteDetails struct {
+	XMLName       xml.Name `xml:"details"`
+	FormattedTime string   `xml:"formatted_time,attr"`
 }
 
 // TestCase - TestCase

--- a/test/cloudtest/pkg/reporting/junit.go
+++ b/test/cloudtest/pkg/reporting/junit.go
@@ -17,6 +17,7 @@ type Suite struct {
 	Name       string      `xml:"name,attr"`
 	Properties []*Property `xml:"properties>property,omitempty"`
 	TestCases  []*TestCase
+	Suite      []*Suite
 }
 
 // TestCase - TestCase
@@ -25,6 +26,7 @@ type TestCase struct {
 	Classname   string       `xml:"classname,attr"`
 	Name        string       `xml:"name,attr"`
 	Time        string       `xml:"time,attr"`
+	Cluster     string       `xml:"cluster,attr"`
 	SkipMessage *SkipMessage `xml:"skipped,omitempty"`
 	Failure     *Failure     `xml:"failure,omitempty"`
 }

--- a/test/cloudtest/pkg/reporting/junit.go
+++ b/test/cloudtest/pkg/reporting/junit.go
@@ -2,6 +2,11 @@ package reporting
 
 import "encoding/xml"
 
+const (
+	// TimeCommentFormat is a format for printing readable time suite comment
+	TimeCommentFormat = "Suite was running for %v"
+)
+
 // JUnitFile - JUnitFile
 type JUnitFile struct {
 	XMLName xml.Name `xml:"testsuites"`
@@ -10,15 +15,15 @@ type JUnitFile struct {
 
 // Suite - Suite
 type Suite struct {
-	XMLName    xml.Name    `xml:"testsuite"`
-	Tests      int         `xml:"tests,attr"`
-	Failures   int         `xml:"failures,attr"`
-	Time       string      `xml:"time,attr"`
-	Name       string      `xml:"name,attr"`
-	Properties []*Property `xml:"properties>property,omitempty"`
-	Details    SuiteDetails
-	TestCases  []*TestCase
-	Suites     []*Suite
+	XMLName     xml.Name    `xml:"testsuite"`
+	Tests       int         `xml:"tests,attr"`
+	Failures    int         `xml:"failures,attr"`
+	Time        string      `xml:"time,attr"`
+	Name        string      `xml:"name,attr"`
+	Properties  []*Property `xml:"properties>property,omitempty"`
+	TimeComment string      `xml:",comment"`
+	TestCases   []*TestCase
+	Suites      []*Suite
 }
 
 // SuiteDetails holds additional information about test suite.

--- a/test/cloudtest/pkg/tests/all_cluster_fail_test.go
+++ b/test/cloudtest/pkg/tests/all_cluster_fail_test.go
@@ -38,7 +38,8 @@ func TestClusterInstancesFailed(t *testing.T) {
 	testConfig.Reporting.JUnitReportFile = JunitReport
 
 	report, err := commands.PerformTesting(testConfig, &testValidationFactory{}, &commands.Arguments{})
-	g.Expect(err.Error()).To(Equal("there is failed tests 6"))
+
+	g.Expect(err.Error()).To(Equal("there is failed tests 3"))
 
 	g.Expect(report).NotTo(BeNil())
 
@@ -48,7 +49,7 @@ func TestClusterInstancesFailed(t *testing.T) {
 
 	g.Expect(len(rootSuite.Suites[0].Suites)).To(Equal(2))
 
-	g.Expect(rootSuite.Suites[0].Failures).To(Equal(4))
+	g.Expect(rootSuite.Suites[0].Failures).To(Equal(1))
 	g.Expect(rootSuite.Suites[0].Tests).To(Equal(6))
 	g.Expect(len(rootSuite.Suites[0].Suites[0].TestCases)).To(Equal(3))
 	g.Expect(len(rootSuite.Suites[0].Suites[1].TestCases)).To(Equal(3))
@@ -86,7 +87,7 @@ func TestClusterInstancesOnFailGoRunner(t *testing.T) {
 	testConfig.Reporting.JUnitReportFile = JunitReport
 
 	report, err := commands.PerformTesting(testConfig, &testValidationFactory{}, &commands.Arguments{})
-	g.Expect(err.Error()).To(Equal("there is failed tests 6"))
+	g.Expect(err.Error()).To(Equal("there is failed tests 3"))
 
 	g.Expect(report).NotTo(BeNil())
 
@@ -94,7 +95,7 @@ func TestClusterInstancesOnFailGoRunner(t *testing.T) {
 
 	g.Expect(len(rootSuite.Suites)).To(Equal(2))
 
-	g.Expect(rootSuite.Suites[0].Failures).To(Equal(4))
+	g.Expect(rootSuite.Suites[0].Failures).To(Equal(1))
 	g.Expect(rootSuite.Suites[0].Tests).To(Equal(6))
 	g.Expect(len(rootSuite.Suites[0].Suites[0].TestCases)).To(Equal(3))
 	g.Expect(len(rootSuite.Suites[0].Suites[1].TestCases)).To(Equal(3))

--- a/test/cloudtest/pkg/tests/all_cluster_fail_test.go
+++ b/test/cloudtest/pkg/tests/all_cluster_fail_test.go
@@ -38,7 +38,7 @@ func TestClusterInstancesFailed(t *testing.T) {
 	testConfig.Reporting.JUnitReportFile = JunitReport
 
 	report, err := commands.PerformTesting(testConfig, &testValidationFactory{}, &commands.Arguments{})
-	g.Expect(err.Error()).To(Equal("there is failed tests 3"))
+	g.Expect(err.Error()).To(Equal("there is failed tests 6"))
 
 	g.Expect(report).NotTo(BeNil())
 
@@ -48,7 +48,7 @@ func TestClusterInstancesFailed(t *testing.T) {
 
 	g.Expect(len(rootSuite.Suites[0].Suites)).To(Equal(2))
 
-	g.Expect(rootSuite.Suites[0].Failures).To(Equal(1))
+	g.Expect(rootSuite.Suites[0].Failures).To(Equal(4))
 	g.Expect(rootSuite.Suites[0].Tests).To(Equal(6))
 	g.Expect(len(rootSuite.Suites[0].Suites[0].TestCases)).To(Equal(3))
 	g.Expect(len(rootSuite.Suites[0].Suites[1].TestCases)).To(Equal(3))
@@ -86,7 +86,7 @@ func TestClusterInstancesOnFailGoRunner(t *testing.T) {
 	testConfig.Reporting.JUnitReportFile = JunitReport
 
 	report, err := commands.PerformTesting(testConfig, &testValidationFactory{}, &commands.Arguments{})
-	g.Expect(err.Error()).To(Equal("there is failed tests 3"))
+	g.Expect(err.Error()).To(Equal("there is failed tests 6"))
 
 	g.Expect(report).NotTo(BeNil())
 
@@ -94,7 +94,7 @@ func TestClusterInstancesOnFailGoRunner(t *testing.T) {
 
 	g.Expect(len(rootSuite.Suites)).To(Equal(2))
 
-	g.Expect(rootSuite.Suites[0].Failures).To(Equal(1))
+	g.Expect(rootSuite.Suites[0].Failures).To(Equal(4))
 	g.Expect(rootSuite.Suites[0].Tests).To(Equal(6))
 	g.Expect(len(rootSuite.Suites[0].Suites[0].TestCases)).To(Equal(3))
 	g.Expect(len(rootSuite.Suites[0].Suites[1].TestCases)).To(Equal(3))
@@ -210,8 +210,9 @@ func TestClusterInstancesOnFailShellRunnerInterdomain(t *testing.T) {
 	g.Expect(err.Error()).To(Equal("there is failed tests 1"))
 	foundFailTest := false
 
-	for _, t := range report.Suites[0].TestCases {
-		if t.Name == "a_provider_b_provider_fail" {
+	for _, suite := range report.Suites[0].Suites {
+		t := suite.Suites[0].TestCases[0]
+		if suite.Name == "fail" {
 			g.Expect(t.Failure).NotTo(Equal(BeNil()))
 			g.Expect(strings.Contains(t.Failure.Contents, ">>>Running on fail script with ./.tests/config.a <<<")).To(Equal(true))
 			g.Expect(strings.Contains(t.Failure.Contents, ">>>Running on fail script with ./.tests/config.b <<<")).To(Equal(true))

--- a/test/cloudtest/pkg/tests/all_cluster_fail_test.go
+++ b/test/cloudtest/pkg/tests/all_cluster_fail_test.go
@@ -108,7 +108,7 @@ func TestClusterInstancesOnFailGoRunner(t *testing.T) {
 	for _, execSuite := range rootSuite.Suites[0].Suites {
 		if execSuite.Name == "a_provider" {
 			for _, testCase := range execSuite.TestCases {
-				if testCase.Name == "_TestFail" {
+				if testCase.Name == "TestFail" {
 					g.Expect(testCase.Failure).NotTo(BeNil())
 					g.Expect(strings.Contains(testCase.Failure.Contents, ">>>Running on fail script<<<")).To(Equal(true))
 					foundFailTest = true

--- a/test/cloudtest/pkg/tests/all_cluster_fail_test.go
+++ b/test/cloudtest/pkg/tests/all_cluster_fail_test.go
@@ -42,18 +42,20 @@ func TestClusterInstancesFailed(t *testing.T) {
 
 	g.Expect(report).NotTo(BeNil())
 
-	g.Expect(len(report.Suites)).To(Equal(2))
+	rootSuite := report.Suites[0]
 
-	g.Expect(len(report.Suites[0].Suites)).To(Equal(2))
+	g.Expect(len(rootSuite.Suites)).To(Equal(2))
 
-	g.Expect(report.Suites[0].Failures).To(Equal(1))
-	g.Expect(report.Suites[0].Tests).To(Equal(6))
-	g.Expect(len(report.Suites[0].Suites[0].TestCases)).To(Equal(3))
-	g.Expect(len(report.Suites[0].Suites[1].TestCases)).To(Equal(3))
+	g.Expect(len(rootSuite.Suites[0].Suites)).To(Equal(2))
 
-	g.Expect(report.Suites[1].Failures).To(Equal(2))
-	g.Expect(report.Suites[1].Tests).To(Equal(5))
-	g.Expect(len(report.Suites[1].TestCases)).To(Equal(5))
+	g.Expect(rootSuite.Suites[0].Failures).To(Equal(1))
+	g.Expect(rootSuite.Suites[0].Tests).To(Equal(6))
+	g.Expect(len(rootSuite.Suites[0].Suites[0].TestCases)).To(Equal(3))
+	g.Expect(len(rootSuite.Suites[0].Suites[1].TestCases)).To(Equal(3))
+
+	g.Expect(rootSuite.Suites[1].Failures).To(Equal(2))
+	g.Expect(rootSuite.Suites[1].Tests).To(Equal(2))
+	g.Expect(len(rootSuite.Suites[1].TestCases)).To(Equal(2))
 
 	// Do assertions
 }
@@ -88,19 +90,22 @@ func TestClusterInstancesOnFailGoRunner(t *testing.T) {
 
 	g.Expect(report).NotTo(BeNil())
 
-	g.Expect(len(report.Suites)).To(Equal(2))
-	g.Expect(report.Suites[0].Failures).To(Equal(1))
-	g.Expect(report.Suites[0].Tests).To(Equal(6))
-	g.Expect(len(report.Suites[0].Suites[0].TestCases)).To(Equal(3))
-	g.Expect(len(report.Suites[0].Suites[1].TestCases)).To(Equal(3))
+	rootSuite := report.Suites[0]
 
-	g.Expect(report.Suites[1].Failures).To(Equal(2))
-	g.Expect(report.Suites[1].Tests).To(Equal(5))
-	g.Expect(len(report.Suites[1].TestCases)).To(Equal(5))
+	g.Expect(len(rootSuite.Suites)).To(Equal(2))
+
+	g.Expect(rootSuite.Suites[0].Failures).To(Equal(1))
+	g.Expect(rootSuite.Suites[0].Tests).To(Equal(6))
+	g.Expect(len(rootSuite.Suites[0].Suites[0].TestCases)).To(Equal(3))
+	g.Expect(len(rootSuite.Suites[0].Suites[1].TestCases)).To(Equal(3))
+
+	g.Expect(rootSuite.Suites[1].Failures).To(Equal(2))
+	g.Expect(rootSuite.Suites[1].Tests).To(Equal(2))
+	g.Expect(len(rootSuite.Suites[1].TestCases)).To(Equal(2))
 
 	foundFailTest := false
 
-	for _, execSuite := range report.Suites[0].Suites {
+	for _, execSuite := range rootSuite.Suites[0].Suites {
 		if execSuite.Name == "a_provider" {
 			for _, testCase := range execSuite.TestCases {
 				if testCase.Name == "_TestFail" {
@@ -149,7 +154,7 @@ func TestClusterInstancesOnFailShellRunner(t *testing.T) {
 	g.Expect(err.Error()).To(Equal("there is failed tests 1"))
 	foundFailTest := false
 
-	for _, executionSuite := range report.Suites {
+	for _, executionSuite := range report.Suites[0].Suites {
 		testCase := executionSuite.Suites[0].TestCases[0]
 		if executionSuite.Name == "fail" {
 			g.Expect(testCase.Failure).NotTo(BeNil())

--- a/test/cloudtest/pkg/tests/all_cluster_fail_test.go
+++ b/test/cloudtest/pkg/tests/all_cluster_fail_test.go
@@ -43,9 +43,13 @@ func TestClusterInstancesFailed(t *testing.T) {
 	g.Expect(report).NotTo(BeNil())
 
 	g.Expect(len(report.Suites)).To(Equal(2))
+
+	g.Expect(len(report.Suites[0].Suites)).To(Equal(2))
+
 	g.Expect(report.Suites[0].Failures).To(Equal(1))
-	g.Expect(report.Suites[0].Tests).To(Equal(3))
-	g.Expect(len(report.Suites[0].TestCases)).To(Equal(3))
+	g.Expect(report.Suites[0].Tests).To(Equal(6))
+	g.Expect(len(report.Suites[0].Suites[0].TestCases)).To(Equal(3))
+	g.Expect(len(report.Suites[0].Suites[1].TestCases)).To(Equal(3))
 
 	g.Expect(report.Suites[1].Failures).To(Equal(2))
 	g.Expect(report.Suites[1].Tests).To(Equal(5))
@@ -86,8 +90,9 @@ func TestClusterInstancesOnFailGoRunner(t *testing.T) {
 
 	g.Expect(len(report.Suites)).To(Equal(2))
 	g.Expect(report.Suites[0].Failures).To(Equal(1))
-	g.Expect(report.Suites[0].Tests).To(Equal(3))
-	g.Expect(len(report.Suites[0].TestCases)).To(Equal(3))
+	g.Expect(report.Suites[0].Tests).To(Equal(6))
+	g.Expect(len(report.Suites[0].Suites[0].TestCases)).To(Equal(3))
+	g.Expect(len(report.Suites[0].Suites[1].TestCases)).To(Equal(3))
 
 	g.Expect(report.Suites[1].Failures).To(Equal(2))
 	g.Expect(report.Suites[1].Tests).To(Equal(5))
@@ -95,7 +100,7 @@ func TestClusterInstancesOnFailGoRunner(t *testing.T) {
 
 	foundFailTest := false
 
-	for _, t := range report.Suites[0].TestCases {
+	for _, t := range report.Suites[0].Suites[0].TestCases {
 		if t.Name == "_TestFail" {
 			g.Expect(t.Failure).NotTo(Equal(BeNil()))
 			g.Expect(strings.Contains(t.Failure.Contents, ">>>Running on fail script<<<")).To(Equal(true))
@@ -140,8 +145,9 @@ func TestClusterInstancesOnFailShellRunner(t *testing.T) {
 	g.Expect(err.Error()).To(Equal("there is failed tests 1"))
 	foundFailTest := false
 
-	for _, t := range report.Suites[0].TestCases {
-		if t.Name == "_fail" {
+	for _, executionSuite := range report.Suites {
+		t := executionSuite.Suites[0].TestCases[0]
+		if executionSuite.Name == "fail" {
 			g.Expect(t.Failure).NotTo(Equal(BeNil()))
 			g.Expect(strings.Contains(t.Failure.Contents, ">>>Running on fail script<<<")).To(Equal(true))
 			foundFailTest = true

--- a/test/cloudtest/pkg/tests/all_cluster_fail_test.go
+++ b/test/cloudtest/pkg/tests/all_cluster_fail_test.go
@@ -100,13 +100,17 @@ func TestClusterInstancesOnFailGoRunner(t *testing.T) {
 
 	foundFailTest := false
 
-	for _, t := range report.Suites[0].Suites[0].TestCases {
-		if t.Name == "_TestFail" {
-			g.Expect(t.Failure).NotTo(Equal(BeNil()))
-			g.Expect(strings.Contains(t.Failure.Contents, ">>>Running on fail script<<<")).To(Equal(true))
-			foundFailTest = true
-		} else {
-			g.Expect(t.Failure).Should(BeNil())
+	for _, execSuite := range report.Suites[0].Suites {
+		if execSuite.Name == "a_provider" {
+			for _, testCase := range execSuite.TestCases {
+				if testCase.Name == "_TestFail" {
+					g.Expect(testCase.Failure).NotTo(BeNil())
+					g.Expect(strings.Contains(testCase.Failure.Contents, ">>>Running on fail script<<<")).To(Equal(true))
+					foundFailTest = true
+				} else {
+					g.Expect(testCase.Failure).Should(BeNil())
+				}
+			}
 		}
 	}
 	g.Expect(foundFailTest).Should(BeTrue())
@@ -146,13 +150,13 @@ func TestClusterInstancesOnFailShellRunner(t *testing.T) {
 	foundFailTest := false
 
 	for _, executionSuite := range report.Suites {
-		t := executionSuite.Suites[0].TestCases[0]
+		testCase := executionSuite.Suites[0].TestCases[0]
 		if executionSuite.Name == "fail" {
-			g.Expect(t.Failure).NotTo(Equal(BeNil()))
-			g.Expect(strings.Contains(t.Failure.Contents, ">>>Running on fail script<<<")).To(Equal(true))
+			g.Expect(testCase.Failure).NotTo(BeNil())
+			g.Expect(strings.Contains(testCase.Failure.Contents, ">>>Running on fail script<<<")).To(Equal(true))
 			foundFailTest = true
 		} else {
-			g.Expect(t.Failure).Should(BeNil())
+			g.Expect(testCase.Failure).Should(BeNil())
 		}
 	}
 	g.Expect(foundFailTest).Should(BeTrue())

--- a/test/cloudtest/pkg/tests/retest_test.go
+++ b/test/cloudtest/pkg/tests/retest_test.go
@@ -114,7 +114,7 @@ func TestRestartRetestDestroyCluster(t *testing.T) {
 	testConfig.Reporting.JUnitReportFile = JunitReport
 
 	report, err := commands.PerformTesting(testConfig, &testValidationFactory{}, &commands.Arguments{})
-	g.Expect(err.Error()).To(Equal("there is failed tests 2"))
+	g.Expect(err.Error()).To(Equal("there is failed tests 1"))
 
 	g.Expect(report).NotTo(BeNil())
 
@@ -122,7 +122,7 @@ func TestRestartRetestDestroyCluster(t *testing.T) {
 	g.Expect(len(rootSuite.Suites)).To(Equal(2))
 
 	g.Expect(rootSuite.Suites[0].Tests).To(Equal(2))
-	g.Expect(rootSuite.Suites[0].Failures).To(Equal(1))
+	g.Expect(rootSuite.Suites[0].Failures).To(Equal(0))
 	g.Expect(len(rootSuite.Suites[0].Suites[0].TestCases)).To(Equal(2))
 
 	g.Expect(rootSuite.Suites[1].Tests).To(Equal(1))

--- a/test/cloudtest/pkg/tests/retest_test.go
+++ b/test/cloudtest/pkg/tests/retest_test.go
@@ -64,10 +64,12 @@ func TestRestartRequest(t *testing.T) {
 
 	g.Expect(report).NotTo(BeNil())
 
-	g.Expect(len(report.Suites)).To(Equal(1))
-	g.Expect(report.Suites[0].Failures).To(Equal(1))
-	g.Expect(report.Suites[0].Tests).To(Equal(2))
-	g.Expect(len(report.Suites[0].Suites[0].TestCases)).To(Equal(2))
+	rootSuite := report.Suites[0]
+
+	g.Expect(len(rootSuite.Suites)).To(Equal(1))
+	g.Expect(rootSuite.Suites[0].Failures).To(Equal(1))
+	g.Expect(rootSuite.Suites[0].Tests).To(Equal(2))
+	g.Expect(len(rootSuite.Suites[0].Suites[0].TestCases)).To(Equal(2))
 
 	logKeeper.CheckMessagesOrder(t, []string{
 		"Starting TestRequestRestart",
@@ -116,15 +118,16 @@ func TestRestartRetestDestroyCluster(t *testing.T) {
 
 	g.Expect(report).NotTo(BeNil())
 
-	g.Expect(len(report.Suites)).To(Equal(2))
+	rootSuite := report.Suites[0]
+	g.Expect(len(rootSuite.Suites)).To(Equal(2))
 
-	g.Expect(report.Suites[0].Tests).To(Equal(2))
-	g.Expect(report.Suites[0].Failures).To(Equal(0))
-	g.Expect(len(report.Suites[0].Suites[0].TestCases)).To(Equal(2))
+	g.Expect(rootSuite.Suites[0].Tests).To(Equal(2))
+	g.Expect(rootSuite.Suites[0].Failures).To(Equal(0))
+	g.Expect(len(rootSuite.Suites[0].Suites[0].TestCases)).To(Equal(2))
 
-	g.Expect(report.Suites[1].Tests).To(Equal(1))
-	g.Expect(report.Suites[1].Failures).To(Equal(1))
-	g.Expect(len(report.Suites[1].TestCases)).To(Equal(1))
+	g.Expect(rootSuite.Suites[1].Tests).To(Equal(1))
+	g.Expect(rootSuite.Suites[1].Failures).To(Equal(1))
+	g.Expect(len(rootSuite.Suites[1].TestCases)).To(Equal(1))
 
 	logKeeper.CheckMessagesOrder(t, []string{
 		"Starting TestRequestRestart",
@@ -177,10 +180,11 @@ func TestRestartRequestRestartCluster(t *testing.T) {
 
 	g.Expect(report).NotTo(BeNil())
 
-	g.Expect(len(report.Suites)).To(Equal(1))
-	g.Expect(report.Suites[0].Failures).To(Equal(1))
-	g.Expect(report.Suites[0].Tests).To(Equal(2))
-	g.Expect(len(report.Suites[0].Suites[0].TestCases)).To(Equal(2))
+	rootSuite := report.Suites[0]
+	g.Expect(len(rootSuite.Suites)).To(Equal(1))
+	g.Expect(rootSuite.Suites[0].Failures).To(Equal(1))
+	g.Expect(rootSuite.Suites[0].Tests).To(Equal(2))
+	g.Expect(len(rootSuite.Suites[0].Suites[0].TestCases)).To(Equal(2))
 
 	logKeeper.CheckMessagesOrder(t, []string{
 		"Starting TestRequestRestart",
@@ -228,12 +232,13 @@ func TestRestartRequestSkip(t *testing.T) {
 
 	g.Expect(report).NotTo(BeNil())
 
-	g.Expect(len(report.Suites)).To(Equal(1))
-	g.Expect(report.Suites[0].Failures).To(Equal(0))
-	g.Expect(report.Suites[0].Tests).To(Equal(2))
-	g.Expect(len(report.Suites[0].Suites[0].TestCases)).To(Equal(2))
+	rootSuite := report.Suites[0]
+	g.Expect(len(rootSuite.Suites)).To(Equal(1))
+	g.Expect(rootSuite.Suites[0].Failures).To(Equal(0))
+	g.Expect(rootSuite.Suites[0].Tests).To(Equal(2))
+	g.Expect(len(rootSuite.Suites[0].Suites[0].TestCases)).To(Equal(2))
 
-	for _, tt := range report.Suites[0].TestCases {
+	for _, tt := range rootSuite.Suites[0].TestCases {
 		if tt.Name == "_TestRequestRestart" {
 			g.Expect(tt.SkipMessage.Message).To(Equal("Test TestRequestRestart retry count 2 exceed: err: failed to run go test . -test.timeout 50m0s -count 1 --run \"^(TestRequestRestart)\\\\z\" --tags \"request_restart\" --test.v ExitCode: 1"))
 		}

--- a/test/cloudtest/pkg/tests/retest_test.go
+++ b/test/cloudtest/pkg/tests/retest_test.go
@@ -67,7 +67,7 @@ func TestRestartRequest(t *testing.T) {
 	g.Expect(len(report.Suites)).To(Equal(1))
 	g.Expect(report.Suites[0].Failures).To(Equal(1))
 	g.Expect(report.Suites[0].Tests).To(Equal(2))
-	g.Expect(len(report.Suites[0].TestCases)).To(Equal(2))
+	g.Expect(len(report.Suites[0].Suites[0].TestCases)).To(Equal(2))
 
 	logKeeper.CheckMessagesOrder(t, []string{
 		"Starting TestRequestRestart",
@@ -116,10 +116,15 @@ func TestRestartRetestDestroyCluster(t *testing.T) {
 
 	g.Expect(report).NotTo(BeNil())
 
-	g.Expect(len(report.Suites)).To(Equal(1))
-	g.Expect(report.Suites[0].Failures).To(Equal(1))
-	g.Expect(report.Suites[0].Tests).To(Equal(3))
-	g.Expect(len(report.Suites[0].TestCases)).To(Equal(3))
+	g.Expect(len(report.Suites)).To(Equal(2))
+
+	g.Expect(report.Suites[0].Tests).To(Equal(2))
+	g.Expect(report.Suites[0].Failures).To(Equal(0))
+	g.Expect(len(report.Suites[0].Suites[0].TestCases)).To(Equal(2))
+
+	g.Expect(report.Suites[1].Tests).To(Equal(1))
+	g.Expect(report.Suites[1].Failures).To(Equal(1))
+	g.Expect(len(report.Suites[1].TestCases)).To(Equal(1))
 
 	logKeeper.CheckMessagesOrder(t, []string{
 		"Starting TestRequestRestart",
@@ -175,7 +180,7 @@ func TestRestartRequestRestartCluster(t *testing.T) {
 	g.Expect(len(report.Suites)).To(Equal(1))
 	g.Expect(report.Suites[0].Failures).To(Equal(1))
 	g.Expect(report.Suites[0].Tests).To(Equal(2))
-	g.Expect(len(report.Suites[0].TestCases)).To(Equal(2))
+	g.Expect(len(report.Suites[0].Suites[0].TestCases)).To(Equal(2))
 
 	logKeeper.CheckMessagesOrder(t, []string{
 		"Starting TestRequestRestart",
@@ -226,7 +231,7 @@ func TestRestartRequestSkip(t *testing.T) {
 	g.Expect(len(report.Suites)).To(Equal(1))
 	g.Expect(report.Suites[0].Failures).To(Equal(0))
 	g.Expect(report.Suites[0].Tests).To(Equal(2))
-	g.Expect(len(report.Suites[0].TestCases)).To(Equal(2))
+	g.Expect(len(report.Suites[0].Suites[0].TestCases)).To(Equal(2))
 
 	for _, tt := range report.Suites[0].TestCases {
 		if tt.Name == "_TestRequestRestart" {

--- a/test/cloudtest/pkg/tests/retest_test.go
+++ b/test/cloudtest/pkg/tests/retest_test.go
@@ -114,7 +114,7 @@ func TestRestartRetestDestroyCluster(t *testing.T) {
 	testConfig.Reporting.JUnitReportFile = JunitReport
 
 	report, err := commands.PerformTesting(testConfig, &testValidationFactory{}, &commands.Arguments{})
-	g.Expect(err.Error()).To(Equal("there is failed tests 1"))
+	g.Expect(err.Error()).To(Equal("there is failed tests 2"))
 
 	g.Expect(report).NotTo(BeNil())
 
@@ -122,7 +122,7 @@ func TestRestartRetestDestroyCluster(t *testing.T) {
 	g.Expect(len(rootSuite.Suites)).To(Equal(2))
 
 	g.Expect(rootSuite.Suites[0].Tests).To(Equal(2))
-	g.Expect(rootSuite.Suites[0].Failures).To(Equal(0))
+	g.Expect(rootSuite.Suites[0].Failures).To(Equal(1))
 	g.Expect(len(rootSuite.Suites[0].Suites[0].TestCases)).To(Equal(2))
 
 	g.Expect(rootSuite.Suites[1].Tests).To(Equal(1))

--- a/test/cloudtest/pkg/tests/shell_provider_test.go
+++ b/test/cloudtest/pkg/tests/shell_provider_test.go
@@ -80,9 +80,16 @@ func TestShellProvider(t *testing.T) {
 	g.Expect(report).NotTo(BeNil())
 
 	g.Expect(len(report.Suites)).To(Equal(2))
+
 	g.Expect(report.Suites[0].Failures).To(Equal(2))
 	g.Expect(report.Suites[0].Tests).To(Equal(6))
-	g.Expect(len(report.Suites[0].TestCases)).To(Equal(6))
+	g.Expect(len(report.Suites[0].Suites[0].TestCases)).To(Equal(3))
+	g.Expect(len(report.Suites[0].Suites[1].TestCases)).To(Equal(3))
+
+	g.Expect(report.Suites[0].Failures).To(Equal(2))
+	g.Expect(report.Suites[0].Tests).To(Equal(6))
+	g.Expect(len(report.Suites[1].Suites[0].TestCases)).To(Equal(3))
+	g.Expect(len(report.Suites[1].Suites[1].TestCases)).To(Equal(3))
 
 	// Do assertions
 }
@@ -269,10 +276,27 @@ func TestShellProviderShellTest(t *testing.T) {
 
 	g.Expect(report).NotTo(BeNil())
 
-	g.Expect(len(report.Suites)).To(Equal(2))
-	g.Expect(report.Suites[0].Failures).To(Equal(2))
-	g.Expect(report.Suites[0].Tests).To(Equal(5))
-	g.Expect(len(report.Suites[0].TestCases)).To(Equal(5))
+	g.Expect(len(report.Suites)).To(Equal(3))
+
+	for _, executionSuite := range report.Suites {
+		switch executionSuite.Name {
+		case "simple":
+			g.Expect(executionSuite.Failures).To(Equal(2))
+			g.Expect(executionSuite.Tests).To(Equal(6))
+			g.Expect(len(executionSuite.Suites[0].TestCases)).To(Equal(3))
+			g.Expect(len(executionSuite.Suites[1].TestCases)).To(Equal(3))
+		case "simple_shell":
+			g.Expect(executionSuite.Failures).To(Equal(0))
+			g.Expect(executionSuite.Tests).To(Equal(2))
+			g.Expect(len(executionSuite.Suites[0].TestCases)).To(Equal(1))
+			g.Expect(len(executionSuite.Suites[1].TestCases)).To(Equal(1))
+		case "simple_shell_fail":
+			g.Expect(executionSuite.Failures).To(Equal(2))
+			g.Expect(executionSuite.Tests).To(Equal(2))
+			g.Expect(len(executionSuite.Suites[0].TestCases)).To(Equal(1))
+			g.Expect(len(executionSuite.Suites[1].TestCases)).To(Equal(1))
+		}
+	}
 
 	// Do assertions
 }
@@ -317,9 +341,14 @@ func TestUnusedClusterShutdownByMonitor(t *testing.T) {
 	g.Expect(report).NotTo(BeNil())
 
 	g.Expect(len(report.Suites)).To(Equal(2))
+
 	g.Expect(report.Suites[0].Failures).To(Equal(1))
 	g.Expect(report.Suites[0].Tests).To(Equal(3))
-	g.Expect(len(report.Suites[0].TestCases)).To(Equal(3))
+	g.Expect(len(report.Suites[0].Suites[0].TestCases)).To(Equal(3))
+
+	g.Expect(report.Suites[1].Failures).To(Equal(1))
+	g.Expect(report.Suites[1].Tests).To(Equal(3))
+	g.Expect(len(report.Suites[1].Suites[0].TestCases)).To(Equal(3))
 
 	logKeeper.CheckMessagesOrder(t, []string{
 		"All tasks for cluster group a_provider are complete. Starting cluster shutdown",
@@ -383,12 +412,16 @@ func TestMultiClusterTest(t *testing.T) {
 
 	g.Expect(report).NotTo(BeNil())
 
-	g.Expect(len(report.Suites)).To(Equal(4))
-	g.Expect(report.Suites[0].Failures).To(Equal(2))
-	g.Expect(report.Suites[0].Tests).To(Equal(6))
-	g.Expect(report.Suites[1].Tests).To(Equal(0))
+	g.Expect(len(report.Suites)).To(Equal(3))
+
+	g.Expect(report.Suites[0].Failures).To(Equal(1))
+	g.Expect(report.Suites[0].Tests).To(Equal(3))
+
+	g.Expect(report.Suites[1].Failures).To(Equal(1))
+	g.Expect(report.Suites[1].Tests).To(Equal(3))
+
+	g.Expect(report.Suites[2].Failures).To(Equal(1))
 	g.Expect(report.Suites[2].Tests).To(Equal(3))
-	g.Expect(report.Suites[3].Tests).To(Equal(0))
 
 	// Do assertions
 }
@@ -422,7 +455,7 @@ func TestGlobalTimeout(t *testing.T) {
 	g.Expect(len(report.Suites)).To(Equal(1))
 	g.Expect(report.Suites[0].Failures).To(Equal(1))
 	g.Expect(report.Suites[0].Tests).To(Equal(3))
-	g.Expect(len(report.Suites[0].TestCases)).To(Equal(3))
+	g.Expect(len(report.Suites[0].Suites[0].TestCases)).To(Equal(3))
 
 	// Do assertions
 }

--- a/test/cloudtest/pkg/tests/shell_provider_test.go
+++ b/test/cloudtest/pkg/tests/shell_provider_test.go
@@ -79,17 +79,19 @@ func TestShellProvider(t *testing.T) {
 
 	g.Expect(report).NotTo(BeNil())
 
-	g.Expect(len(report.Suites)).To(Equal(2))
+	rootSuite := report.Suites[0]
 
-	g.Expect(report.Suites[0].Failures).To(Equal(2))
-	g.Expect(report.Suites[0].Tests).To(Equal(6))
-	g.Expect(len(report.Suites[0].Suites[0].TestCases)).To(Equal(3))
-	g.Expect(len(report.Suites[0].Suites[1].TestCases)).To(Equal(3))
+	g.Expect(len(rootSuite.Suites)).To(Equal(2))
 
-	g.Expect(report.Suites[0].Failures).To(Equal(2))
-	g.Expect(report.Suites[0].Tests).To(Equal(6))
-	g.Expect(len(report.Suites[1].Suites[0].TestCases)).To(Equal(3))
-	g.Expect(len(report.Suites[1].Suites[1].TestCases)).To(Equal(3))
+	g.Expect(rootSuite.Suites[0].Failures).To(Equal(2))
+	g.Expect(rootSuite.Suites[0].Tests).To(Equal(6))
+	g.Expect(len(rootSuite.Suites[0].Suites[0].TestCases)).To(Equal(3))
+	g.Expect(len(rootSuite.Suites[0].Suites[1].TestCases)).To(Equal(3))
+
+	g.Expect(rootSuite.Suites[0].Failures).To(Equal(2))
+	g.Expect(rootSuite.Suites[0].Tests).To(Equal(6))
+	g.Expect(len(rootSuite.Suites[1].Suites[0].TestCases)).To(Equal(3))
+	g.Expect(len(rootSuite.Suites[1].Suites[1].TestCases)).To(Equal(3))
 
 	// Do assertions
 }
@@ -276,9 +278,11 @@ func TestShellProviderShellTest(t *testing.T) {
 
 	g.Expect(report).NotTo(BeNil())
 
-	g.Expect(len(report.Suites)).To(Equal(3))
+	rootSuite := report.Suites[0]
 
-	for _, executionSuite := range report.Suites {
+	g.Expect(len(rootSuite.Suites)).To(Equal(3))
+
+	for _, executionSuite := range rootSuite.Suites {
 		switch executionSuite.Name {
 		case "simple":
 			g.Expect(executionSuite.Failures).To(Equal(2))
@@ -340,15 +344,17 @@ func TestUnusedClusterShutdownByMonitor(t *testing.T) {
 
 	g.Expect(report).NotTo(BeNil())
 
-	g.Expect(len(report.Suites)).To(Equal(2))
+	rootSuite := report.Suites[0]
 
-	g.Expect(report.Suites[0].Failures).To(Equal(1))
-	g.Expect(report.Suites[0].Tests).To(Equal(3))
-	g.Expect(len(report.Suites[0].Suites[0].TestCases)).To(Equal(3))
+	g.Expect(len(rootSuite.Suites)).To(Equal(2))
 
-	g.Expect(report.Suites[1].Failures).To(Equal(1))
-	g.Expect(report.Suites[1].Tests).To(Equal(3))
-	g.Expect(len(report.Suites[1].Suites[0].TestCases)).To(Equal(3))
+	g.Expect(rootSuite.Suites[0].Failures).To(Equal(1))
+	g.Expect(rootSuite.Suites[0].Tests).To(Equal(3))
+	g.Expect(len(rootSuite.Suites[0].Suites[0].TestCases)).To(Equal(3))
+
+	g.Expect(rootSuite.Suites[1].Failures).To(Equal(1))
+	g.Expect(rootSuite.Suites[1].Tests).To(Equal(3))
+	g.Expect(len(rootSuite.Suites[1].Suites[0].TestCases)).To(Equal(3))
 
 	logKeeper.CheckMessagesOrder(t, []string{
 		"All tasks for cluster group a_provider are complete. Starting cluster shutdown",
@@ -412,16 +418,18 @@ func TestMultiClusterTest(t *testing.T) {
 
 	g.Expect(report).NotTo(BeNil())
 
-	g.Expect(len(report.Suites)).To(Equal(3))
+	rootSuite := report.Suites[0]
 
-	g.Expect(report.Suites[0].Failures).To(Equal(1))
-	g.Expect(report.Suites[0].Tests).To(Equal(3))
+	g.Expect(len(rootSuite.Suites)).To(Equal(3))
 
-	g.Expect(report.Suites[1].Failures).To(Equal(1))
-	g.Expect(report.Suites[1].Tests).To(Equal(3))
+	g.Expect(rootSuite.Suites[0].Failures).To(Equal(1))
+	g.Expect(rootSuite.Suites[0].Tests).To(Equal(3))
 
-	g.Expect(report.Suites[2].Failures).To(Equal(1))
-	g.Expect(report.Suites[2].Tests).To(Equal(3))
+	g.Expect(rootSuite.Suites[1].Failures).To(Equal(1))
+	g.Expect(rootSuite.Suites[1].Tests).To(Equal(3))
+
+	g.Expect(rootSuite.Suites[2].Failures).To(Equal(1))
+	g.Expect(rootSuite.Suites[2].Tests).To(Equal(3))
 
 	// Do assertions
 }
@@ -452,10 +460,12 @@ func TestGlobalTimeout(t *testing.T) {
 
 	g.Expect(report).NotTo(BeNil())
 
-	g.Expect(len(report.Suites)).To(Equal(1))
-	g.Expect(report.Suites[0].Failures).To(Equal(1))
-	g.Expect(report.Suites[0].Tests).To(Equal(3))
-	g.Expect(len(report.Suites[0].Suites[0].TestCases)).To(Equal(3))
+	rootSuite := report.Suites[0]
+
+	g.Expect(len(rootSuite.Suites)).To(Equal(1))
+	g.Expect(rootSuite.Suites[0].Failures).To(Equal(1))
+	g.Expect(rootSuite.Suites[0].Tests).To(Equal(3))
+	g.Expect(len(rootSuite.Suites[0].Suites[0].TestCases)).To(Equal(3))
 
 	// Do assertions
 }


### PR DESCRIPTION
Signed-off-by: Alena Bastrykina <alena.bastrykina@xored.com>

Reorganize junit.xml structure
## Description
In new structure, test suites represent each execution from config, and have nested suites. Tests in nested suites are grouped by cluster type on which they were run. Added a new tag to testcase, it identifies particular cluster instance on which test ran.

[Example 1](https://116978-127937836-gh.circle-artifacts.com/0/home/circleci/project/.tests/cloud_test/results/junit.xml)
[Example 2](https://117140-127937836-gh.circle-artifacts.com/0/home/circleci/project/.tests/cloud_test/results/junit.xml)
<!--- Describe your changes in detail -->

## Motivation and Context
Now test are grouped by clusters, and some interdomain tests  are duplicated.

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [x] Covered by existing integration testing
- [ ] Added integration testing to cover
- [x] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
