### PR TITLE
Repeat AWS cluster creation if catched Throttling error

### DIFF
--- a/scripts/aws/create-kubernetes-cluster.go
+++ b/scripts/aws/create-kubernetes-cluster.go
@@ -34,13 +34,12 @@ func (ac *AWSCluster) checkError(err error) {
 			case "ResourceInUseException":
 			case "InvalidKeyPair.Duplicate":
 			case "InvalidPermission.Duplicate":
-			case "Throttling":
 			default:
-				log.Fatalf("Error (%s): %s\n", aerr.Code(), aerr.Message())
+				panic(aerr)
 			}
 			log.Printf("Warning (%s): %s\n", aerr.Code(), aerr.Message())
 		} else {
-			log.Fatalf("Error: %s\n", err.Error())
+			panic(err)
 		}
 	}
 }


### PR DESCRIPTION
Signed-off-by: Artem Belov <artem.belov@xored.com>

## Description
Restart cluster creation script if Throttling error

## Motivation and Context
Creating few clusters in parallel may cause AWS Throttling error
https://circleci.com/gh/networkservicemesh/networkservicemesh/117730

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [ ] Covered by existing integration testing
- [ ] Added integration testing to cover
- [x] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
