### PR TITLE
Interdomain helm fixes

### DIFF
--- a/deployments/helm/nsm/templates/nsmgr.tpl
+++ b/deployments/helm/nsm/templates/nsmgr.tpl
@@ -58,6 +58,9 @@ spec:
             - name: JAEGER_AGENT_PORT
               value: "6831"
 {{- end }}
+          ports:
+            - containerPort: 5001
+              hostPort: 5001
           volumeMounts:
             - name: nsm-socket
               mountPath: /var/lib/networkservicemesh

--- a/deployments/helm/proxy-nsmgr/templates/proxy-nsmgr.tpl
+++ b/deployments/helm/proxy-nsmgr/templates/proxy-nsmgr.tpl
@@ -13,6 +13,7 @@ spec:
       labels:
         app: proxy-nsmgr-daemonset
     spec:
+      serviceAccount: nsmgr-acc
       containers:
         - name: proxy-nsmd
           image: {{ .Values.registry }}/{{ .Values.org }}/proxy-nsmd:{{ .Values.tag }}
@@ -20,13 +21,28 @@ spec:
           ports:
             - containerPort: 5006
               hostPort: 5006
+          env:
+            - name: INSECURE
+{{- if .Values.insecure }}
+              value: "true"
+{{- else }}
+              value: "false"
+{{- end }}
+            - name: PROXY_NSMD_K8S_REMOTE_PORT
+              value: "5005"
         - name: proxy-nsmd-k8s
           image: {{ .Values.registry }}/{{ .Values.org }}/proxy-nsmd-k8s:{{ .Values.tag }}
           imagePullPolicy: {{ .Values.pullPolicy }}
           ports:
-            - containerPort: 80
+            - containerPort: 5005
               hostPort: 5005
           env:
+            - name: INSECURE
+{{- if .Values.insecure }}
+              value: "true"
+{{- else }}
+              value: "false"
+{{- end }}
             - name: NODE_NAME
               valueFrom:
                 fieldRef:
@@ -39,6 +55,8 @@ spec:
             - name: JAEGER_AGENT_PORT
               value: "6831"
 {{- end }}
+            - name: PROXY_NSMD_K8S_REMOTE_PORT
+              value: "5005"
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes: #1994 

## Description
<!--- Describe your changes in detail -->
- Make port mappings consistent for exposing services in different clusters.  
- Allow proxy-nsmgr to be deployed in insecure mode
- Set the proxy-nsmgr's service account to the same as nsmgr.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [ ] Covered by existing integration testing
- [ ] Added integration testing to cover
- [ ] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->
Tested with the virtual L3 example.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
