### PR TITLE
cloudtest health check: fix panic 'send on closed channel'

### DIFF
--- a/test/cloudtest/pkg/commands/health.go
+++ b/test/cloudtest/pkg/commands/health.go
@@ -22,9 +22,10 @@ import (
 	"strings"
 	"time"
 
+	"github.com/pkg/errors"
+
 	"github.com/networkservicemesh/networkservicemesh/test/cloudtest/pkg/config"
 	"github.com/networkservicemesh/networkservicemesh/test/cloudtest/pkg/utils"
-	"github.com/pkg/errors"
 )
 
 // RunHealthChecks - Start goroutines with health check probes

--- a/test/cloudtest/pkg/commands/health.go
+++ b/test/cloudtest/pkg/commands/health.go
@@ -1,0 +1,59 @@
+// Copyright (c) 2019 Cisco Systems, Inc and/or its affiliates.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package commands
+
+import (
+	"bufio"
+	"context"
+	"strings"
+	"time"
+
+	"github.com/networkservicemesh/networkservicemesh/test/cloudtest/pkg/config"
+	"github.com/networkservicemesh/networkservicemesh/test/cloudtest/pkg/utils"
+	"github.com/pkg/errors"
+)
+
+// RunHealthChecks - Start goroutines with health check probes
+func RunHealthChecks(checkConfigs []*config.HealthCheckConfig) <-chan error {
+	errCh := make(chan error)
+	ready := true
+
+	for i := range checkConfigs {
+		go func(c int) {
+			config := checkConfigs[c]
+			for {
+				interval := time.Duration(config.Interval) * time.Second
+				<-time.After(interval)
+
+				timeoutCtx, cancel := context.WithTimeout(context.Background(), interval)
+				defer cancel()
+
+				for _, cmd := range utils.ParseScript(config.Run) {
+					builder := &strings.Builder{}
+					_, err := utils.RunCommand(timeoutCtx, cmd, "", func(s string) {}, bufio.NewWriter(builder), nil, nil, false)
+					if ready && err != nil {
+						ready = false
+						errCh <- errors.Errorf(config.Message)
+						return
+					}
+				}
+			}
+		}(i)
+	}
+
+	return errCh
+}

--- a/test/cloudtest/pkg/tests/cloud_config_test.go
+++ b/test/cloudtest/pkg/tests/cloud_config_test.go
@@ -40,7 +40,6 @@ func TestClusterHealthCheckConfig(t *testing.T) {
 	g.Expect(testConfig.Reporting.JUnitReportFile).To(Equal("./.tests/junit.xml"))
 
 	errChan := commands.RunHealthChecks(testConfig.HealthCheck)
-	defer close(errChan)
 
 	select {
 	case err = <-errChan:


### PR DESCRIPTION
Signed-off-by: Denis Tingajkin <denis.tingajkin@xored.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
```
panic: send on closed channel

goroutine 40 [running]:
github.com/networkservicemesh/networkservicemesh/test/cloudtest/pkg/commands.RunHealthChecks.func1(0xc000146620, 0x1, 0x1, 0xc000378310, 0xc00036c780, 0x0)
	/home/circleci/project/test/cloudtest/pkg/commands/commands.go:1602 +0x343
created by github.com/networkservicemesh/networkservicemesh/test/cloudtest/pkg/commands.RunHealthChecks
	/home/circleci/project/test/cloudtest/pkg/commands/commands.go:1588 +0xaf
```
where commands/commands.go = commands/main.go on master branch
build:
https://circleci.com/gh/networkservicemesh/networkservicemesh/117053?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-checks-link
## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [ ] Covered by existing integration testing
- [ ] Added integration testing to cover
- [ ] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
