### PR TITLE
Fix failed ping in vpn tests

### DIFF
--- a/test/integration/usecase_vpn_test.go
+++ b/test/integration/usecase_vpn_test.go
@@ -240,7 +240,13 @@ func testVPN(t *testing.T, ptnum, nodesCount int, affinity map[string]int, verbo
 
 	g.Expect(strings.Contains(routeResponse, "nsm")).To(Equal(true))
 	for i := 1; i <= 1; i++ {
-		pingResponse, errOut, err = k8s.Exec(nscPodNode, nscPodNode.Spec.Containers[0].Name, pingCommand, dstIP, "-A", "-c", "10")
+		// 3 Attempts (sometimes ping command fails on first try)
+		for att := 0; att < 3; att++ {
+			pingResponse, errOut, err = k8s.Exec(nscPodNode, nscPodNode.Spec.Containers[0].Name, pingCommand, dstIP, "-A", "-c", "10")
+			if err == nil {
+				break
+			}
+		}
 		g.Expect(err).To(BeNil())
 		g.Expect(strings.Contains(pingResponse, "10 packets received")).To(Equal(true))
 		logrus.Printf("VPN NSC Ping succeeded:%s", pingResponse)


### PR DESCRIPTION
Signed-off-by: Artem Belov <artem.belov@xored.com>

## Description
Added few ping attempts in vpn tests check.

## Motivation and Context
Sometimes for some reason ping fails on first attempt, but starts passing on the second. 
https://github.com/networkservicemesh/networkservicemesh/issues/1940

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [x] Covered by existing integration testing
- [ ] Added integration testing to cover
- [ ] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
