### PR TITLE
nsmgr interdomain: getEndpoint needs to check if specific endpoint is remote

### DIFF
--- a/controlplane/pkg/nsm/nse_manager.go
+++ b/controlplane/pkg/nsm/nse_manager.go
@@ -31,13 +31,17 @@ func (nsem *nseManager) GetEndpoint(ctx context.Context, requestConnection *conn
 	span.LogObject("ignores", ignoreEndpoints)
 	// Handle case we are remote NSM and asked for particular endpoint to connect to.
 	targetEndpoint := requestConnection.GetNetworkServiceEndpointName()
+	myNsemName := nsem.model.GetNsm().GetName()
+	targetNsemName := requestConnection.GetDestinationNetworkServiceManagerName()
 	span.LogObject("targetEndpoint", targetEndpoint)
 	if len(targetEndpoint) > 0 {
-		endpoint := nsem.model.GetEndpoint(targetEndpoint)
-		if endpoint != nil && ignoreEndpoints[endpoint.Endpoint.GetEndpointNSMName()] == nil {
-			return endpoint.Endpoint, nil
-		} else {
-			return nil, errors.Errorf("Could not find endpoint with name: %s at local registry", targetEndpoint)
+		if len(targetNsemName) > 0 && myNsemName == targetNsemName {
+			endpoint := nsem.model.GetEndpoint(targetEndpoint)
+			if endpoint != nil && ignoreEndpoints[endpoint.Endpoint.GetEndpointNSMName()] == nil {
+				return endpoint.Endpoint, nil
+			} else {
+				return nil, errors.Errorf("Could not find endpoint with name: %s at local registry", targetEndpoint)
+			}
 		}
 	}
 


### PR DESCRIPTION

- if client is asking for exact endpoint it can't assume the endpoint is
  owned by itself--e.g. check the network_service_manager name.

Signed-off-by: Tim Swanson <tiswanso@cisco.com>

<!--- Provide a general summary of your changes in the Title above -->

Fixes: #1997

## Description
<!--- Describe your changes in detail -->
Check whether the endpoint info in the request is for the current nsmgr via checking the network_service_manager name.  If it's not the same, perform a find and forward the request along.

*NOTE*:  this diff currently doesn't check the find result to match up with requested endpoint and name.  That will be added (possibly in a follow-on PR or this one if folks agree).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [ ] Covered by existing integration testing
- [ ] Added integration testing to cover
- [ ] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
