### PR TITLE
Add support for Helm 3 in make targets

### DIFF
--- a/.mk/helm.mk
+++ b/.mk/helm.mk
@@ -17,37 +17,31 @@ CHARTS=$(shell ls deployments/helm)
 INSTALL_CHARTS=$(addprefix helm-install-,$(CHARTS))
 DELETE_CHARTS=$(addprefix helm-delete-,$(CHARTS))
 HELM_TIMEOUT?=300
+INSECURE?=false
+PROMETHEUS?=true
+METRICS_COLLECTOR_ENABLED?=true
 
 .PHONY: helm-init
 helm-init:
-	helm init --wait && ./scripts/helm-patch-tiller.sh
+	./scripts/helm-init-wrapper.sh
 
 .PHONY: $(INSTALL_CHARTS)
 $(INSTALL_CHARTS): export CHART=$(subst helm-install-,,$@)
 $(INSTALL_CHARTS):
-	# We specifically set admission-webhook variables here as it is a subchart
-	# there might be a way to set these as global and refer to them with .Values.global.org
-	# but that seems more intrusive than this hack. Consider changing to global if the charts
-	# get even more complicated
-	helm install --name=${CHART} \
-	--atomic --timeout ${HELM_TIMEOUT} \
-	--set org="${CONTAINER_REPO}",tag="${CONTAINER_TAG}" \
-	--set forwardingPlane="${FORWARDING_PLANE}" \
-	--set insecure="${INSECURE}" \
-	--set prometheus="${PROMETHEUS}" \
-	--set metricsCollectorEnabled="${METRICS_COLLECTOR_ENABLED}" \
-	--set global.JaegerTracing="true" \
-	--set spire.enabled="${SPIRE_ENABLED}",spire.org="${CONTAINER_REPO}",spire.tag="${CONTAINER_TAG}" \
-	--set admission-webhook.org="${CONTAINER_REPO}",admission-webhook.tag="${CONTAINER_TAG}" \
-	--set prefix-service.org="${CONTAINER_REPO}",prefix-service.tag="${CONTAINER_TAG}" \
-	--namespace="${NSM_NAMESPACE}" \
-	deployments/helm/${CHART}
+	./scripts/helm-nsm-install.sh --chart ${CHART} \
+	--container_repo ${CONTAINER_REPO} \
+	--container_tag ${CONTAINER_TAG} \
+	--forwarding_plane ${FORWARDING_PLANE} \
+	--insecure ${INSECURE} \
+	--enable_prometheus ${PROMETHEUS} \
+	--enable_metric_collection ${METRICS_COLLECTOR_ENABLED} \
+	--nsm_namespace ${NSM_NAMESPACE}
 
 .PHONY: $(DELETE_CHARTS)
 $(DELETE_CHARTS): export CHART=$(subst helm-delete-,,$@)
 $(DELETE_CHARTS):
-	helm delete --purge ${CHART} || true
+	./scripts/helm-nsm-uninstall.sh --nsm_namespace ${NSM_NAMESPACE} --chart ${CHART} || true
 
 .PHONY: helm-delete
 helm-delete:
-	helm list --namespace="${NSM_NAMESPACE}" --short | xargs -L1 helm delete --purge
+	./scripts/helm-nsm-uninstall.sh --nsm_namespace ${NSM_NAMESPACE} --all

--- a/scripts/helm-init-wrapper.sh
+++ b/scripts/helm-init-wrapper.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# A script to insulate users from differences between Helm 2 and 3. In Helm 3
+# there is no init and no tiller, so when using Helm 3 we simply skip these
+# steps.
+
+HELM_VERSION=$(helm version | awk -v FS="(Ver\"|\")" '{print$ 2}')
+
+
+if [[ $HELM_VERSION = v2* ]]
+then
+  helm init --wait && ./scripts/helm-patch-tiller.sh
+elif [[ $HELM_VERSION = v3* ]]
+then
+  echo "Using Helm 3, skipping 'helm init'..."
+else
+  echo "Unsupported helm version: $HELM_VERSION"
+fi
+

--- a/scripts/helm-nsm-install.sh
+++ b/scripts/helm-nsm-install.sh
@@ -1,0 +1,204 @@
+#!/bin/bash
+
+# A script for wrapping NSM installation via Helm. Both Helm 2 and Helm 3 are
+# supported.
+
+
+function with_helm_2 () {
+  # We specifically set admission-webhook variables here as it is a subchart
+  # there might be a way to set these as global and refer to them with .Values.global.org
+  # but that seems more intrusive than this hack. Consider changing to global if the charts
+  # get even more complicated
+  echo -n "Performing chart installation..."
+  helm install --name="$CHART" \
+  --atomic --timeout 300 \
+  --set org="$CONTAINER_REPO",tag="$CONTAINER_TAG" \
+  --set forwardingPlane="$FORWARDING_PLANE" \
+  --set insecure="$INSECURE" \
+  --set prometheus="${PROMETHEUS}" \
+  --set metricsCollectorEnabled="${METRICS_COLLECTOR_ENABLED}" \
+  --set global.JaegerTracing="true" \
+  --set spire.enabled="$SPIRE_ENABLED",spire.org="$CONTAINER_REPO",spire.tag="$CONTAINER_TAG" \
+  --set admission-webhook.org="$CONTAINER_REPO",admission-webhook.tag="$CONTAINER_TAG" \
+  --set prefix-service.org="$CONTAINER_REPO",prefix-service.tag="$CONTAINER_TAG" \
+  --namespace="$NSM_NAMESPACE" \
+  deployments/helm/"$CHART" &
+  PID=$!
+  sleep 2
+  while ps -p ${PID} > /dev/null;
+  do
+    printf "."
+    sleep 2
+  done
+  echo "Done"
+}
+
+function with_helm_3 () {
+  # Ensure we have the nsm namespace available
+  echo -n "Ensure namespace $NSM_NAMESPACE exists..."
+  kubectl apply -f k8s/conf/namespace-nsm.yaml &
+  PID=$!
+  sleep 2
+  while ps -p ${PID} > /dev/null;
+  do
+    printf "."
+    sleep 2
+  done
+  echo "Done"
+
+  # We specifically set admission-webhook variables here as it is a subchart
+  # there might be a way to set these as global and refer to them with .Values.global.org
+  # but that seems more intrusive than this hack. Consider changing to global if the charts
+  # get even more complicated
+  echo -n "Performing chart installation..."
+  helm install "$CHART" \
+  --atomic --timeout 5m \
+  --set org="$CONTAINER_REPO",tag="$CONTAINER_TAG" \
+  --set forwardingPlane="$FORWARDING_PLANE" \
+  --set insecure="$INSECURE" \
+  --set prometheus="${PROMETHEUS}" \
+  --set metricsCollectorEnabled="${METRICS_COLLECTOR_ENABLED}" \
+  --set global.JaegerTracing="true" \
+  --set spire.enabled="$SPIRE_ENABLED",spire.org="$CONTAINER_REPO",spire.tag="$CONTAINER_TAG" \
+  --set admission-webhook.org="$CONTAINER_REPO",admission-webhook.tag="$CONTAINER_TAG" \
+  --set prefix-service.org="$CONTAINER_REPO",prefix-service.tag="$CONTAINER_TAG" \
+  --namespace "$NSM_NAMESPACE" \
+  deployments/helm/"$CHART" &
+  PID=$!
+  sleep 2
+  while ps -p ${PID} > /dev/null;
+  do
+    printf "."
+    sleep 2
+  done
+  echo "Done"
+}
+
+function usage () {
+  echo "Usage: $0 [flags]"
+  echo "Available flags:"
+  FLAGS="--chart [chart],Chart name. Defaults to value of CHART
+--container_repo [repo URI],Container repository. Defaults to value of CONTAINER_REPO
+--container_tag [tag],Container tag. Defaults to value of CONTAINER_TAG
+--forwarding_plane [forwarding plane],NSM forwarding plane to use. Defaults to value of FORWARDING_PLANE
+--insecure [true|false],Defaults to value of INSECURE
+--nsm_namespace [namespace],Name of the NSM namespace. Defaults to value of NSM_NAMESPACE
+--spire_enabled [true|false],Defaults to value of SPIRE_ENABLED
+-h | --help,Display usage"
+
+echo -e "$FLAGS" | column -t --separator ","
+}
+
+function check_flags () {
+  SHOW_USAGE=0
+  if [ -z ${CHART+x} ]; then
+    echo "CHART is not set, use --chart or set a value for it."
+    SHOW_USAGE=1
+  fi
+  if [ -z ${CONTAINER_REPO+x} ]; then
+    echo "CONTAINER_REPO is not set, use --container_repo or set a value for it."
+    SHOW_USAGE=1
+  fi
+  if [ -z ${CONTAINER_TAG+x} ]; then
+    echo "CONTAINER_TAG is not set, use --container_tag or set a value for it."
+    SHOW_USAGE=1
+  fi
+  if [ -z ${INSECURE+x} ]; then
+    echo "INSECURE is not set, use --insecure or set a value for it."
+    SHOW_USAGE=1
+  fi
+  if [ -z ${FORWARDING_PLANE+x} ]; then
+    echo "FORWARDING_PLANE is not set, use --forwarding_plane or set a value for it."
+    SHOW_USAGE=1
+  fi
+  if [ -z ${NSM_NAMESPACE+x} ]; then
+    echo "NSM_NAMESPACE is not set, use --nsm_namespace or set a value for it."
+    SHOW_USAGE=1
+  fi
+  if [ -z ${PROMETHEUS+x} ]; then
+    echo "PROMETHEUS is not set, use --enable_prometheus or set a value for it."
+    SHOW_USAGE=1
+  fi
+  if [ -z ${METRICS_COLLECTOR_ENABLED+x} ]; then
+    echo "METRICS_COLLECTOR_ENABLED is not set, use --enable_metric_collection or set a value for it."
+    SHOW_USAGE=1
+  fi
+  if [ $SHOW_USAGE -ne 0 ]; then
+    usage
+    exit 1
+  fi
+}
+
+while [[ $# -gt 0 ]]
+do
+key="$1"
+
+case $key in
+    --chart)
+    CHART="$2"
+    shift
+    shift
+    ;;
+    --container_repo)
+    CONTAINER_REPO="$2"
+    shift
+    shift
+    ;;
+    --container_tag)
+    CONTAINER_TAG="$2"
+    shift
+    shift
+    ;;
+    --insecure)
+    INSECURE="$2"
+    shift
+    shift
+    ;;
+    --forwarding_plane)
+    FORWARDING_PLANE="$2"
+    shift
+    shift
+    ;;
+    --nsm_namespace)
+    NSM_NAMESPACE="$2"
+    shift
+    shift
+    ;;
+    --enable_prometheus)
+    PROMETHEUS="$2"
+    shift
+    shift
+    ;;
+    --enable_metric_collection)
+    METRICS_COLLECTOR_ENABLED="$2"
+    shift
+    shift
+    ;;
+    -h|--help)
+    usage
+    exit
+    ;;
+    *)
+    shift
+    ;;
+esac
+done
+
+
+if ! command -v helm > /dev/null; then
+  echo "Unable to locate helm client"
+  exit 1
+fi
+
+HELM_VERSION=$(helm version 2> /dev/null | awk -v FS="(Ver\"|\")" '{print$ 2}')
+check_flags
+
+if [[ $HELM_VERSION = v2* ]]
+then
+  with_helm_2
+elif [[ $HELM_VERSION = v3* ]]
+then
+  with_helm_3
+else
+  echo "Unsupported helm version: $HELM_VERSION"
+fi

--- a/scripts/helm-nsm-uninstall.sh
+++ b/scripts/helm-nsm-uninstall.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+
+# A script for wrapping NSM clenaup via Helm. Both Helm 2 and Helm 3 are
+# supported.
+
+function usage () {
+  echo "Usage: $0 --nsm_namespace <namespace> [--char <chart name> | --all | --help]"
+}
+
+function check_flags () {
+  SHOW_USAGE=0
+  if [ -z ${NSM_NAMESPACE+x} ]; then
+    echo "--nsm_namespace is required."
+    SHOW_USAGE=1
+  fi
+  if [ -z "${CHART+set}" ] && [ -z "${NSM_PURGE+set}" ]; then
+    echo "One of --chart or --all is required."
+    SHOW_USAGE=1
+  fi
+  if [ -n "${CHART+set}" ] && [ -n "${NSM_PURGE}" ]; then
+    echo "--chart and --all cannot be used together."
+    SHOW_USAGE=1
+  fi
+  if [ $SHOW_USAGE -ne 0 ]; then
+    usage
+    exit 1
+  fi
+}
+
+
+with_helm2() {
+  if [ -z ${NSM_PURGE+x} ]; then
+    helm list | xargs -L1 helm delete --purge
+  else
+     helm delete --purge "${CHART}"
+  fi
+}
+
+with_helm3() {
+  if [ -z ${NSM_PURGE+x} ]; then
+    helm list -n "${NSM_NAMESPACE}" --short | xargs -L1 helm uninstall -n "${NSM_NAMESPACE}"
+  else
+     helm uninstall -n "$NSM_NAMESPACE" "${CHART}"
+  fi
+}
+
+while [[ $# -gt 0 ]]
+do
+key="$1"
+case $key in
+    --chart)
+    CHART="$2"
+    shift
+    shift
+    ;;
+    --nsm_namespace)
+    NSM_NAMESPACE="$2"
+    shift
+    shift
+    ;;
+    --all)
+    NSM_PURGE=true
+    shift
+    ;;
+    -h|--help)
+    usage
+    exit
+    ;;
+    *)
+    shift
+    ;;
+esac
+done
+
+check_flags
+HELM_VERSION=$(helm version 2> /dev/null | awk -v FS="(Ver\"|\")" '{print$ 2}')
+
+echo "Cleaning up NSM"
+
+if [[ $HELM_VERSION = v2* ]]
+then
+  with_helm2
+elif [[ $HELM_VERSION = v3* ]]
+then
+  with_helm3
+else
+  echo "Unsupported helm version: $HELM_VERSION"
+fi


### PR DESCRIPTION
This change adds support for Helm 3 while ensuring backward compatibility
with Helm 2. To accomplish this, affected make targets now invoke
wrapper scripts that determine the version of Helm available and invoke
helm accordingly.

Signed-off-by: Ryan Tidwell <rtidwell@suse.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
* Introduce wrapper scripts for the 'helm init' step and the NSM install steps. These scripts check the version of the helm client available and proceed accordingly.
* Change .mk/helm.mk to invoke wrapper scripts so that makefiles are insulated from the differences in helm versions.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
With the recent availability of Helm 3 and support for Helm 2 disappearing in about a year, a little housekeeping to ensure compatibility with Helm 3 is in order. See #1950 

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [ ] Covered by existing integration testing
- [ ] Added integration testing to cover
- [x] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
