### PR TITLE
CloudTest: do not report as failed tests skipped due cluster unavailability when a whole cloud is down

### DIFF
--- a/test/cloudtest/pkg/tests/all_cluster_fail_test.go
+++ b/test/cloudtest/pkg/tests/all_cluster_fail_test.go
@@ -38,7 +38,7 @@ func TestClusterInstancesFailed(t *testing.T) {
 	testConfig.Reporting.JUnitReportFile = JunitReport
 
 	report, err := commands.PerformTesting(testConfig, &testValidationFactory{}, &commands.Arguments{})
-	g.Expect(err.Error()).To(Equal("there is failed tests 6"))
+	g.Expect(err.Error()).To(Equal("there is failed tests 3"))
 
 	g.Expect(report).NotTo(BeNil())
 
@@ -47,7 +47,7 @@ func TestClusterInstancesFailed(t *testing.T) {
 	g.Expect(report.Suites[0].Tests).To(Equal(3))
 	g.Expect(len(report.Suites[0].TestCases)).To(Equal(3))
 
-	g.Expect(report.Suites[1].Failures).To(Equal(5))
+	g.Expect(report.Suites[1].Failures).To(Equal(2))
 	g.Expect(report.Suites[1].Tests).To(Equal(5))
 	g.Expect(len(report.Suites[1].TestCases)).To(Equal(5))
 
@@ -80,7 +80,7 @@ func TestClusterInstancesOnFailGoRunner(t *testing.T) {
 	testConfig.Reporting.JUnitReportFile = JunitReport
 
 	report, err := commands.PerformTesting(testConfig, &testValidationFactory{}, &commands.Arguments{})
-	g.Expect(err.Error()).To(Equal("there is failed tests 6"))
+	g.Expect(err.Error()).To(Equal("there is failed tests 3"))
 
 	g.Expect(report).NotTo(BeNil())
 
@@ -89,7 +89,7 @@ func TestClusterInstancesOnFailGoRunner(t *testing.T) {
 	g.Expect(report.Suites[0].Tests).To(Equal(3))
 	g.Expect(len(report.Suites[0].TestCases)).To(Equal(3))
 
-	g.Expect(report.Suites[1].Failures).To(Equal(5))
+	g.Expect(report.Suites[1].Failures).To(Equal(2))
 	g.Expect(report.Suites[1].Tests).To(Equal(5))
 	g.Expect(len(report.Suites[1].TestCases)).To(Equal(5))
 

--- a/test/cloudtest/pkg/tests/retest_test.go
+++ b/test/cloudtest/pkg/tests/retest_test.go
@@ -112,12 +112,12 @@ func TestRestartRetestDestroyCluster(t *testing.T) {
 	testConfig.Reporting.JUnitReportFile = JunitReport
 
 	report, err := commands.PerformTesting(testConfig, &testValidationFactory{}, &commands.Arguments{})
-	g.Expect(err.Error()).To(Equal("there is failed tests 2"))
+	g.Expect(err.Error()).To(Equal("there is failed tests 1"))
 
 	g.Expect(report).NotTo(BeNil())
 
 	g.Expect(len(report.Suites)).To(Equal(1))
-	g.Expect(report.Suites[0].Failures).To(Equal(2))
+	g.Expect(report.Suites[0].Failures).To(Equal(1))
 	g.Expect(report.Suites[0].Tests).To(Equal(3))
 	g.Expect(len(report.Suites[0].TestCases)).To(Equal(3))
 
@@ -129,7 +129,7 @@ func TestRestartRetestDestroyCluster(t *testing.T) {
 		"Starting cluster ",
 		"Starting TestRequestRestart",
 		"Re schedule task TestRequestRestart reason: rerun-request",
-		"Skip-and-fail TestRequestRestart on a_provider-1: 1 of 1 required cluster(s) unavailable: [a_provider]",
+		"Skip TestRequestRestart on a_provider-1: 1 of 1 required cluster(s) unavailable: [a_provider]",
 	})
 }
 


### PR DESCRIPTION
Signed-off-by: Alexander Yustus <alexander.yustus@xored.com>

Currently, in a situation when one of the providers is completely down, the tests scheduled for its clusters appear as failed at the end of testing.

This should not happen.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [ ] Covered by existing integration testing
- [ ] Added integration testing to cover
- [ ] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
