### PR TITLE
Change AWS instance type

### DIFF
--- a/scripts/aws/amazon-eks-nodegroup.yaml
+++ b/scripts/aws/amazon-eks-nodegroup.yaml
@@ -15,7 +15,7 @@ Parameters:
   NodeInstanceType:
     Description: EC2 instance type for the node instances
     Type: String
-    Default: t2.medium
+    Default: t2.large
     ConstraintDescription: Must be a valid EC2 instance type
     AllowedValues:
       - t2.small


### PR DESCRIPTION
Signed-off-by: Artem Belov <artem.belov@xored.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
Change AWS instance type to t2.large

## Motivation and Context
TestInterdomainVPNNSERemote is unstable with an error
```time="2019-12-09T02:55:57Z" level=error msg="blockUntilPodReady failed. Cause: pod vppagent-passthrough-nse-5 deploy error: Failed create pod sandbox: rpc error: code = Unknown desc = failed to set up sandbox container \"dd00e008078d2a0bd5689c48b2d051bb27399c25e84c1af539ca33cc5613dd26\" network for pod \"vppagent-passthrough-nse-5\": NetworkPlugin cni failed to set up pod \"vppagent-passthrough-nse-5_nsm-system-bhhf4\" network: add cmd: failed to assign an IP address to container. pod: vppagent-passthrough-nse-5"```

Cause of the issue:
t2.medium has a limit of 17 pods (limited ip addresses per interface), which is reached with all default kubernetes pods and security pods. 
t2.large gives limit of 29 pods

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [ ] Covered by existing integration testing
- [ ] Added integration testing to cover
- [ ] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
