### PR TITLE
Call downstream resync on failed vpp-agent update

### DIFF
--- a/forwarder/vppagent/pkg/vppagent/vppagent.go
+++ b/forwarder/vppagent/pkg/vppagent/vppagent.go
@@ -52,6 +52,7 @@ const (
 type VPPAgent struct {
 	metricsCollector *MetricsCollector
 	common           *common.ForwarderConfig
+	downstreamResync func()
 }
 
 func CreateVPPAgent() *VPPAgent {
@@ -67,7 +68,7 @@ func (v *VPPAgent) CreateForwarderServer(config *common.ForwarderConfig) forward
 		sdk.Connect(v.endpoint()),
 		sdk.KernelInterfaces(config.NSMBaseDir),
 		sdk.ClearMechanisms(config.NSMBaseDir),
-		sdk.Commit())
+		sdk.Commit(v.downstreamResync))
 }
 
 // MonitorMechanisms sends mechanism updates
@@ -277,6 +278,8 @@ func (v *VPPAgent) configureVPPAgent() error {
 	if kvSchedulerClient, err = kvschedclient.NewKVSchedulerClient(v.endpoint()); err != nil {
 		return err
 	}
+
+	v.downstreamResync = kvSchedulerClient.DownstreamResync
 	common.CreateNSMonitor(v.common.Monitor, kvSchedulerClient.DownstreamResync)
 
 	v.common.MechanismsUpdateChannel = make(chan *common.Mechanisms, 1)


### PR DESCRIPTION
Signed-off-by: Artem Belov <artem.belov@xored.com>

## Description
Call downstream resync on failed vpp-agent update

## Motivation and Context
Failed vpp-agent update might be the cause of vpp - vppagent desynchronization
#853 
```
time="2019-12-02T11:00:21Z" level=warning msg="VPP health check probe timed out after 250ms (1. timeout)"
time="2019-12-02 11:00:22.03173" level=error msg="no reply received within the timeout period 1s" loc="descriptor/interface_crud.go(27)" logger=vpp-ifplugin.if-descriptor
time="2019-12-02T11:00:22Z" level=warning msg="Received reply to an already closed binary API request" seqNum=28
time="2019-12-02T11:00:22Z" level=warning msg="ignoring received reply: &{seqNum:28 msgID:56 data:[0 56 0 6 0 28 0 0 0 0 0 0 0 2] lastReceived:false err:<nil>} (expecting: vxlan_add_del_tunnel_reply)" channel=3 expSeqNum=29
```

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [ ] Covered by existing integration testing
- [ ] Added integration testing to cover
- [x] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
