### PR TITLE
WIP: Cleanup old CI generated images from DockerHub

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -228,6 +228,19 @@ jobs:
           command: |
             .circleci/helm/test-charts.sh
 
+  cleanup-images:
+    docker:
+      - image: circleci/golang:1.13-stretch
+    steps:
+      - checkout
+      - run:
+          name: Cleanup old CI images from DockerHub
+          command: |
+            CONTAINER_REPO="networkservicemeshci"
+            # Limit the number of tags to remove so it doesn't take much time of every CI run
+            tags=$(MIN_AGE_DAYS=7 .circleci/dockerhub-repo-tags $CONTAINER_REPO/nsmd | head -10) || true
+            REPO=$CONTAINER_REPO TAGS="$tags" IMAGES=$(make docker-list) .circleci/dockerhub-image-remove
+
 # workflows
 workflows:
   version: 2
@@ -262,3 +275,5 @@ workflows:
           filters:
             branches:
               only: master
+
+      - cleanup-images

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -211,16 +211,7 @@ jobs:
             export CONTAINER_TAG="<< parameters.tag >>"
             export REPO="networkservicemesh"
             export PULL_REPO="networkservicemeshci"
-            export CONTAINERS=(nsmd nsmd-k8s nsmdp)
-            export CONTAINERS=(${CONTAINERS[@]} proxy-nsmd proxy-nsmd-k8s)
-            export CONTAINERS=(${CONTAINERS[@]} crossconnect-monitor nsm-init nsm-monitor admission-webhook)
-            export CONTAINERS=(${CONTAINERS[@]} vppagent-forwarder)
-            export CONTAINERS=(${CONTAINERS[@]} test-common vpp-test-common nsm-coredns)
-            export CONTAINERS=(${CONTAINERS[@]} kernel-forwarder)
-            export CONTAINERS=(${CONTAINERS[@]} spire-registration)
-            export CONTAINERS=(${CONTAINERS[@]} prefix-service)
-            echo "${DOCKER_PASSWORD}" | docker login -u "${DOCKER_USERNAME}" --password-stdin
-            for c in ${CONTAINERS[@]}; do
+            for c in $(make docker-list); do
               docker pull ${PULL_REPO}/${c}:${PULL_TAG}
               docker tag ${PULL_REPO}/${c}:${PULL_TAG} ${REPO}/${c}:${CONTAINER_TAG}
               docker push ${REPO}/${c}:${CONTAINER_TAG}

--- a/.circleci/dockerhub-image-remove
+++ b/.circleci/dockerhub-image-remove
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+error(){ echo "error: $*" >&2; exit 1; }
+info(){ echo "$*" >&2; }
+
+JWT_TOKEN=$(curl -s -H "Content-Type: application/json" -X POST \
+  -d '{"username": "'$DOCKER_USERNAME'", "password": "'$DOCKER_PASSWORD'"}' \
+  https://hub.docker.com/v2/users/login/ \
+    | jq -r .token) || error "failed to get access token"
+
+image=${1%%:*}
+[ -n "$image" ] && IMAGES=$image # Override with value from command line
+[ -z "$IMAGES" ] && info "No IMAGES given, nothing to do" && exit
+
+[ "$image" != "$1" ] && tag=${1##*:}
+[ -n "$tag" ] && TAGS=$tag # Override with value from command line
+[ -z "$TAGS" ] && info "No TAGS given, nothing to do" && exit
+
+for tag in $TAGS; do
+  echo "Removing images for tag $tag:"
+  for image in $IMAGES; do
+    echo -n "$image "
+    repo="$REPO/$image"
+    curl -s "https://hub.docker.com/v2/repositories/${repo}/tags/${tag}/" \
+      -X DELETE \
+      -H "Authorization: JWT ${JWT_TOKEN}" || echo -n "FAILED"
+  done
+  echo
+done
+
+echo Done

--- a/.circleci/dockerhub-repo-tags
+++ b/.circleci/dockerhub-repo-tags
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+#set -x
+error(){ echo "error: $*" >&2; exit 1; }
+info(){ echo "info: $*" >&2; }
+trace(){ [ "$DEBUG" != "1" ] && echo "trace: $*" >&2; }
+
+initParameter() {
+  name=$1
+  val=$2
+  dflt=$3
+  if [ -z "$val" ]; then
+    info "Set '$name' to default: $dflt"
+    eval "$name=$dflt"
+  else
+    eval "$name=$val"
+  fi
+}
+
+REPO=$1
+initParameter ORGANIZATION "${REPO%%/*}" networkservicemeshci
+initParameter IMAGE "${REPO##*/}" nsmd
+
+if [ -n "$MIN_AGE_DAYS" ]; then
+  [[ "$MIN_AGE_DAYS" == +([0-9]) ]] || error "MIN_AGE_DAYS: an integer is expected, got '$MIN_AGE_DAYS'"
+  minAge=$((MIN_AGE_DAYS * 24 * 60 * 60))
+  NOW=$(date --utc +%s)
+fi
+
+# read field(s) from json
+field() {  echo "$1" | jq -r "$2"; }
+
+next="https://hub.docker.com/v2/repositories/${ORGANIZATION}/${IMAGE}/tags"
+
+while [[ "$next" != null ]]; do
+  list=$(curl -s "$next") || error "failed to fetch URL: $next"
+  tagCount=$(field "$list" '.results[].name' | wc -l)
+  for ((i=0; i < tagCount; ++i)); do
+    tagInfo=$(field "$list" ".results[$i]")
+    if [ -n "$minAge" ]; then
+      timestamp=$(field "$tagInfo" .last_updated)
+      ts=$(date -d "$timestamp" +%s)
+      (( (NOW - ts) < minAge)) && continue
+    fi
+    name=$(field "$tagInfo" .name)
+    echo "$name"
+  done
+
+  next=$(field "$list" .next)
+#  trace "next: $next"
+done

--- a/.mk/build.mk
+++ b/.mk/build.mk
@@ -55,6 +55,10 @@ $(foreach module, $(modules), $(eval $(call build_rule, $(module))))
 images += $(modules)
 images += spire-registration
 
+.PHONY: docker-list
+docker-list: $(addsuffix -list, $(addprefix docker-, $(modules)))
+	@echo spire-registration
+
 .PHONY: docker-build
 docker-build: $(addsuffix -build, $(addprefix docker-, $(images)))
 

--- a/controlplane/build.mk
+++ b/controlplane/build.mk
@@ -18,6 +18,10 @@ controlplane_targets = $(addsuffix -build, $(addprefix go-, $(controlplane_apps)
 .PHONY: $(controlplane_targets)
 $(controlplane_targets): go-%-build: controlplane-%-build
 
+.PHONY: docker-controlplane-list
+docker-controlplane-list:
+	@echo $(controlplane_apps)
+
 .PHONY: docker-controlplane-build
 docker-controlplane-build: $(addsuffix -build, $(addprefix docker-, $(controlplane_apps)))
 

--- a/forwarder/build.mk
+++ b/forwarder/build.mk
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+forwarder_images = vppagent-forwarder kernel-forwarder
+
 # TODO: files in forwarder doesn't follow the regular structure: ./module/cmd/app,
 # after fixing 'kernel-forwarder' and 'vppagent-forwarder' targets could be eliminated
 .PHONY: go-kernel-forwarder-build
@@ -37,12 +39,16 @@ docker-vppagent-forwarder-prepare: docker-%-prepare: go-%-build
 		forwarder/vppagent/conf/supervisord/supervisord.conf \
 		forwarder/vppagent/conf/supervisord/govpp.conf)
 
+.PHONY: docker-forwarder-list
+docker-forwarder-list:
+	@echo $(forwarder_images)
+
 .PHONY: docker-forwarder-build
-docker-forwarder-build: docker-vppagent-forwarder-build docker-kernel-forwarder-build
+docker-forwarder-build: $(addsuffix -build, $(addprefix docker-, $(forwarder_images)))
 
 .PHONY: docker-forwarder-save
-docker-forwarder-save: docker-vppagent-forwarder-save docker-kernel-forwarder-save
+docker-forwarder-save: $(addsuffix -save, $(addprefix docker-, $(forwarder_images)))
 
 .PHONY: docker-forwarder-push
-docker-forwarder-push: docker-vppagent-forwarder-push docker-kernel-forwarder-push
+docker-forwarder-push: $(addsuffix -push, $(addprefix docker-, $(forwarder_images)))
 

--- a/k8s/build.mk
+++ b/k8s/build.mk
@@ -15,6 +15,10 @@
 k8s_apps = $(shell ls ./k8s/cmd/)
 k8s_targets = $(addsuffix -build, $(addprefix go-, $(k8s_apps)))
 
+.PHONY: docker-k8s-list
+docker-k8s-list:
+	@echo $(k8s_apps)
+
 .PHONY: $(k8s_targets)
 $(k8s_targets): go-%-build: k8s-%-build
 

--- a/side-cars/build.mk
+++ b/side-cars/build.mk
@@ -15,6 +15,10 @@
 sidecars_apps = $(shell ls ./side-cars/cmd/)
 sidecars_targets = $(addsuffix -build, $(addprefix go-, $(sidecars_apps)))
 
+.PHONY: docker-side-cars-list
+docker-side-cars-list:
+	@echo $(sidecars_apps)
+
 .PHONY: $(sidecars_targets)
 $(sidecars_targets): go-%-build: side-cars-%-build
 

--- a/test/build.mk
+++ b/test/build.mk
@@ -14,6 +14,7 @@
 
 test_apps = $(shell ls ./test/applications/cmd/)
 test_targets = $(addsuffix -build, $(addprefix go-, $(test_apps)))
+test_images = test-common vpp-test-common
 
 # TODO: files in test doesn't follow the regular structure: ./module/cmd/app,
 # we should get rid of 'application' directory to have for example ./test/cmd/icmp-responder-nse
@@ -42,12 +43,16 @@ docker-vpp-test-common-prepare: docker-%-prepare: $(addsuffix -build, $(addprefi
 		test/applications/vpp-conf/supervisord.conf \
 		test/applications/vpp-conf/run.sh)
 
+.PHONY: docker-test-list
+docker-test-list:
+	@echo $(test_images)
+
 .PHONY: docker-test-build
-docker-test-build: docker-test-common-build docker-vpp-test-common-build
+docker-test-build: $(addsuffix -build, $(addprefix docker-, $(test_images)))
 
 .PHONY: docker-test-save
-docker-test-save: docker-test-common-save docker-vpp-test-common-save
+docker-test-save: $(addsuffix -save, $(addprefix docker-, $(test_images)))
 
 .PHONY: docker-test-push
-docker-test-push: docker-test-common-push docker-vpp-test-common-push
+docker-test-push: $(addsuffix -push, $(addprefix docker-, $(test_images)))
 


### PR DESCRIPTION
#1728 

The implementation that doesn't use separate worker to detect when CI workflow finishes.
Each CI run removes at most 10 tags of CI images older that given number of days, if there are any.
Currently there are about 2000 old tags for each container in CI repos.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [ ] Covered by existing integration testing
- [ ] Added integration testing to cover
- [ ] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
