### PR TITLE
Delete `HealNscChecker`

### DIFF
--- a/test/integration/recover_nse_nsm_heal_test.go
+++ b/test/integration/recover_nse_nsm_heal_test.go
@@ -60,7 +60,7 @@ func TestNSMHealLocalDieNSMD(t *testing.T) {
 	k8s.WaitLogsContains(nodes_setup[0].Nsmd, "nsmd", "Heal: Connection recovered:", defaultTimeout)
 	logrus.Infof("Waiting for connection recovery Done...")
 
-	kubetest.HealNscChecker(k8s, nscPodNode)
+	kubetest.CheckNSC(k8s, nscPodNode)
 }
 
 func TestNSMHealLocalDieNSMDOneNode(t *testing.T) {

--- a/test/integration/recover_remote_nse_nsm_heal_test.go
+++ b/test/integration/recover_remote_nse_nsm_heal_test.go
@@ -80,7 +80,7 @@ func TestNSMHealRemoteDieNSMD_NSE(t *testing.T) {
 	k8s.WaitLogsContains(nodes_setup[0].Nsmd, "nsmd", "Heal: Connection recovered:", defaultTimeout)
 	logrus.Infof("Waiting for connection recovery Done...")
 
-	kubetest.HealNscChecker(k8s, nscPodNode)
+	kubetest.CheckNSC(k8s, nscPodNode)
 }
 
 func TestNSMHealRemoteDieNSMD(t *testing.T) {
@@ -126,7 +126,7 @@ func TestNSMHealRemoteDieNSMD(t *testing.T) {
 	k8s.WaitLogsContains(nodes_setup[0].Nsmd, "nsmd", "Heal: Connection recovered:", defaultTimeout)
 	logrus.Infof("Waiting for connection recovery Done...")
 
-	kubetest.HealNscChecker(k8s, nscPodNode)
+	kubetest.CheckNSC(k8s, nscPodNode)
 }
 
 func TestNSMHealRemoteDieNSMDFakeEndpoint(t *testing.T) {
@@ -201,5 +201,5 @@ func TestNSMHealRemoteDieNSMDFakeEndpoint(t *testing.T) {
 	k8s.WaitLogsContains(nodesSetup[0].Nsmd, "nsmd", "Heal: Connection recovered:", defaultTimeout)
 	logrus.Infof("Waiting for connection recovery Done...")
 
-	kubetest.HealNscChecker(k8s, nscPodNode)
+	kubetest.CheckNSC(k8s, nscPodNode)
 }

--- a/test/kubetest/utils.go
+++ b/test/kubetest/utils.go
@@ -783,26 +783,6 @@ func checkNSCConfig(k8s *K8s, nscPodNode *v1.Pod, checkIP, pingIP string) *NSCCh
 	return info
 }
 
-// HealNscChecker checks that heal worked properly
-func HealNscChecker(k8s *K8s, nscPod *v1.Pod) *NSCCheckInfo {
-	const attempts = 10
-	success := false
-	var rv *NSCCheckInfo
-	for i := 0; i < attempts; i++ {
-		info := &NSCCheckInfo{}
-		info.pingResponse = pingNse(k8s, nscPod)
-
-		if !strings.Contains(info.pingResponse, "100% packet loss") {
-			success = true
-			rv = info
-			break
-		}
-		<-time.After(time.Second)
-	}
-	k8s.g.Expect(success).To(BeTrue())
-	return rv
-}
-
 // IsBrokeTestsEnabled - Check if broken tests are enabled
 func IsBrokeTestsEnabled() bool {
 	_, ok := os.LookupEnv("BROKEN_TESTS_ENABLED")


### PR DESCRIPTION
Signed-off-by: Denis Tingajkin <denis.tingajkin@xored.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
`HealTestingPodFixture` has been removed by [this]( https://github.com/networkservicemesh/networkservicemesh/commit/fcafc5b537ae5b52677b6a9d98f9b7cdf1a9ec90) , but some tests still use `HealNscChecker`. This checker should be deleted because the problem with arp entries is solved.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [ ] Covered by existing integration testing
- [ ] Added integration testing to cover
- [X] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
