### PR TITLE
Rename config env

### DIFF
--- a/controlplane/pkg/tests/nsmd_registry_test.go
+++ b/controlplane/pkg/tests/nsmd_registry_test.go
@@ -23,10 +23,10 @@ func TestNSMDRestart1(t *testing.T) {
 	reply := srv.RequestNSM("nsm-1")
 
 	configuration := (&common.NSConfiguration{
-		Workspace:        reply.Workspace,
-		NsmServerSocket:  reply.ClientBaseDir + reply.Workspace + "/" + reply.NsmServerSocket,
-		NsmClientSocket:  reply.ClientBaseDir + reply.Workspace + "/" + reply.NsmClientSocket,
-		AdvertiseNseName: "test_nse",
+		Workspace:              reply.Workspace,
+		NsmServerSocket:        reply.ClientBaseDir + reply.Workspace + "/" + reply.NsmServerSocket,
+		NsmClientSocket:        reply.ClientBaseDir + reply.Workspace + "/" + reply.NsmClientSocket,
+		EndpointNetworkService: "test_nse",
 	}).FromEnv()
 
 	composite := endpoint.NewCompositeEndpoint(

--- a/deployments/helm/icmp-responder/templates/icmp-responder-nse.tpl
+++ b/deployments/helm/icmp-responder/templates/icmp-responder-nse.tpl
@@ -34,7 +34,7 @@ spec:
           command: ["/bin/icmp-responder-nse"]
           imagePullPolicy: {{ .Values.pullPolicy }}
           env:
-            - name: ADVERTISE_NSE_NAME
+            - name: ENDPOINT_NETWORK_SERVICE
               value: "icmp-responder"
             - name: ADVERTISE_NSE_LABELS
               value: "app=icmp-responder"

--- a/deployments/helm/icmp-responder/templates/icmp-responder-nse.tpl
+++ b/deployments/helm/icmp-responder/templates/icmp-responder-nse.tpl
@@ -36,7 +36,7 @@ spec:
           env:
             - name: ENDPOINT_NETWORK_SERVICE
               value: "icmp-responder"
-            - name: ADVERTISE_NSE_LABELS
+            - name: ENDPOINT_LABELS
               value: "app=icmp-responder"
             - name: TRACER_ENABLED
               value: "true"

--- a/deployments/helm/vpn/templates/vpn-gateway-nse.tpl
+++ b/deployments/helm/vpn/templates/vpn-gateway-nse.tpl
@@ -32,7 +32,7 @@ spec:
           env:
             - name: ENDPOINT_NETWORK_SERVICE
               value: "secure-intranet-connectivity"
-            - name: ADVERTISE_NSE_LABELS
+            - name: ENDPOINT_LABELS
               value: "app=vpn-gateway"
             - name: IP_ADDRESS
               value: "172.16.1.0/24"

--- a/deployments/helm/vpn/templates/vpn-gateway-nse.tpl
+++ b/deployments/helm/vpn/templates/vpn-gateway-nse.tpl
@@ -30,7 +30,7 @@ spec:
           command: ["/bin/icmp-responder-nse"]
           imagePullPolicy: {{ .Values.pullPolicy }}
           env:
-            - name: ADVERTISE_NSE_NAME
+            - name: ENDPOINT_NETWORK_SERVICE
               value: "secure-intranet-connectivity"
             - name: ADVERTISE_NSE_LABELS
               value: "app=vpn-gateway"

--- a/deployments/helm/vpn/templates/vppagent-firewall-nse.tpl
+++ b/deployments/helm/vpn/templates/vppagent-firewall-nse.tpl
@@ -27,7 +27,7 @@ spec:
               value: "app=firewall"
             - name: CLIENT_NETWORK_SERVICE
               value: "secure-intranet-connectivity"
-            - name: OUTGOING_NSC_LABELS
+            - name: CLIENT_LABELS
               value: "app=firewall"
 {{- if .Values.global.JaegerTracing }}
             - name: TRACER_ENABLED

--- a/deployments/helm/vpn/templates/vppagent-firewall-nse.tpl
+++ b/deployments/helm/vpn/templates/vppagent-firewall-nse.tpl
@@ -21,7 +21,7 @@ spec:
           env:
             - name: TEST_APPLICATION
               value: "vppagent-firewall-nse"
-            - name: ADVERTISE_NSE_NAME
+            - name: ENDPOINT_NETWORK_SERVICE
               value: "secure-intranet-connectivity"
             - name: ADVERTISE_NSE_LABELS
               value: "app=firewall"

--- a/deployments/helm/vpn/templates/vppagent-firewall-nse.tpl
+++ b/deployments/helm/vpn/templates/vppagent-firewall-nse.tpl
@@ -23,7 +23,7 @@ spec:
               value: "vppagent-firewall-nse"
             - name: ENDPOINT_NETWORK_SERVICE
               value: "secure-intranet-connectivity"
-            - name: ADVERTISE_NSE_LABELS
+            - name: ENDPOINT_LABELS
               value: "app=firewall"
             - name: OUTGOING_NSC_NAME
               value: "secure-intranet-connectivity"

--- a/deployments/helm/vpn/templates/vppagent-firewall-nse.tpl
+++ b/deployments/helm/vpn/templates/vppagent-firewall-nse.tpl
@@ -25,7 +25,7 @@ spec:
               value: "secure-intranet-connectivity"
             - name: ENDPOINT_LABELS
               value: "app=firewall"
-            - name: OUTGOING_NSC_NAME
+            - name: CLIENT_NETWORK_SERVICE
               value: "secure-intranet-connectivity"
             - name: OUTGOING_NSC_LABELS
               value: "app=firewall"

--- a/deployments/helm/vpn/templates/vppagent-passthrough-nse.tpl
+++ b/deployments/helm/vpn/templates/vppagent-passthrough-nse.tpl
@@ -25,7 +25,7 @@ spec:
               value: "secure-intranet-connectivity"
             - name: ENDPOINT_LABELS
               value: "app=passthrough-1"
-            - name: OUTGOING_NSC_NAME
+            - name: CLIENT_NETWORK_SERVICE
               value: "secure-intranet-connectivity"
             - name: OUTGOING_NSC_LABELS
               value: "app=passthrough-1"
@@ -70,7 +70,7 @@ spec:
               value: "secure-intranet-connectivity"
             - name: ENDPOINT_LABELS
               value: "app=passthrough-2"
-            - name: OUTGOING_NSC_NAME
+            - name: CLIENT_NETWORK_SERVICE
               value: "secure-intranet-connectivity"
             - name: OUTGOING_NSC_LABELS
               value: "app=passthrough-2"
@@ -109,7 +109,7 @@ spec:
               value: "secure-intranet-connectivity"
             - name: ENDPOINT_LABELS
               value: "app=passthrough-3"
-            - name: OUTGOING_NSC_NAME
+            - name: CLIENT_NETWORK_SERVICE
               value: "secure-intranet-connectivity"
             - name: OUTGOING_NSC_LABELS
               value: "app=passthrough-3"

--- a/deployments/helm/vpn/templates/vppagent-passthrough-nse.tpl
+++ b/deployments/helm/vpn/templates/vppagent-passthrough-nse.tpl
@@ -27,7 +27,7 @@ spec:
               value: "app=passthrough-1"
             - name: CLIENT_NETWORK_SERVICE
               value: "secure-intranet-connectivity"
-            - name: OUTGOING_NSC_LABELS
+            - name: CLIENT_LABELS
               value: "app=passthrough-1"
 {{- if .Values.global.JaegerTracing }}
             - name: TRACER_ENABLED
@@ -72,7 +72,7 @@ spec:
               value: "app=passthrough-2"
             - name: CLIENT_NETWORK_SERVICE
               value: "secure-intranet-connectivity"
-            - name: OUTGOING_NSC_LABELS
+            - name: CLIENT_LABELS
               value: "app=passthrough-2"
             - name: TRACER_ENABLED
               value: "true"
@@ -111,7 +111,7 @@ spec:
               value: "app=passthrough-3"
             - name: CLIENT_NETWORK_SERVICE
               value: "secure-intranet-connectivity"
-            - name: OUTGOING_NSC_LABELS
+            - name: CLIENT_LABELS
               value: "app=passthrough-3"
             - name: TRACER_ENABLED
               value: "true"

--- a/deployments/helm/vpn/templates/vppagent-passthrough-nse.tpl
+++ b/deployments/helm/vpn/templates/vppagent-passthrough-nse.tpl
@@ -23,7 +23,7 @@ spec:
               value: "vppagent-firewall-nse"
             - name: ENDPOINT_NETWORK_SERVICE
               value: "secure-intranet-connectivity"
-            - name: ADVERTISE_NSE_LABELS
+            - name: ENDPOINT_LABELS
               value: "app=passthrough-1"
             - name: OUTGOING_NSC_NAME
               value: "secure-intranet-connectivity"
@@ -68,7 +68,7 @@ spec:
               value: "vppagent-firewall-nse"
             - name: ENDPOINT_NETWORK_SERVICE
               value: "secure-intranet-connectivity"
-            - name: ADVERTISE_NSE_LABELS
+            - name: ENDPOINT_LABELS
               value: "app=passthrough-2"
             - name: OUTGOING_NSC_NAME
               value: "secure-intranet-connectivity"
@@ -107,7 +107,7 @@ spec:
               value: "vppagent-firewall-nse"
             - name: ENDPOINT_NETWORK_SERVICE
               value: "secure-intranet-connectivity"
-            - name: ADVERTISE_NSE_LABELS
+            - name: ENDPOINT_LABELS
               value: "app=passthrough-3"
             - name: OUTGOING_NSC_NAME
               value: "secure-intranet-connectivity"

--- a/deployments/helm/vpn/templates/vppagent-passthrough-nse.tpl
+++ b/deployments/helm/vpn/templates/vppagent-passthrough-nse.tpl
@@ -21,7 +21,7 @@ spec:
           env:
             - name: TEST_APPLICATION
               value: "vppagent-firewall-nse"
-            - name: ADVERTISE_NSE_NAME
+            - name: ENDPOINT_NETWORK_SERVICE
               value: "secure-intranet-connectivity"
             - name: ADVERTISE_NSE_LABELS
               value: "app=passthrough-1"
@@ -66,7 +66,7 @@ spec:
           env:
             - name: TEST_APPLICATION
               value: "vppagent-firewall-nse"
-            - name: ADVERTISE_NSE_NAME
+            - name: ENDPOINT_NETWORK_SERVICE
               value: "secure-intranet-connectivity"
             - name: ADVERTISE_NSE_LABELS
               value: "app=passthrough-2"
@@ -105,7 +105,7 @@ spec:
           env:
             - name: TEST_APPLICATION
               value: "vppagent-firewall-nse"
-            - name: ADVERTISE_NSE_NAME
+            - name: ENDPOINT_NETWORK_SERVICE
               value: "secure-intranet-connectivity"
             - name: ADVERTISE_NSE_LABELS
               value: "app=passthrough-3"

--- a/deployments/helm/vpp-icmp-responder/templates/vpp-icmp-responder-nsc.tpl
+++ b/deployments/helm/vpp-icmp-responder/templates/vpp-icmp-responder-nsc.tpl
@@ -22,7 +22,7 @@ spec:
           env:
             - name: TEST_APPLICATION
               value: "vppagent-nsc"
-            - name: OUTGOING_NSC_LABELS
+            - name: CLIENT_LABELS
               value: "app=icmp"
             - name: CLIENT_NETWORK_SERVICE
               value: "icmp-responder"

--- a/deployments/helm/vpp-icmp-responder/templates/vpp-icmp-responder-nsc.tpl
+++ b/deployments/helm/vpp-icmp-responder/templates/vpp-icmp-responder-nsc.tpl
@@ -24,7 +24,7 @@ spec:
               value: "vppagent-nsc"
             - name: OUTGOING_NSC_LABELS
               value: "app=icmp"
-            - name: OUTGOING_NSC_NAME
+            - name: CLIENT_NETWORK_SERVICE
               value: "icmp-responder"
           resources:
             limits:

--- a/deployments/helm/vpp-icmp-responder/templates/vpp-icmp-responder-nse.tpl
+++ b/deployments/helm/vpp-icmp-responder/templates/vpp-icmp-responder-nse.tpl
@@ -37,7 +37,7 @@ spec:
               value: "vppagent-icmp-responder-nse"
             - name: ENDPOINT_NETWORK_SERVICE
               value: "icmp-responder"
-            - name: ADVERTISE_NSE_LABELS
+            - name: ENDPOINT_LABELS
               value: "app=icmp-responder"
             - name: IP_ADDRESS
               value: "10.30.1.0/24"

--- a/deployments/helm/vpp-icmp-responder/templates/vpp-icmp-responder-nse.tpl
+++ b/deployments/helm/vpp-icmp-responder/templates/vpp-icmp-responder-nse.tpl
@@ -35,7 +35,7 @@ spec:
           env:
             - name: TEST_APPLICATION
               value: "vppagent-icmp-responder-nse"
-            - name: ADVERTISE_NSE_NAME
+            - name: ENDPOINT_NETWORK_SERVICE
               value: "icmp-responder"
             - name: ADVERTISE_NSE_LABELS
               value: "app=icmp-responder"

--- a/k8s/conf/vppagent-passthrough-nse.yaml
+++ b/k8s/conf/vppagent-passthrough-nse.yaml
@@ -25,7 +25,7 @@ spec:
               value: "secure-intranet-connectivity"
             - name: ENDPOINT_LABELS
               value: "app=passthrough-1"
-            - name: OUTGOING_NSC_NAME
+            - name: CLIENT_NETWORK_SERVICE
               value: "secure-intranet-connectivity"
             - name: OUTGOING_NSC_LABELS
               value: "app=passthrough-1"
@@ -64,7 +64,7 @@ spec:
               value: "secure-intranet-connectivity"
             - name: ENDPOINT_LABELS
               value: "app=passthrough-2"
-            - name: OUTGOING_NSC_NAME
+            - name: CLIENT_NETWORK_SERVICE
               value: "secure-intranet-connectivity"
             - name: OUTGOING_NSC_LABELS
               value: "app=passthrough-2"
@@ -103,7 +103,7 @@ spec:
               value: "secure-intranet-connectivity"
             - name: ENDPOINT_LABELS
               value: "app=passthrough-3"
-            - name: OUTGOING_NSC_NAME
+            - name: CLIENT_NETWORK_SERVICE
               value: "secure-intranet-connectivity"
             - name: OUTGOING_NSC_LABELS
               value: "app=passthrough-3"

--- a/k8s/conf/vppagent-passthrough-nse.yaml
+++ b/k8s/conf/vppagent-passthrough-nse.yaml
@@ -21,7 +21,7 @@ spec:
           env:
             - name: TEST_APPLICATION
               value: "vppagent-firewall-nse"
-            - name: ADVERTISE_NSE_NAME
+            - name: ENDPOINT_NETWORK_SERVICE
               value: "secure-intranet-connectivity"
             - name: ADVERTISE_NSE_LABELS
               value: "app=passthrough-1"
@@ -60,7 +60,7 @@ spec:
           env:
             - name: TEST_APPLICATION
               value: "vppagent-firewall-nse"
-            - name: ADVERTISE_NSE_NAME
+            - name: ENDPOINT_NETWORK_SERVICE
               value: "secure-intranet-connectivity"
             - name: ADVERTISE_NSE_LABELS
               value: "app=passthrough-2"
@@ -99,7 +99,7 @@ spec:
           env:
             - name: TEST_APPLICATION
               value: "vppagent-firewall-nse"
-            - name: ADVERTISE_NSE_NAME
+            - name: ENDPOINT_NETWORK_SERVICE
               value: "secure-intranet-connectivity"
             - name: ADVERTISE_NSE_LABELS
               value: "app=passthrough-3"

--- a/k8s/conf/vppagent-passthrough-nse.yaml
+++ b/k8s/conf/vppagent-passthrough-nse.yaml
@@ -23,7 +23,7 @@ spec:
               value: "vppagent-firewall-nse"
             - name: ENDPOINT_NETWORK_SERVICE
               value: "secure-intranet-connectivity"
-            - name: ADVERTISE_NSE_LABELS
+            - name: ENDPOINT_LABELS
               value: "app=passthrough-1"
             - name: OUTGOING_NSC_NAME
               value: "secure-intranet-connectivity"
@@ -62,7 +62,7 @@ spec:
               value: "vppagent-firewall-nse"
             - name: ENDPOINT_NETWORK_SERVICE
               value: "secure-intranet-connectivity"
-            - name: ADVERTISE_NSE_LABELS
+            - name: ENDPOINT_LABELS
               value: "app=passthrough-2"
             - name: OUTGOING_NSC_NAME
               value: "secure-intranet-connectivity"
@@ -101,7 +101,7 @@ spec:
               value: "vppagent-firewall-nse"
             - name: ENDPOINT_NETWORK_SERVICE
               value: "secure-intranet-connectivity"
-            - name: ADVERTISE_NSE_LABELS
+            - name: ENDPOINT_LABELS
               value: "app=passthrough-3"
             - name: OUTGOING_NSC_NAME
               value: "secure-intranet-connectivity"

--- a/k8s/conf/vppagent-passthrough-nse.yaml
+++ b/k8s/conf/vppagent-passthrough-nse.yaml
@@ -27,7 +27,7 @@ spec:
               value: "app=passthrough-1"
             - name: CLIENT_NETWORK_SERVICE
               value: "secure-intranet-connectivity"
-            - name: OUTGOING_NSC_LABELS
+            - name: CLIENT_LABELS
               value: "app=passthrough-1"
             - name: TRACER_ENABLED
               value: "true"
@@ -66,7 +66,7 @@ spec:
               value: "app=passthrough-2"
             - name: CLIENT_NETWORK_SERVICE
               value: "secure-intranet-connectivity"
-            - name: OUTGOING_NSC_LABELS
+            - name: CLIENT_LABELS
               value: "app=passthrough-2"
             - name: TRACER_ENABLED
               value: "true"
@@ -105,7 +105,7 @@ spec:
               value: "app=passthrough-3"
             - name: CLIENT_NETWORK_SERVICE
               value: "secure-intranet-connectivity"
-            - name: OUTGOING_NSC_LABELS
+            - name: CLIENT_LABELS
               value: "app=passthrough-3"
             - name: TRACER_ENABLED
               value: "true"

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -32,7 +32,7 @@ type NSConfiguration struct {
     EndpointNetworkService   string // ENDPOINT_NETWORK_SERVICE
     ClientNetworkService    string // CLIENT_NETWORK_SERVICE
     EndpointLabels string // ENDPOINT_LABELS
-    OutgoingNscLabels  string // OUTGOING_NSC_LABELS
+    ClientLabels  string // CLIENT_LABELS
     NscInterfaceName   string // NSC_INTERFACE_NAME
     MechanismType      string // MECHANISM_TYPE
     IPAddress          string // IP_ADDRESS
@@ -48,7 +48,7 @@ Note that some of the members of this structure can be initialized through the e
 * `EndpointNetworkService` - [ `ENDPOINT_NETWORK_SERVICE` ], the *Network Service* name that the *Endpoint* implements, as advertised to the NS registry
 * `ClientNetworkService` - [ `CLIENT_NETWORK_SERVICE` ], the *Network Service* name, as the *Client* asks for it from the *NSMgr*
 * `EndpointLabels` - [ `ENDPOINT_LABELS` ], the *Endpoint* labels, as advertised to the NS registry. Used in *NSMgr* selector to match the DestinationSelector. The format is `label1=value1,label2=value2`
-* `OutgoingNscLabels` - [ `OUTGOING_NSC_LABELS` ], the *endpoint* labels, as send by the *client* . Used in *NSMgr* selector to match the SourceSelector. The format is the same as `EndpointLabels`
+* `ClientLabels` - [ `CLIENT_LABELS` ], the *endpoint* labels, as send by the *client* . Used in *NSMgr* selector to match the SourceSelector. The format is the same as `EndpointLabels`
 * `NscInterfaceName` - [ `NSC_INTERFACE_NAME` ], the name off th interface as injected on the client side
 * `MechanismType` - [ `MECHANISM_TYPE` ], enforce a particular Mechanism type. Currently `kernel` or `mem`. Defaults to `kernel`
 * `IPAddress` - [ `IP_ADDRESS` ], the IP network to initialize a prefix pool in the IPAM composite

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -29,7 +29,7 @@ type NSConfiguration struct {
     NsmServerSocket    string
     NsmClientSocket    string
     Workspace          string
-    AdvertiseNseName   string // ADVERTISE_NSE_NAME
+    EndpointNetworkService   string // ENDPOINT_NETWORK_SERVICE
     OutgoingNscName    string // OUTGOING_NSC_NAME
     AdvertiseNseLabels string // ADVERTISE_NSE_LABELS
     OutgoingNscLabels  string // OUTGOING_NSC_LABELS
@@ -45,7 +45,7 @@ Note that some of the members of this structure can be initialized through the e
 * `NsmServerSocket` - [ *system* ], NS manager communication socket
 * `NsmClientSocket` - [ *system* ], NS manager communication socket
 * `Workspace` - [ *system* ], Kubernetes Pod namespace
-* `AdvertiseNseName` - [ `ADVERTISE_NSE_NAME` ], the *endpoint* name, as advertised to the NS registry
+* `EndpointNetworkService` - [ `ENDPOINT_NETWORK_SERVICE` ], the *Network Service* name that the *Endpoint* implements, as advertised to the NS registry
 * `OutgoingNscName` - [ `OUTGOING_NSC_NAME` ], the *endpoint* name, as the *client* looks up in the NS registry
 * `AdvertiseNseLabels` - [ `ADVERTISE_NSE_LABELS` ], the *endpoint* labels, as advertised to the NS registry. Used in NSM's selector to match the DestinationSelector. The format is `label1=value1,label2=value2`
 * `OutgoingNscLabels` - [ `OUTGOING_NSC_LABELS` ], the *endpoint* labels, as send by the *client* . Used in NSM's selector to match the SourceSelector. The format is the same as `AdvertiseNseLabels`

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -31,7 +31,7 @@ type NSConfiguration struct {
     Workspace          string
     EndpointNetworkService   string // ENDPOINT_NETWORK_SERVICE
     OutgoingNscName    string // OUTGOING_NSC_NAME
-    AdvertiseNseLabels string // ADVERTISE_NSE_LABELS
+    EndpointLabels string // ENDPOINT_LABELS
     OutgoingNscLabels  string // OUTGOING_NSC_LABELS
     NscInterfaceName   string // NSC_INTERFACE_NAME
     MechanismType      string // MECHANISM_TYPE
@@ -47,8 +47,8 @@ Note that some of the members of this structure can be initialized through the e
 * `Workspace` - [ *system* ], Kubernetes Pod namespace
 * `EndpointNetworkService` - [ `ENDPOINT_NETWORK_SERVICE` ], the *Network Service* name that the *Endpoint* implements, as advertised to the NS registry
 * `OutgoingNscName` - [ `OUTGOING_NSC_NAME` ], the *endpoint* name, as the *client* looks up in the NS registry
-* `AdvertiseNseLabels` - [ `ADVERTISE_NSE_LABELS` ], the *endpoint* labels, as advertised to the NS registry. Used in NSM's selector to match the DestinationSelector. The format is `label1=value1,label2=value2`
-* `OutgoingNscLabels` - [ `OUTGOING_NSC_LABELS` ], the *endpoint* labels, as send by the *client* . Used in NSM's selector to match the SourceSelector. The format is the same as `AdvertiseNseLabels`
+* `EndpointLabels` - [ `ENDPOINT_LABELS` ], the *Endpoint* labels, as advertised to the NS registry. Used in *NSMgr* selector to match the DestinationSelector. The format is `label1=value1,label2=value2`
+* `OutgoingNscLabels` - [ `OUTGOING_NSC_LABELS` ], the *endpoint* labels, as send by the *client* . Used in *NSMgr* selector to match the SourceSelector. The format is the same as `EndpointLabels`
 * `NscInterfaceName` - [ `NSC_INTERFACE_NAME` ], the name off th interface as injected on the client side
 * `MechanismType` - [ `MECHANISM_TYPE` ], enforce a particular Mechanism type. Currently `kernel` or `mem`. Defaults to `kernel`
 * `IPAddress` - [ `IP_ADDRESS` ], the IP network to initialize a prefix pool in the IPAM composite

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -30,7 +30,7 @@ type NSConfiguration struct {
     NsmClientSocket    string
     Workspace          string
     EndpointNetworkService   string // ENDPOINT_NETWORK_SERVICE
-    OutgoingNscName    string // OUTGOING_NSC_NAME
+    ClientNetworkService    string // CLIENT_NETWORK_SERVICE
     EndpointLabels string // ENDPOINT_LABELS
     OutgoingNscLabels  string // OUTGOING_NSC_LABELS
     NscInterfaceName   string // NSC_INTERFACE_NAME
@@ -46,7 +46,7 @@ Note that some of the members of this structure can be initialized through the e
 * `NsmClientSocket` - [ *system* ], NS manager communication socket
 * `Workspace` - [ *system* ], Kubernetes Pod namespace
 * `EndpointNetworkService` - [ `ENDPOINT_NETWORK_SERVICE` ], the *Network Service* name that the *Endpoint* implements, as advertised to the NS registry
-* `OutgoingNscName` - [ `OUTGOING_NSC_NAME` ], the *endpoint* name, as the *client* looks up in the NS registry
+* `ClientNetworkService` - [ `CLIENT_NETWORK_SERVICE` ], the *Network Service* name, as the *Client* asks for it from the *NSMgr*
 * `EndpointLabels` - [ `ENDPOINT_LABELS` ], the *Endpoint* labels, as advertised to the NS registry. Used in *NSMgr* selector to match the DestinationSelector. The format is `label1=value1,label2=value2`
 * `OutgoingNscLabels` - [ `OUTGOING_NSC_LABELS` ], the *endpoint* labels, as send by the *client* . Used in *NSMgr* selector to match the SourceSelector. The format is the same as `EndpointLabels`
 * `NscInterfaceName` - [ `NSC_INTERFACE_NAME` ], the name off th interface as injected on the client side

--- a/sdk/client/client.go
+++ b/sdk/client/client.go
@@ -51,7 +51,7 @@ const (
 type NsmClient struct {
 	*common.NsmConnection
 	ClientNetworkService string
-	OutgoingNscLabels    map[string]string
+	ClientLabels         map[string]string
 	OutgoingConnections  []*connection.Connection
 	NscInterfaceName     string
 	tracerCloser         io.Closer
@@ -103,7 +103,7 @@ func (nsmc *NsmClient) ConnectRetry(ctx context.Context, name, mechanism, descri
 					SrcRoutes:     routes,
 				},
 			},
-			Labels: nsmc.OutgoingNscLabels,
+			Labels: nsmc.ClientLabels,
 		},
 		MechanismPreferences: []*connection.Mechanism{
 			outgoingMechanism,
@@ -195,7 +195,7 @@ func NewNSMClient(ctx context.Context, configuration *common.NSConfiguration) (*
 
 	client := &NsmClient{
 		ClientNetworkService: configuration.ClientNetworkService,
-		OutgoingNscLabels:    tools.ParseKVStringToMap(configuration.OutgoingNscLabels, ",", "="),
+		ClientLabels:         tools.ParseKVStringToMap(configuration.ClientLabels, ",", "="),
 		NscInterfaceName:     configuration.NscInterfaceName,
 	}
 

--- a/sdk/client/client.go
+++ b/sdk/client/client.go
@@ -50,11 +50,11 @@ const (
 // NsmClient is the NSM client struct
 type NsmClient struct {
 	*common.NsmConnection
-	OutgoingNscName     string
-	OutgoingNscLabels   map[string]string
-	OutgoingConnections []*connection.Connection
-	NscInterfaceName    string
-	tracerCloser        io.Closer
+	ClientNetworkService string
+	OutgoingNscLabels    map[string]string
+	OutgoingConnections  []*connection.Connection
+	NscInterfaceName     string
+	tracerCloser         io.Closer
 }
 
 // Connect with no retry and delay
@@ -95,7 +95,7 @@ func (nsmc *NsmClient) ConnectRetry(ctx context.Context, name, mechanism, descri
 
 	outgoingRequest := &networkservice.NetworkServiceRequest{
 		Connection: &connection.Connection{
-			NetworkService: nsmc.Configuration.OutgoingNscName,
+			NetworkService: nsmc.Configuration.ClientNetworkService,
 			Context: &connectioncontext.ConnectionContext{
 				IpContext: &connectioncontext.IPContext{
 					SrcIpRequired: true,
@@ -194,9 +194,9 @@ func NewNSMClient(ctx context.Context, configuration *common.NSConfiguration) (*
 	}
 
 	client := &NsmClient{
-		OutgoingNscName:   configuration.OutgoingNscName,
-		OutgoingNscLabels: tools.ParseKVStringToMap(configuration.OutgoingNscLabels, ",", "="),
-		NscInterfaceName:  configuration.NscInterfaceName,
+		ClientNetworkService: configuration.ClientNetworkService,
+		OutgoingNscLabels:    tools.ParseKVStringToMap(configuration.OutgoingNscLabels, ",", "="),
+		NscInterfaceName:     configuration.NscInterfaceName,
 	}
 
 	client.tracerCloser = jaeger.InitJaeger("nsm-client")

--- a/sdk/client/clientlist.go
+++ b/sdk/client/clientlist.go
@@ -51,12 +51,12 @@ func (nsmcl *NsmClientList) ConnectRetry(ctx context.Context, name, mechanism, d
 	for idx := range nsmcl.clients {
 		entry := &nsmcl.clients[idx]
 		if entry.client.NsmConnection.Configuration.PodName != "" &&
-			entry.client.OutgoingNscLabels[connection.PodNameKey] == "" {
-			entry.client.OutgoingNscLabels[connection.PodNameKey] = entry.client.NsmConnection.Configuration.PodName
+			entry.client.ClientLabels[connection.PodNameKey] == "" {
+			entry.client.ClientLabels[connection.PodNameKey] = entry.client.NsmConnection.Configuration.PodName
 		}
 		if entry.client.NsmConnection.Configuration.Namespace != "" &&
-			entry.client.OutgoingNscLabels[connection.NamespaceKey] == "" {
-			entry.client.OutgoingNscLabels[connection.NamespaceKey] = entry.client.NsmConnection.Configuration.Namespace
+			entry.client.ClientLabels[connection.NamespaceKey] == "" {
+			entry.client.ClientLabels[connection.NamespaceKey] = entry.client.NsmConnection.Configuration.Namespace
 		}
 		conn, err := entry.client.ConnectRetry(ctx, name+strconv.Itoa(idx), mechanism, description, retryCount, retryDelay)
 		if err != nil {

--- a/sdk/common/configuration.go
+++ b/sdk/common/configuration.go
@@ -26,7 +26,7 @@ const (
 	endpointNetworkServiceEnv = "ENDPOINT_NETWORK_SERVICE"
 	endpointLabelsEnv         = "ENDPOINT_LABELS"
 	clientNetworkServiceEnv   = "CLIENT_NETWORK_SERVICE"
-	outgoingNscLabelsEnv      = "OUTGOING_NSC_LABELS"
+	clientLabelsEnv           = "CLIENT_LABELS"
 	nscInterfaceName          = "NSC_INTERFACE_NAME"
 	mechanismTypeEnv          = "MECHANISM_TYPE"
 	ipAddressEnv              = "IP_ADDRESS"
@@ -42,7 +42,7 @@ type NSConfiguration struct {
 	EndpointNetworkService string
 	ClientNetworkService   string
 	EndpointLabels         string
-	OutgoingNscLabels      string
+	ClientLabels           string
 	NscInterfaceName       string
 	MechanismType          string
 	IPAddress              string
@@ -86,8 +86,8 @@ func (configuration *NSConfiguration) FromEnv() *NSConfiguration {
 		configuration.EndpointLabels = getEnv(endpointLabelsEnv, "Advertise labels", false)
 	}
 
-	if configuration.OutgoingNscLabels == "" {
-		configuration.OutgoingNscLabels = getEnv(outgoingNscLabelsEnv, "Outgoing labels", false)
+	if configuration.ClientLabels == "" {
+		configuration.ClientLabels = getEnv(clientLabelsEnv, "Outgoing labels", false)
 	}
 
 	if configuration.NscInterfaceName == "" {
@@ -141,7 +141,7 @@ func (configuration *NSConfiguration) FromNSUrl(url *tools.NSUrl) *NSConfigurati
 		labels.WriteRune('=')
 		labels.WriteString(v[0])
 	}
-	configuration.OutgoingNscLabels = labels.String()
+	configuration.ClientLabels = labels.String()
 	return configuration
 }
 

--- a/sdk/common/configuration.go
+++ b/sdk/common/configuration.go
@@ -25,7 +25,7 @@ const (
 	NamespaceEnv              = "NSM_NAMESPACE"
 	endpointNetworkServiceEnv = "ENDPOINT_NETWORK_SERVICE"
 	endpointLabelsEnv         = "ENDPOINT_LABELS"
-	outgoingNscNameEnv        = "OUTGOING_NSC_NAME"
+	clientNetworkServiceEnv   = "CLIENT_NETWORK_SERVICE"
 	outgoingNscLabelsEnv      = "OUTGOING_NSC_LABELS"
 	nscInterfaceName          = "NSC_INTERFACE_NAME"
 	mechanismTypeEnv          = "MECHANISM_TYPE"
@@ -40,7 +40,7 @@ type NSConfiguration struct {
 	NsmClientSocket        string
 	Workspace              string
 	EndpointNetworkService string
-	OutgoingNscName        string
+	ClientNetworkService   string
 	EndpointLabels         string
 	OutgoingNscLabels      string
 	NscInterfaceName       string
@@ -78,8 +78,8 @@ func (configuration *NSConfiguration) FromEnv() *NSConfiguration {
 		configuration.EndpointNetworkService = getEnv(endpointNetworkServiceEnv, "Advertise Network Service Name", false)
 	}
 
-	if configuration.OutgoingNscName == "" {
-		configuration.OutgoingNscName = getEnv(outgoingNscNameEnv, "Outgoing Network Service Name", false)
+	if configuration.ClientNetworkService == "" {
+		configuration.ClientNetworkService = getEnv(clientNetworkServiceEnv, "Outgoing Network Service Name", false)
 	}
 
 	if configuration.EndpointLabels == "" {
@@ -127,7 +127,7 @@ func (configuration *NSConfiguration) FromNSUrl(url *tools.NSUrl) *NSConfigurati
 	if configuration == nil {
 		return nil
 	}
-	configuration.OutgoingNscName = url.NsName
+	configuration.ClientNetworkService = url.NsName
 	configuration.NscInterfaceName = url.Intf
 	var labels strings.Builder
 	separator := false

--- a/sdk/common/configuration.go
+++ b/sdk/common/configuration.go
@@ -22,33 +22,33 @@ import (
 )
 
 const (
-	NamespaceEnv          = "NSM_NAMESPACE"
-	advertiseNseNameEnv   = "ADVERTISE_NSE_NAME"
-	advertiseNseLabelsEnv = "ADVERTISE_NSE_LABELS"
-	outgoingNscNameEnv    = "OUTGOING_NSC_NAME"
-	outgoingNscLabelsEnv  = "OUTGOING_NSC_LABELS"
-	nscInterfaceName      = "NSC_INTERFACE_NAME"
-	mechanismTypeEnv      = "MECHANISM_TYPE"
-	ipAddressEnv          = "IP_ADDRESS"
-	routesEnv             = "ROUTES"
-	podNameEnv            = "POD_NAME"
+	NamespaceEnv              = "NSM_NAMESPACE"
+	endpointNetworkServiceEnv = "ENDPOINT_NETWORK_SERVICE"
+	advertiseNseLabelsEnv     = "ADVERTISE_NSE_LABELS"
+	outgoingNscNameEnv        = "OUTGOING_NSC_NAME"
+	outgoingNscLabelsEnv      = "OUTGOING_NSC_LABELS"
+	nscInterfaceName          = "NSC_INTERFACE_NAME"
+	mechanismTypeEnv          = "MECHANISM_TYPE"
+	ipAddressEnv              = "IP_ADDRESS"
+	routesEnv                 = "ROUTES"
+	podNameEnv                = "POD_NAME"
 )
 
 // NSConfiguration contains the full configuration used in the SDK
 type NSConfiguration struct {
-	NsmServerSocket    string
-	NsmClientSocket    string
-	Workspace          string
-	AdvertiseNseName   string
-	OutgoingNscName    string
-	AdvertiseNseLabels string
-	OutgoingNscLabels  string
-	NscInterfaceName   string
-	MechanismType      string
-	IPAddress          string
-	Routes             []string
-	PodName            string
-	Namespace          string
+	NsmServerSocket        string
+	NsmClientSocket        string
+	Workspace              string
+	EndpointNetworkService string
+	OutgoingNscName        string
+	AdvertiseNseLabels     string
+	OutgoingNscLabels      string
+	NscInterfaceName       string
+	MechanismType          string
+	IPAddress              string
+	Routes                 []string
+	PodName                string
+	Namespace              string
 }
 
 // FromEnv creates a new NSConfiguration and fills all unset options from the env variables
@@ -74,8 +74,8 @@ func (configuration *NSConfiguration) FromEnv() *NSConfiguration {
 		configuration.Workspace = getEnv(WorkspaceEnv, "workspace", true)
 	}
 
-	if configuration.AdvertiseNseName == "" {
-		configuration.AdvertiseNseName = getEnv(advertiseNseNameEnv, "Advertise Network Service Name", false)
+	if configuration.EndpointNetworkService == "" {
+		configuration.EndpointNetworkService = getEnv(endpointNetworkServiceEnv, "Advertise Network Service Name", false)
 	}
 
 	if configuration.OutgoingNscName == "" {

--- a/sdk/common/configuration.go
+++ b/sdk/common/configuration.go
@@ -22,12 +22,12 @@ import (
 )
 
 const (
-	NamespaceEnv              = "NSM_NAMESPACE"
+	namespaceEnv              = "NSM_NAMESPACE"
 	endpointNetworkServiceEnv = "ENDPOINT_NETWORK_SERVICE"
 	endpointLabelsEnv         = "ENDPOINT_LABELS"
 	clientNetworkServiceEnv   = "CLIENT_NETWORK_SERVICE"
 	clientLabelsEnv           = "CLIENT_LABELS"
-	nscInterfaceName          = "NSC_INTERFACE_NAME"
+	nscInterfaceNameEnv       = "NSC_INTERFACE_NAME"
 	mechanismTypeEnv          = "MECHANISM_TYPE"
 	ipAddressEnv              = "IP_ADDRESS"
 	routesEnv                 = "ROUTES"
@@ -91,7 +91,7 @@ func (configuration *NSConfiguration) FromEnv() *NSConfiguration {
 	}
 
 	if configuration.NscInterfaceName == "" {
-		configuration.NscInterfaceName = getEnv(nscInterfaceName, "NSC Interface name", false)
+		configuration.NscInterfaceName = getEnv(nscInterfaceNameEnv, "NSC Interface name", false)
 	}
 
 	if configuration.MechanismType == "" {
@@ -107,7 +107,7 @@ func (configuration *NSConfiguration) FromEnv() *NSConfiguration {
 	}
 
 	if configuration.Namespace == "" {
-		configuration.Namespace = getEnv(NamespaceEnv, "Namespace", false)
+		configuration.Namespace = getEnv(namespaceEnv, "Namespace", false)
 	}
 
 	if len(configuration.Routes) == 0 {
@@ -146,7 +146,7 @@ func (configuration *NSConfiguration) FromNSUrl(url *tools.NSUrl) *NSConfigurati
 }
 
 func GetNamespace() string {
-	namespace := getEnv(NamespaceEnv, "Namespace", false)
+	namespace := getEnv(namespaceEnv, "Namespace", false)
 	if len(namespace) == 0 {
 		return "default"
 	}

--- a/sdk/common/configuration.go
+++ b/sdk/common/configuration.go
@@ -24,7 +24,7 @@ import (
 const (
 	NamespaceEnv              = "NSM_NAMESPACE"
 	endpointNetworkServiceEnv = "ENDPOINT_NETWORK_SERVICE"
-	advertiseNseLabelsEnv     = "ADVERTISE_NSE_LABELS"
+	endpointLabelsEnv         = "ENDPOINT_LABELS"
 	outgoingNscNameEnv        = "OUTGOING_NSC_NAME"
 	outgoingNscLabelsEnv      = "OUTGOING_NSC_LABELS"
 	nscInterfaceName          = "NSC_INTERFACE_NAME"
@@ -41,7 +41,7 @@ type NSConfiguration struct {
 	Workspace              string
 	EndpointNetworkService string
 	OutgoingNscName        string
-	AdvertiseNseLabels     string
+	EndpointLabels         string
 	OutgoingNscLabels      string
 	NscInterfaceName       string
 	MechanismType          string
@@ -82,8 +82,8 @@ func (configuration *NSConfiguration) FromEnv() *NSConfiguration {
 		configuration.OutgoingNscName = getEnv(outgoingNscNameEnv, "Outgoing Network Service Name", false)
 	}
 
-	if configuration.AdvertiseNseLabels == "" {
-		configuration.AdvertiseNseLabels = getEnv(advertiseNseLabelsEnv, "Advertise labels", false)
+	if configuration.EndpointLabels == "" {
+		configuration.EndpointLabels = getEnv(endpointLabelsEnv, "Advertise labels", false)
 	}
 
 	if configuration.OutgoingNscLabels == "" {

--- a/sdk/endpoint/endpoint.go
+++ b/sdk/endpoint/endpoint.go
@@ -101,7 +101,7 @@ func (nsme *nsmEndpoint) Start() error {
 	nsme.serve(listener)
 
 	span := spanhelper.FromContext(nsme.Context, fmt.Sprintf("Endpoint-%v-Start", nsme.Configuration.EndpointNetworkService))
-	span.LogObject("labels", nsme.Configuration.AdvertiseNseLabels)
+	span.LogObject("labels", nsme.Configuration.EndpointLabels)
 	defer span.Finish()
 
 	// Registering NSE API, it will listen for Connection requests from NSM and return information
@@ -109,7 +109,7 @@ func (nsme *nsmEndpoint) Start() error {
 	nse := &registry.NetworkServiceEndpoint{
 		NetworkServiceName: nsme.Configuration.EndpointNetworkService,
 		Payload:            "IP",
-		Labels:             tools.ParseKVStringToMap(nsme.Configuration.AdvertiseNseLabels, ",", "="),
+		Labels:             tools.ParseKVStringToMap(nsme.Configuration.EndpointLabels, ",", "="),
 	}
 	registration := &registry.NSERegistration{
 		NetworkService: &registry.NetworkService{

--- a/sdk/endpoint/endpoint.go
+++ b/sdk/endpoint/endpoint.go
@@ -78,7 +78,7 @@ func (nsme *nsmEndpoint) serve(listener net.Listener) {
 }
 
 func (nsme *nsmEndpoint) Start() error {
-	nsme.tracerCloser = jaeger.InitJaeger(nsme.Configuration.AdvertiseNseName)
+	nsme.tracerCloser = jaeger.InitJaeger(nsme.Configuration.EndpointNetworkService)
 
 	nsme.grpcServer = tools.NewServer(nsme.Context)
 	unified.RegisterNetworkServiceServer(nsme.grpcServer, nsme)
@@ -100,20 +100,20 @@ func (nsme *nsmEndpoint) Start() error {
 	// spawn the listnening thread
 	nsme.serve(listener)
 
-	span := spanhelper.FromContext(nsme.Context, fmt.Sprintf("Endpoint-%v-Start", nsme.Configuration.AdvertiseNseName))
+	span := spanhelper.FromContext(nsme.Context, fmt.Sprintf("Endpoint-%v-Start", nsme.Configuration.EndpointNetworkService))
 	span.LogObject("labels", nsme.Configuration.AdvertiseNseLabels)
 	defer span.Finish()
 
 	// Registering NSE API, it will listen for Connection requests from NSM and return information
 	// needed for NSE's forwarder programming.
 	nse := &registry.NetworkServiceEndpoint{
-		NetworkServiceName: nsme.Configuration.AdvertiseNseName,
+		NetworkServiceName: nsme.Configuration.EndpointNetworkService,
 		Payload:            "IP",
 		Labels:             tools.ParseKVStringToMap(nsme.Configuration.AdvertiseNseLabels, ",", "="),
 	}
 	registration := &registry.NSERegistration{
 		NetworkService: &registry.NetworkService{
-			Name:    nsme.Configuration.AdvertiseNseName,
+			Name:    nsme.Configuration.EndpointNetworkService,
 			Payload: "IP",
 		},
 		NetworkServiceEndpoint: nse,
@@ -134,7 +134,7 @@ func (nsme *nsmEndpoint) Start() error {
 }
 
 func (nsme *nsmEndpoint) Delete() error {
-	span := spanhelper.FromContext(context.Background(), fmt.Sprintf("Endpoint-%v-Delete", nsme.Configuration.AdvertiseNseName))
+	span := spanhelper.FromContext(context.Background(), fmt.Sprintf("Endpoint-%v-Delete", nsme.Configuration.EndpointNetworkService))
 	defer span.Finish()
 	// prepare and defer removing of the advertised endpoint
 	removeNSE := &registry.RemoveNSERequest{

--- a/sdk/tests/firewall_test.go
+++ b/sdk/tests/firewall_test.go
@@ -28,11 +28,11 @@ func TestFirewallMemif(t *testing.T) {
 	defer ClearFolder(rootDir, false)
 
 	configuration := (&common.NSConfiguration{
-		MechanismType:    memif.MECHANISM,
-		NsmServerSocket:  rootDir + "/server.sock",
-		NsmClientSocket:  rootDir + "/client.sock",
-		Workspace:        rootDir,
-		AdvertiseNseName: "my_network_sercice",
+		MechanismType:          memif.MECHANISM,
+		NsmServerSocket:        rootDir + "/server.sock",
+		NsmClientSocket:        rootDir + "/client.sock",
+		Workspace:              rootDir,
+		EndpointNetworkService: "my_network_sercice",
 	}).FromEnv()
 
 	mechanism, err := common.NewMechanism(cls.LOCAL, memif.MECHANISM, "memif_outgoing", "")

--- a/test/integration/basic_excluded_prefixes_test.go
+++ b/test/integration/basic_excluded_prefixes_test.go
@@ -61,7 +61,7 @@ func TestExcludePrefixCheck(t *testing.T) {
 
 	nsc, err := clientset.CoreV1().Pods(k8s.GetK8sNamespace()).Create(pods.NSCPod("nsc", nodes[0].Node,
 		map[string]string{
-			"OUTGOING_NSC_LABELS":    "app=icmp",
+			"CLIENT_LABELS":          "app=icmp",
 			"CLIENT_NETWORK_SERVICE": "icmp-responder",
 		},
 	))

--- a/test/integration/basic_excluded_prefixes_test.go
+++ b/test/integration/basic_excluded_prefixes_test.go
@@ -61,8 +61,8 @@ func TestExcludePrefixCheck(t *testing.T) {
 
 	nsc, err := clientset.CoreV1().Pods(k8s.GetK8sNamespace()).Create(pods.NSCPod("nsc", nodes[0].Node,
 		map[string]string{
-			"OUTGOING_NSC_LABELS": "app=icmp",
-			"OUTGOING_NSC_NAME":   "icmp-responder",
+			"OUTGOING_NSC_LABELS":    "app=icmp",
+			"CLIENT_NETWORK_SERVICE": "icmp-responder",
 		},
 	))
 

--- a/test/integration/basic_nsmd_k8s_excluded_prefixes_test.go
+++ b/test/integration/basic_nsmd_k8s_excluded_prefixes_test.go
@@ -55,7 +55,7 @@ func TestK8sExcludedPrefixes(t *testing.T) {
 
 	nsc, err := clientset.CoreV1().Pods(k8s.GetK8sNamespace()).Create(pods.NSCPod("nsc", nodes[0].Node,
 		map[string]string{
-			"OUTGOING_NSC_LABELS":    "app=icmp",
+			"CLIENT_LABELS":          "app=icmp",
 			"CLIENT_NETWORK_SERVICE": "icmp-responder",
 		},
 	))

--- a/test/integration/basic_nsmd_k8s_excluded_prefixes_test.go
+++ b/test/integration/basic_nsmd_k8s_excluded_prefixes_test.go
@@ -55,8 +55,8 @@ func TestK8sExcludedPrefixes(t *testing.T) {
 
 	nsc, err := clientset.CoreV1().Pods(k8s.GetK8sNamespace()).Create(pods.NSCPod("nsc", nodes[0].Node,
 		map[string]string{
-			"OUTGOING_NSC_LABELS": "app=icmp",
-			"OUTGOING_NSC_NAME":   "icmp-responder",
+			"OUTGOING_NSC_LABELS":    "app=icmp",
+			"CLIENT_NETWORK_SERVICE": "icmp-responder",
 		},
 	))
 

--- a/test/integration/interdomain_death_handling_test.go
+++ b/test/integration/interdomain_death_handling_test.go
@@ -91,8 +91,8 @@ func testInterdomainNSMDies(t *testing.T, clustersCount int, killSrc bool) {
 	}
 
 	nscPodNode := kubetest.DeployNSCWithEnv(k8ss[0].K8s, k8ss[0].NodesSetup[0].Node, "nsc-1", defaultTimeout, map[string]string{
-		"OUTGOING_NSC_LABELS": "app=icmp",
-		"OUTGOING_NSC_NAME":   fmt.Sprintf("icmp-responder@%s", nseExternalIP),
+		"OUTGOING_NSC_LABELS":    "app=icmp",
+		"CLIENT_NETWORK_SERVICE": fmt.Sprintf("icmp-responder@%s", nseExternalIP),
 	})
 
 	kubetest.CheckNSC(k8ss[0].K8s, nscPodNode)

--- a/test/integration/interdomain_death_handling_test.go
+++ b/test/integration/interdomain_death_handling_test.go
@@ -91,7 +91,7 @@ func testInterdomainNSMDies(t *testing.T, clustersCount int, killSrc bool) {
 	}
 
 	nscPodNode := kubetest.DeployNSCWithEnv(k8ss[0].K8s, k8ss[0].NodesSetup[0].Node, "nsc-1", defaultTimeout, map[string]string{
-		"OUTGOING_NSC_LABELS":    "app=icmp",
+		"CLIENT_LABELS":          "app=icmp",
 		"CLIENT_NETWORK_SERVICE": fmt.Sprintf("icmp-responder@%s", nseExternalIP),
 	})
 

--- a/test/integration/interdomain_nsc_icmp_configuration_test.go
+++ b/test/integration/interdomain_nsc_icmp_configuration_test.go
@@ -94,8 +94,8 @@ func testInterdomainNSCAndICMP(t *testing.T, clustersCount int, nodesCount int, 
 	}
 
 	nscPodNode := kubetest.DeployNSCWithEnv(k8ss[0].K8s, k8ss[0].NodesSetup[0].Node, "nsc-1", defaultTimeout, map[string]string{
-		"OUTGOING_NSC_LABELS": "app=icmp",
-		"OUTGOING_NSC_NAME":   fmt.Sprintf("icmp-responder@%s", nseExternalIP),
+		"OUTGOING_NSC_LABELS":    "app=icmp",
+		"CLIENT_NETWORK_SERVICE": fmt.Sprintf("icmp-responder@%s", nseExternalIP),
 	})
 
 	kubetest.CheckNSC(k8ss[0].K8s, nscPodNode)

--- a/test/integration/interdomain_nsc_icmp_configuration_test.go
+++ b/test/integration/interdomain_nsc_icmp_configuration_test.go
@@ -94,7 +94,7 @@ func testInterdomainNSCAndICMP(t *testing.T, clustersCount int, nodesCount int, 
 	}
 
 	nscPodNode := kubetest.DeployNSCWithEnv(k8ss[0].K8s, k8ss[0].NodesSetup[0].Node, "nsc-1", defaultTimeout, map[string]string{
-		"OUTGOING_NSC_LABELS":    "app=icmp",
+		"CLIENT_LABELS":          "app=icmp",
 		"CLIENT_NETWORK_SERVICE": fmt.Sprintf("icmp-responder@%s", nseExternalIP),
 	})
 

--- a/test/integration/interdomain_nse_forwarder_heal_test.go
+++ b/test/integration/interdomain_nse_forwarder_heal_test.go
@@ -85,7 +85,7 @@ func testInterdomainForwarderHeal(t *testing.T, clustersCount int, nodesCount in
 	}
 
 	nscPodNode := kubetest.DeployNSCWithEnv(k8ss[0].K8s, k8ss[0].NodesSetup[0].Node, "nsc-1", defaultTimeout, map[string]string{
-		"OUTGOING_NSC_LABELS":    "app=icmp",
+		"CLIENT_LABELS":          "app=icmp",
 		"CLIENT_NETWORK_SERVICE": fmt.Sprintf("icmp-responder@%s", nseExternalIP),
 	})
 

--- a/test/integration/interdomain_nse_forwarder_heal_test.go
+++ b/test/integration/interdomain_nse_forwarder_heal_test.go
@@ -85,8 +85,8 @@ func testInterdomainForwarderHeal(t *testing.T, clustersCount int, nodesCount in
 	}
 
 	nscPodNode := kubetest.DeployNSCWithEnv(k8ss[0].K8s, k8ss[0].NodesSetup[0].Node, "nsc-1", defaultTimeout, map[string]string{
-		"OUTGOING_NSC_LABELS": "app=icmp",
-		"OUTGOING_NSC_NAME":   fmt.Sprintf("icmp-responder@%s", nseExternalIP),
+		"OUTGOING_NSC_LABELS":    "app=icmp",
+		"CLIENT_NETWORK_SERVICE": fmt.Sprintf("icmp-responder@%s", nseExternalIP),
 	})
 
 	kubetest.CheckNSC(k8ss[0].K8s, nscPodNode)

--- a/test/integration/interdomain_nse_heal_test.go
+++ b/test/integration/interdomain_nse_heal_test.go
@@ -109,8 +109,8 @@ func testInterdomainNSEHeal(t *testing.T, clustersCount int, nodesCount int, aff
 	}
 
 	nscPodNode := kubetest.DeployNSCWithEnv(k8ss[0].K8s, k8ss[0].NodesSetup[0].Node, "nsc-1", defaultTimeout, map[string]string{
-		"OUTGOING_NSC_LABELS": "app=icmp",
-		"OUTGOING_NSC_NAME":   fmt.Sprintf("icmp-responder@%s", nseExternalIP),
+		"OUTGOING_NSC_LABELS":    "app=icmp",
+		"CLIENT_NETWORK_SERVICE": fmt.Sprintf("icmp-responder@%s", nseExternalIP),
 	})
 
 	kubetest.CheckNSC(k8ss[0].K8s, nscPodNode)

--- a/test/integration/interdomain_nse_heal_test.go
+++ b/test/integration/interdomain_nse_heal_test.go
@@ -109,7 +109,7 @@ func testInterdomainNSEHeal(t *testing.T, clustersCount int, nodesCount int, aff
 	}
 
 	nscPodNode := kubetest.DeployNSCWithEnv(k8ss[0].K8s, k8ss[0].NodesSetup[0].Node, "nsc-1", defaultTimeout, map[string]string{
-		"OUTGOING_NSC_LABELS":    "app=icmp",
+		"CLIENT_LABELS":          "app=icmp",
 		"CLIENT_NETWORK_SERVICE": fmt.Sprintf("icmp-responder@%s", nseExternalIP),
 	})
 

--- a/test/integration/interdomain_nse_nsm_heal_test.go
+++ b/test/integration/interdomain_nse_nsm_heal_test.go
@@ -94,7 +94,7 @@ func testInterdomainNSMHeal(t *testing.T, clustersCount int, killIndex int, dele
 	}
 
 	nscPodNode := kubetest.DeployNSCWithEnv(k8ss[0].K8s, k8ss[0].NodesSetup[0].Node, "nsc-1", defaultTimeout, map[string]string{
-		"OUTGOING_NSC_LABELS":    "app=icmp",
+		"CLIENT_LABELS":          "app=icmp",
 		"CLIENT_NETWORK_SERVICE": fmt.Sprintf("icmp-responder@%s", nseExternalIP),
 	})
 

--- a/test/integration/interdomain_nse_nsm_heal_test.go
+++ b/test/integration/interdomain_nse_nsm_heal_test.go
@@ -94,8 +94,8 @@ func testInterdomainNSMHeal(t *testing.T, clustersCount int, killIndex int, dele
 	}
 
 	nscPodNode := kubetest.DeployNSCWithEnv(k8ss[0].K8s, k8ss[0].NodesSetup[0].Node, "nsc-1", defaultTimeout, map[string]string{
-		"OUTGOING_NSC_LABELS": "app=icmp",
-		"OUTGOING_NSC_NAME":   fmt.Sprintf("icmp-responder@%s", nseExternalIP),
+		"OUTGOING_NSC_LABELS":    "app=icmp",
+		"CLIENT_NETWORK_SERVICE": fmt.Sprintf("icmp-responder@%s", nseExternalIP),
 	})
 
 	kubetest.CheckNSC(k8ss[0].K8s, nscPodNode)

--- a/test/integration/interdomain_vpn_test.go
+++ b/test/integration/interdomain_vpn_test.go
@@ -174,7 +174,7 @@ func testInterdomainVPN(t *testing.T, ptnum, clustersCount int, nodesCount int, 
 		map[string]string{
 			"ENDPOINT_NETWORK_SERVICE": "secure-intranet-connectivity",
 			"ENDPOINT_LABELS":          "app=firewall",
-			"OUTGOING_NSC_NAME":        nscOutgoingName,
+			"CLIENT_NETWORK_SERVICE":   nscOutgoingName,
 			"OUTGOING_NSC_LABELS":      "app=firewall",
 		},
 	))
@@ -194,7 +194,7 @@ func testInterdomainVPN(t *testing.T, ptnum, clustersCount int, nodesCount int, 
 			map[string]string{
 				"ENDPOINT_NETWORK_SERVICE": "secure-intranet-connectivity",
 				"ENDPOINT_LABELS":          "app=passthrough-" + id,
-				"OUTGOING_NSC_NAME":        "secure-intranet-connectivity",
+				"CLIENT_NETWORK_SERVICE":   "secure-intranet-connectivity",
 				"OUTGOING_NSC_LABELS":      "app=passthrough-" + id,
 			},
 		))
@@ -228,7 +228,7 @@ func testInterdomainVPN(t *testing.T, ptnum, clustersCount int, nodesCount int, 
 	}
 	nscPodNode := k8ss[nscCluster].K8s.CreatePod(pods.NSCPod("vpn-gateway-nsc-1", &clusterNodes[nscCluster][0],
 		map[string]string{
-			"OUTGOING_NSC_NAME": nscOutgoingName,
+			"CLIENT_NETWORK_SERVICE": nscOutgoingName,
 		},
 	))
 	g.Expect(nscPodNode.Name).To(Equal("vpn-gateway-nsc-1"))

--- a/test/integration/interdomain_vpn_test.go
+++ b/test/integration/interdomain_vpn_test.go
@@ -172,7 +172,7 @@ func testInterdomainVPN(t *testing.T, ptnum, clustersCount int, nodesCount int, 
 	g.Expect(err).To(BeNil())
 	vppagentFirewallNode := k8ss[firewallCluster].K8s.CreatePod(pods.VppAgentFirewallNSEPodWithConfigMap("vppagent-firewall-nse-1", &clusterNodes[firewallCluster][0],
 		map[string]string{
-			"ADVERTISE_NSE_NAME":   "secure-intranet-connectivity",
+			"ENDPOINT_NETWORK_SERVICE":   "secure-intranet-connectivity",
 			"ADVERTISE_NSE_LABELS": "app=firewall",
 			"OUTGOING_NSC_NAME":    nscOutgoingName,
 			"OUTGOING_NSC_LABELS":  "app=firewall",
@@ -192,7 +192,7 @@ func testInterdomainVPN(t *testing.T, ptnum, clustersCount int, nodesCount int, 
 
 		vppagentPassthroughNode := k8ss[passthroughCluster].K8s.CreatePod(pods.VppAgentFirewallNSEPod("vppagent-passthrough-nse-"+id, &clusterNodes[passthroughCluster][0],
 			map[string]string{
-				"ADVERTISE_NSE_NAME":   "secure-intranet-connectivity",
+				"ENDPOINT_NETWORK_SERVICE":   "secure-intranet-connectivity",
 				"ADVERTISE_NSE_LABELS": "app=passthrough-" + id,
 				"OUTGOING_NSC_NAME":    "secure-intranet-connectivity",
 				"OUTGOING_NSC_LABELS":  "app=passthrough-" + id,
@@ -209,7 +209,7 @@ func testInterdomainVPN(t *testing.T, ptnum, clustersCount int, nodesCount int, 
 	logrus.Infof("Starting VPN Gateway NSE on node: %d", nseCluster)
 	vpnGatewayPodNode := k8ss[nseCluster].K8s.CreatePod(pods.VPNGatewayNSEPod("vpn-gateway-nse-1", &clusterNodes[nseCluster][0],
 		map[string]string{
-			"ADVERTISE_NSE_NAME":   "secure-intranet-connectivity",
+			"ENDPOINT_NETWORK_SERVICE":   "secure-intranet-connectivity",
 			"ADVERTISE_NSE_LABELS": "app=vpn-gateway",
 			"IP_ADDRESS":           addressPool,
 		},

--- a/test/integration/interdomain_vpn_test.go
+++ b/test/integration/interdomain_vpn_test.go
@@ -175,7 +175,7 @@ func testInterdomainVPN(t *testing.T, ptnum, clustersCount int, nodesCount int, 
 			"ENDPOINT_NETWORK_SERVICE": "secure-intranet-connectivity",
 			"ENDPOINT_LABELS":          "app=firewall",
 			"CLIENT_NETWORK_SERVICE":   nscOutgoingName,
-			"OUTGOING_NSC_LABELS":      "app=firewall",
+			"CLIENT_LABELS":            "app=firewall",
 		},
 	))
 	g.Expect(vppagentFirewallNode.Name).To(Equal("vppagent-firewall-nse-1"))
@@ -195,7 +195,7 @@ func testInterdomainVPN(t *testing.T, ptnum, clustersCount int, nodesCount int, 
 				"ENDPOINT_NETWORK_SERVICE": "secure-intranet-connectivity",
 				"ENDPOINT_LABELS":          "app=passthrough-" + id,
 				"CLIENT_NETWORK_SERVICE":   "secure-intranet-connectivity",
-				"OUTGOING_NSC_LABELS":      "app=passthrough-" + id,
+				"CLIENT_LABELS":            "app=passthrough-" + id,
 			},
 		))
 		g.Expect(vppagentPassthroughNode.Name).To(Equal("vppagent-passthrough-nse-" + id))

--- a/test/integration/interdomain_vpn_test.go
+++ b/test/integration/interdomain_vpn_test.go
@@ -172,10 +172,10 @@ func testInterdomainVPN(t *testing.T, ptnum, clustersCount int, nodesCount int, 
 	g.Expect(err).To(BeNil())
 	vppagentFirewallNode := k8ss[firewallCluster].K8s.CreatePod(pods.VppAgentFirewallNSEPodWithConfigMap("vppagent-firewall-nse-1", &clusterNodes[firewallCluster][0],
 		map[string]string{
-			"ENDPOINT_NETWORK_SERVICE":   "secure-intranet-connectivity",
-			"ADVERTISE_NSE_LABELS": "app=firewall",
-			"OUTGOING_NSC_NAME":    nscOutgoingName,
-			"OUTGOING_NSC_LABELS":  "app=firewall",
+			"ENDPOINT_NETWORK_SERVICE": "secure-intranet-connectivity",
+			"ENDPOINT_LABELS":          "app=firewall",
+			"OUTGOING_NSC_NAME":        nscOutgoingName,
+			"OUTGOING_NSC_LABELS":      "app=firewall",
 		},
 	))
 	g.Expect(vppagentFirewallNode.Name).To(Equal("vppagent-firewall-nse-1"))
@@ -192,10 +192,10 @@ func testInterdomainVPN(t *testing.T, ptnum, clustersCount int, nodesCount int, 
 
 		vppagentPassthroughNode := k8ss[passthroughCluster].K8s.CreatePod(pods.VppAgentFirewallNSEPod("vppagent-passthrough-nse-"+id, &clusterNodes[passthroughCluster][0],
 			map[string]string{
-				"ENDPOINT_NETWORK_SERVICE":   "secure-intranet-connectivity",
-				"ADVERTISE_NSE_LABELS": "app=passthrough-" + id,
-				"OUTGOING_NSC_NAME":    "secure-intranet-connectivity",
-				"OUTGOING_NSC_LABELS":  "app=passthrough-" + id,
+				"ENDPOINT_NETWORK_SERVICE": "secure-intranet-connectivity",
+				"ENDPOINT_LABELS":          "app=passthrough-" + id,
+				"OUTGOING_NSC_NAME":        "secure-intranet-connectivity",
+				"OUTGOING_NSC_LABELS":      "app=passthrough-" + id,
 			},
 		))
 		g.Expect(vppagentPassthroughNode.Name).To(Equal("vppagent-passthrough-nse-" + id))
@@ -209,9 +209,9 @@ func testInterdomainVPN(t *testing.T, ptnum, clustersCount int, nodesCount int, 
 	logrus.Infof("Starting VPN Gateway NSE on node: %d", nseCluster)
 	vpnGatewayPodNode := k8ss[nseCluster].K8s.CreatePod(pods.VPNGatewayNSEPod("vpn-gateway-nse-1", &clusterNodes[nseCluster][0],
 		map[string]string{
-			"ENDPOINT_NETWORK_SERVICE":   "secure-intranet-connectivity",
-			"ADVERTISE_NSE_LABELS": "app=vpn-gateway",
-			"IP_ADDRESS":           addressPool,
+			"ENDPOINT_NETWORK_SERVICE": "secure-intranet-connectivity",
+			"ENDPOINT_LABELS":          "app=vpn-gateway",
+			"IP_ADDRESS":               addressPool,
 		},
 	))
 	g.Expect(vpnGatewayPodNode).ToNot(BeNil())

--- a/test/integration/usecase_vpn_test.go
+++ b/test/integration/usecase_vpn_test.go
@@ -140,7 +140,7 @@ func testVPN(t *testing.T, ptnum, nodesCount int, affinity map[string]int, verbo
 		g.Expect(err).To(BeNil())
 		vppagentFirewallNode := k8s.CreatePod(pods.VppAgentFirewallNSEPodWithConfigMap("vppagent-firewall-nse-1", &nodes[node],
 			map[string]string{
-				"ADVERTISE_NSE_NAME":   "secure-intranet-connectivity",
+				"ENDPOINT_NETWORK_SERVICE":   "secure-intranet-connectivity",
 				"ADVERTISE_NSE_LABELS": "app=firewall",
 				"OUTGOING_NSC_NAME":    "secure-intranet-connectivity",
 				"OUTGOING_NSC_LABELS":  "app=firewall",
@@ -162,7 +162,7 @@ func testVPN(t *testing.T, ptnum, nodesCount int, affinity map[string]int, verbo
 
 			vppagentPassthroughNode := k8s.CreatePod(pods.VppAgentFirewallNSEPod("vppagent-passthrough-nse-"+id, &nodes[node],
 				map[string]string{
-					"ADVERTISE_NSE_NAME":   "secure-intranet-connectivity",
+					"ENDPOINT_NETWORK_SERVICE":   "secure-intranet-connectivity",
 					"ADVERTISE_NSE_LABELS": "app=passthrough-" + id,
 					"OUTGOING_NSC_NAME":    "secure-intranet-connectivity",
 					"OUTGOING_NSC_LABELS":  "app=passthrough-" + id,
@@ -184,7 +184,7 @@ func testVPN(t *testing.T, ptnum, nodesCount int, affinity map[string]int, verbo
 		logrus.Infof("Starting VPN Gateway NSE on node: %d", node)
 		vpnGatewayPodNode := k8s.CreatePod(pods.VPNGatewayNSEPod("vpn-gateway-nse-1", &nodes[node],
 			map[string]string{
-				"ADVERTISE_NSE_NAME":   "secure-intranet-connectivity",
+				"ENDPOINT_NETWORK_SERVICE":   "secure-intranet-connectivity",
 				"ADVERTISE_NSE_LABELS": "app=vpn-gateway",
 				"IP_ADDRESS":           addressPool,
 			},

--- a/test/integration/usecase_vpn_test.go
+++ b/test/integration/usecase_vpn_test.go
@@ -140,10 +140,10 @@ func testVPN(t *testing.T, ptnum, nodesCount int, affinity map[string]int, verbo
 		g.Expect(err).To(BeNil())
 		vppagentFirewallNode := k8s.CreatePod(pods.VppAgentFirewallNSEPodWithConfigMap("vppagent-firewall-nse-1", &nodes[node],
 			map[string]string{
-				"ENDPOINT_NETWORK_SERVICE":   "secure-intranet-connectivity",
-				"ADVERTISE_NSE_LABELS": "app=firewall",
-				"OUTGOING_NSC_NAME":    "secure-intranet-connectivity",
-				"OUTGOING_NSC_LABELS":  "app=firewall",
+				"ENDPOINT_NETWORK_SERVICE": "secure-intranet-connectivity",
+				"ENDPOINT_LABELS":          "app=firewall",
+				"OUTGOING_NSC_NAME":        "secure-intranet-connectivity",
+				"OUTGOING_NSC_LABELS":      "app=firewall",
 			},
 		))
 		g.Expect(vppagentFirewallNode.Name).To(Equal("vppagent-firewall-nse-1"))
@@ -162,10 +162,10 @@ func testVPN(t *testing.T, ptnum, nodesCount int, affinity map[string]int, verbo
 
 			vppagentPassthroughNode := k8s.CreatePod(pods.VppAgentFirewallNSEPod("vppagent-passthrough-nse-"+id, &nodes[node],
 				map[string]string{
-					"ENDPOINT_NETWORK_SERVICE":   "secure-intranet-connectivity",
-					"ADVERTISE_NSE_LABELS": "app=passthrough-" + id,
-					"OUTGOING_NSC_NAME":    "secure-intranet-connectivity",
-					"OUTGOING_NSC_LABELS":  "app=passthrough-" + id,
+					"ENDPOINT_NETWORK_SERVICE": "secure-intranet-connectivity",
+					"ENDPOINT_LABELS":          "app=passthrough-" + id,
+					"OUTGOING_NSC_NAME":        "secure-intranet-connectivity",
+					"OUTGOING_NSC_LABELS":      "app=passthrough-" + id,
 				},
 			))
 			g.Expect(vppagentPassthroughNode.Name).To(Equal("vppagent-passthrough-nse-" + id))
@@ -184,9 +184,9 @@ func testVPN(t *testing.T, ptnum, nodesCount int, affinity map[string]int, verbo
 		logrus.Infof("Starting VPN Gateway NSE on node: %d", node)
 		vpnGatewayPodNode := k8s.CreatePod(pods.VPNGatewayNSEPod("vpn-gateway-nse-1", &nodes[node],
 			map[string]string{
-				"ENDPOINT_NETWORK_SERVICE":   "secure-intranet-connectivity",
-				"ADVERTISE_NSE_LABELS": "app=vpn-gateway",
-				"IP_ADDRESS":           addressPool,
+				"ENDPOINT_NETWORK_SERVICE": "secure-intranet-connectivity",
+				"ENDPOINT_LABELS":          "app=vpn-gateway",
+				"IP_ADDRESS":               addressPool,
 			},
 		))
 		g.Expect(vpnGatewayPodNode).ToNot(BeNil())

--- a/test/integration/usecase_vpn_test.go
+++ b/test/integration/usecase_vpn_test.go
@@ -142,7 +142,7 @@ func testVPN(t *testing.T, ptnum, nodesCount int, affinity map[string]int, verbo
 			map[string]string{
 				"ENDPOINT_NETWORK_SERVICE": "secure-intranet-connectivity",
 				"ENDPOINT_LABELS":          "app=firewall",
-				"OUTGOING_NSC_NAME":        "secure-intranet-connectivity",
+				"CLIENT_NETWORK_SERVICE":   "secure-intranet-connectivity",
 				"OUTGOING_NSC_LABELS":      "app=firewall",
 			},
 		))
@@ -164,7 +164,7 @@ func testVPN(t *testing.T, ptnum, nodesCount int, affinity map[string]int, verbo
 				map[string]string{
 					"ENDPOINT_NETWORK_SERVICE": "secure-intranet-connectivity",
 					"ENDPOINT_LABELS":          "app=passthrough-" + id,
-					"OUTGOING_NSC_NAME":        "secure-intranet-connectivity",
+					"CLIENT_NETWORK_SERVICE":   "secure-intranet-connectivity",
 					"OUTGOING_NSC_LABELS":      "app=passthrough-" + id,
 				},
 			))
@@ -203,7 +203,7 @@ func testVPN(t *testing.T, ptnum, nodesCount int, affinity map[string]int, verbo
 	node := affinity["vpn-gateway-nsc-1"]
 	nscPodNode := k8s.CreatePod(pods.NSCPod("vpn-gateway-nsc-1", &nodes[node],
 		map[string]string{
-			"OUTGOING_NSC_NAME": "secure-intranet-connectivity",
+			"CLIENT_NETWORK_SERVICE": "secure-intranet-connectivity",
 		},
 	))
 	g.Expect(nscPodNode.Name).To(Equal("vpn-gateway-nsc-1"))

--- a/test/integration/usecase_vpn_test.go
+++ b/test/integration/usecase_vpn_test.go
@@ -143,7 +143,7 @@ func testVPN(t *testing.T, ptnum, nodesCount int, affinity map[string]int, verbo
 				"ENDPOINT_NETWORK_SERVICE": "secure-intranet-connectivity",
 				"ENDPOINT_LABELS":          "app=firewall",
 				"CLIENT_NETWORK_SERVICE":   "secure-intranet-connectivity",
-				"OUTGOING_NSC_LABELS":      "app=firewall",
+				"CLIENT_LABELS":            "app=firewall",
 			},
 		))
 		g.Expect(vppagentFirewallNode.Name).To(Equal("vppagent-firewall-nse-1"))
@@ -165,7 +165,7 @@ func testVPN(t *testing.T, ptnum, nodesCount int, affinity map[string]int, verbo
 					"ENDPOINT_NETWORK_SERVICE": "secure-intranet-connectivity",
 					"ENDPOINT_LABELS":          "app=passthrough-" + id,
 					"CLIENT_NETWORK_SERVICE":   "secure-intranet-connectivity",
-					"OUTGOING_NSC_LABELS":      "app=passthrough-" + id,
+					"CLIENT_LABELS":            "app=passthrough-" + id,
 				},
 			))
 			g.Expect(vppagentPassthroughNode.Name).To(Equal("vppagent-passthrough-nse-" + id))

--- a/test/kubetest/utils.go
+++ b/test/kubetest/utils.go
@@ -399,15 +399,15 @@ func InitSpireSecurity(k8s *K8s) func() {
 func defaultICMPEnv(useIPv6 bool) map[string]string {
 	if !useIPv6 {
 		return map[string]string{
-			"ENDPOINT_NETWORK_SERVICE":   "icmp-responder",
-			"ADVERTISE_NSE_LABELS": "app=icmp",
-			"IP_ADDRESS":           "172.16.1.0/24",
+			"ENDPOINT_NETWORK_SERVICE": "icmp-responder",
+			"ENDPOINT_LABELS":          "app=icmp",
+			"IP_ADDRESS":               "172.16.1.0/24",
 		}
 	}
 	return map[string]string{
-		"ENDPOINT_NETWORK_SERVICE":   "icmp-responder",
-		"ADVERTISE_NSE_LABELS": "app=icmp",
-		"IP_ADDRESS":           "100::/64",
+		"ENDPOINT_NETWORK_SERVICE": "icmp-responder",
+		"ENDPOINT_LABELS":          "app=icmp",
+		"IP_ADDRESS":               "100::/64",
 	}
 }
 

--- a/test/kubetest/utils.go
+++ b/test/kubetest/utils.go
@@ -413,7 +413,7 @@ func defaultICMPEnv(useIPv6 bool) map[string]string {
 
 func defaultNSCEnv() map[string]string {
 	return map[string]string{
-		"OUTGOING_NSC_LABELS":    "app=icmp",
+		"CLIENT_LABELS":          "app=icmp",
 		"CLIENT_NETWORK_SERVICE": "icmp-responder",
 	}
 }

--- a/test/kubetest/utils.go
+++ b/test/kubetest/utils.go
@@ -413,8 +413,8 @@ func defaultICMPEnv(useIPv6 bool) map[string]string {
 
 func defaultNSCEnv() map[string]string {
 	return map[string]string{
-		"OUTGOING_NSC_LABELS": "app=icmp",
-		"OUTGOING_NSC_NAME":   "icmp-responder",
+		"OUTGOING_NSC_LABELS":    "app=icmp",
+		"CLIENT_NETWORK_SERVICE": "icmp-responder",
 	}
 }
 

--- a/test/kubetest/utils.go
+++ b/test/kubetest/utils.go
@@ -399,13 +399,13 @@ func InitSpireSecurity(k8s *K8s) func() {
 func defaultICMPEnv(useIPv6 bool) map[string]string {
 	if !useIPv6 {
 		return map[string]string{
-			"ADVERTISE_NSE_NAME":   "icmp-responder",
+			"ENDPOINT_NETWORK_SERVICE":   "icmp-responder",
 			"ADVERTISE_NSE_LABELS": "app=icmp",
 			"IP_ADDRESS":           "172.16.1.0/24",
 		}
 	}
 	return map[string]string{
-		"ADVERTISE_NSE_NAME":   "icmp-responder",
+		"ENDPOINT_NETWORK_SERVICE":   "icmp-responder",
 		"ADVERTISE_NSE_LABELS": "app=icmp",
 		"IP_ADDRESS":           "100::/64",
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Renames the SDK env configuration variables as follows:

 * `ADVERTISE_NSE_NAME` -> `ENDPOINT_NETWORK_SERVICE`
 * `ADVERTISE_NSE_LABELS` -> `ENDPOINT_LABELS`
 * `OUTGOING_NSC_NAME` -> `CLIENT_NETWORK_SERVICE`
 * `OUTGOING_NSC_LABELS` -> `CLIENT_LABELS`

Deprecates #931 and closes #866.

## Motivation and Context
Our env variable naming in the SDK is a bit confusing and refers ro NSE and NSC which we want to replace with the terms Endpoint and Client.

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [x] Covered by existing integration testing
- [ ] Added integration testing to cover
- [x] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
