### PR TITLE
Fix: 'CloudTest: Test doesn't get rescheduled when cluster fails'

### DIFF
--- a/test/cloudtest/pkg/commands/main.go
+++ b/test/cloudtest/pkg/commands/main.go
@@ -189,7 +189,7 @@ func performImport(testConfig *config.CloudTestConfig) error {
 	return nil
 }
 
-// PerformTesting - PerformTesting
+// PerformTesting performs cloud test testing. Returns junit report file.
 func PerformTesting(config *config.CloudTestConfig, factory k8s.ValidationFactory, arguments *Arguments) (*reporting.JUnitFile, error) {
 	ctx := &executionContext{
 		cloudTestConfig:  config,
@@ -200,17 +200,19 @@ func PerformTesting(config *config.CloudTestConfig, factory k8s.ValidationFactor
 		tests:            []*model.TestEntry{},
 		factory:          factory,
 		arguments:        arguments,
+		manager:          execmanager.NewExecutionManager(config.ConfigRoot),
 	}
-	ctx.manager = execmanager.NewExecutionManager(ctx.cloudTestConfig.ConfigRoot)
+	return performTestingContext(ctx)
+}
+
+func performTestingContext(ctx *executionContext) (*reporting.JUnitFile, error) {
 	// Create cluster instance handles
 	if err := ctx.createClusters(); err != nil {
 		return nil, err
 	}
-
 	cleanupCtx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	go ctx.cleanupClusters(cleanupCtx)
-
 	// Collect tests
 	if err := ctx.findTests(); err != nil {
 		logrus.Errorf("Error finding tests %v", err)
@@ -222,14 +224,14 @@ func PerformTesting(config *config.CloudTestConfig, factory k8s.ValidationFactor
 	ctx.createTasks()
 
 	err := ctx.performExecution()
-	reportfile, err2 := ctx.generateJUnitReportFile()
+	result, err2 := ctx.generateJUnitReportFile()
 	if err2 != nil {
 		logrus.Errorf("Error during generation of report: %v", err2)
 	}
 	if err != nil {
-		return reportfile, err
+		return result, err
 	}
-	return reportfile, err2
+	return result, err2
 }
 
 func parseConfig(cloudTestConfig *config.CloudTestConfig, configFileContent []byte) error {
@@ -277,51 +279,58 @@ func (ctx *executionContext) performExecution() error {
 	timeoutCtx, cancelFunc := context.WithTimeout(context.Background(), time.Duration(ctx.cloudTestConfig.Timeout)*time.Second)
 	defer cancelFunc()
 
-	termChannel := tools.NewOSSignalChannel()
-	defer ctx.printStatistics()
-
-	statsTimeout := 60 * time.Second
-	if ctx.cloudTestConfig.Statistics.Enabled && ctx.cloudTestConfig.Statistics.Interval > 0 {
-		statsTimeout = time.Duration(ctx.cloudTestConfig.Statistics.Interval) * time.Second
-	}
-	statTicker := time.NewTicker(statsTimeout)
-	defer statTicker.Stop()
-
-	healthCheckChannel := RunHealthChecks(ctx.cloudTestConfig.HealthCheck)
+	defer func() {
+		if ctx.cloudTestConfig.Statistics.Enabled {
+			ctx.printStatistics()
+		}
+	}()
 
 	for len(ctx.tasks) > 0 || len(ctx.running) > 0 {
 		// WE take 1 test task from list and do execution.
 		ctx.assignTasks()
 		ctx.checkClustersUsage()
 
+		if err := ctx.pollEvents(timeoutCtx); err != nil {
+			return err
+		}
+
 		if len(ctx.tasks) == 0 && len(ctx.running) == 0 {
-			// No tasks left to execute.
 			break
 		}
+	}
+	logrus.Info("Finished test execution")
+	return nil
+}
 
-		select {
-		case event := <-ctx.operationChannel:
-			switch event.kind {
-			case eventClusterUpdate:
-				ctx.performClusterUpdate(event)
-			case eventTaskUpdate:
-				// Remove from running onces.
-				ctx.processTaskUpdate(event)
-			}
-		case <-termChannel:
-			return errors.New("termination request is received")
-		case <-timeoutCtx.Done():
-			return errors.Errorf("global timeout elapsed: %v seconds", ctx.cloudTestConfig.Timeout)
-		case err := <-healthCheckChannel:
-			return errors.Wrapf(err, "health check probe failed")
-		case <-statTicker.C:
-			if ctx.cloudTestConfig.Statistics.Enabled {
-				ctx.printStatistics()
-			}
+func (ctx *executionContext) pollEvents(c context.Context) error {
+	statsTimeout := 60 * time.Second
+	if ctx.cloudTestConfig.Statistics.Enabled && ctx.cloudTestConfig.Statistics.Interval > 0 {
+		statsTimeout = time.Duration(ctx.cloudTestConfig.Statistics.Interval) * time.Second
+	}
+	statTicker := time.NewTicker(statsTimeout)
+	defer statTicker.Stop()
+	healthCheckChannel := RunHealthChecks(ctx.cloudTestConfig.HealthCheck)
+	termChannel := tools.NewOSSignalChannel()
+	select {
+	case event := <-ctx.operationChannel:
+		switch event.kind {
+		case eventClusterUpdate:
+			ctx.performClusterUpdate(event)
+		case eventTaskUpdate:
+			// Remove from running onces.
+			ctx.processTaskUpdate(event)
+		}
+	case <-termChannel:
+		return errors.New("termination request is received")
+	case <-c.Done():
+		return errors.Errorf("global timeout elapsed: %v seconds", ctx.cloudTestConfig.Timeout)
+	case err := <-healthCheckChannel:
+		return errors.Wrapf(err, "health check probe failed")
+	case <-statTicker.C:
+		if ctx.cloudTestConfig.Statistics.Enabled {
+			ctx.printStatistics()
 		}
 	}
-
-	logrus.Info("Finished test execution")
 	return nil
 }
 
@@ -422,7 +431,7 @@ func (ctx *executionContext) processTaskUpdate(event operationEvent) {
 	} else {
 		if event.task.test.Status == model.StatusRerunRequest && ctx.cloudTestConfig.RetestConfig.WarmupTimeout > 0 {
 			go func() {
-				ids := []string{}
+				var ids []string
 				for _, ci := range event.task.clusterInstances {
 					ids = append(ids, ci.id)
 				}
@@ -433,12 +442,8 @@ func (ctx *executionContext) processTaskUpdate(event operationEvent) {
 				ctx.rescheduleTask(event)
 				logrus.Infof("Re schedule task %v reason: %v", event.task.test.Name, statusName(event.task.test.Status))
 			}()
-		} else if event.task.test.Status == model.StatusRerunRequest {
-			// Make cluster as ready
-			ctx.rescheduleTask(event)
-			logrus.Infof("Re schedule task %v reason: %v", event.task.test.Name, statusName(event.task.test.Status))
 		} else {
-			ctx.completeTask(event)
+			ctx.rescheduleTask(event)
 			logrus.Infof("Re schedule task %v reason: %v", event.task.test.Name, statusName(event.task.test.Status))
 		}
 	}

--- a/test/cloudtest/pkg/commands/poll_events_test.go
+++ b/test/cloudtest/pkg/commands/poll_events_test.go
@@ -1,0 +1,46 @@
+package commands
+
+import (
+	"context"
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/networkservicemesh/networkservicemesh/test/cloudtest/pkg/utils"
+
+	"github.com/networkservicemesh/networkservicemesh/test/cloudtest/pkg/execmanager"
+
+	"github.com/networkservicemesh/networkservicemesh/test/cloudtest/pkg/model"
+
+	"github.com/networkservicemesh/networkservicemesh/test/cloudtest/pkg/config"
+
+	"github.com/onsi/gomega"
+)
+
+func TestUpdateTaskWithTimeout_ShouldNotCompeteTask(t *testing.T) {
+	assert := gomega.NewWithT(t)
+	tmpDir, err := ioutil.TempDir(os.TempDir(), t.Name())
+	defer utils.ClearFolder(tmpDir, false)
+	assert.Expect(err).To(gomega.BeNil())
+
+	ctx := executionContext{
+		cloudTestConfig:  config.NewCloudTestConfig(),
+		manager:          execmanager.NewExecutionManager(tmpDir),
+		running:          make(map[string]*testTask),
+		operationChannel: make(chan operationEvent, 1),
+	}
+	ctx.cloudTestConfig.Timeout = 2
+	ctx.cloudTestConfig.Statistics.Enabled = false
+	task := &testTask{
+		test: &model.TestEntry{
+			ExecutionConfig: &config.ExecutionConfig{
+				Timeout: 1,
+			},
+			Status: model.StatusSkipped,
+		},
+	}
+	ctx.tasks = append(ctx.tasks, task)
+	ctx.updateTestExecution(task, "", model.StatusTimeout)
+	_ = ctx.pollEvents(context.Background())
+	assert.Expect(len(ctx.completed)).Should(gomega.BeZero())
+}


### PR DESCRIPTION
Signed-off-by: Denis Tingajkin <denis.tingajkin@xored.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
https://github.com/networkservicemesh/networkservicemesh/issues/1981

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [ ] Covered by existing integration testing
- [ ] Added unit testing to cover
- [X] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
