### PR TITLE
Fix ssh fail on packet start

### DIFF
--- a/.cloudtest/packet.yaml
+++ b/.cloudtest/packet.yaml
@@ -40,7 +40,7 @@ providers:
       setup: |
         ssh-keygen -t rsa -f $(tempdir)/sshkey -q -N ""
         ssh-add $(tempdir)/sshkey
-      start: ./.cloudtest/packet/create-kubernetes-cluster.sh $(device.Master.pub.ip.4) $(device.Worker.pub.ip.4)
+      start: ./.cloudtest/packet/create-kubernetes-cluster.sh $(device.Master.pub.ip.4) $(device.Worker.pub.ip.4) "$(tempdir)/sshkey"
       prepare: |
         make k8s-config helm-init
         make spire-install

--- a/.cloudtest/packet/create-kubernetes-cluster.sh
+++ b/.cloudtest/packet/create-kubernetes-cluster.sh
@@ -3,8 +3,9 @@
 
 master_ip=$1
 worker_ip=$2
+sshkey=$3
 
-SSH_OPTS="-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no"
+SSH_OPTS="-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o IdentitiesOnly=yes -i ${sshkey}"
 
 
 # Install kubeadm, kubelet and kubectl

--- a/.cloudtest/packet/download-postmortem-data.sh
+++ b/.cloudtest/packet/download-postmortem-data.sh
@@ -4,8 +4,9 @@
 master_ip=$1
 worker_ip=$2
 cluster_id=$3
+sshkey=$4
 
-SSH_OPTS="-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no"
+SSH_OPTS="-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o IdentitiesOnly=yes -i ${sshkey}"
 SOURCE_LOC="/var/tmp/nsm-postmortem/"
 
 mkdir -p ~/postmortem

--- a/scripts/terraform/create-kubernetes-cluster.sh
+++ b/scripts/terraform/create-kubernetes-cluster.sh
@@ -5,7 +5,7 @@ cluster_id=${PACKET_CLUSTER_ID:-1}
 master_ip="$(terraform output master${cluster_id}.public_ip)"
 worker_ip="$(terraform output worker${cluster_id}_1.public_ip)"
 
-SSH_OPTS="-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no"
+SSH_OPTS="-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o IdentitiesOnly=yes"
 
 
 # Install kubeadm, kubelet and kubectl

--- a/scripts/terraform/download-postmortem-data.sh
+++ b/scripts/terraform/download-postmortem-data.sh
@@ -5,7 +5,7 @@ cluster_id=${PACKET_CLUSTER_ID:-1}
 master_ip="$(terraform output master${cluster_id}.public_ip)"
 worker_ip="$(terraform output worker${cluster_id}_1.public_ip)"
 
-SSH_OPTS="-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no"
+SSH_OPTS="-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o IdentitiesOnly=yes"
 SOURCE_LOC="/var/tmp/nsm-postmortem/"
 
 mkdir -p ~/postmortem


### PR DESCRIPTION
Signed-off-by: Artem Belov <artem.belov@xored.com>

## Description
Add `IdentitiesOnly=yes` option to ssh command

## Motivation and Context
Packet start script fails with error:
`Received disconnect from <ip> port 22:2: Too many authentication failures`
https://117120-127937836-gh.circle-artifacts.com/0/home/circleci/project/.tests/cloud_test/packet-6/032-start.log

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [ ] Covered by existing integration testing
- [ ] Added integration testing to cover
- [x] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
