### PR TITLE
Fix: Sometimes VPN tests not passing because ping is not a success with 1 attempt

### DIFF
--- a/controlplane/pkg/local/forwarder_service.go
+++ b/controlplane/pkg/local/forwarder_service.go
@@ -260,7 +260,9 @@ func (cce *forwarderService) updateClientConnection(ctx context.Context, conn *c
 
 	clientConnection.ForwarderRegisteredName = dp.RegisteredName
 	clientConnection.ForwarderState = model.ForwarderStateReady
-
+	if clientConnection.GetConnectionDestination() != nil && clientConnection.GetConnectionDestination().GetContext() != nil {
+		conn.Context.EthernetContext = clientConnection.GetConnectionDestination().GetContext().EthernetContext
+	}
 	return conn, nil
 }
 

--- a/forwarder/sdk/vppagent/chained_forwarder_server.go
+++ b/forwarder/sdk/vppagent/chained_forwarder_server.go
@@ -1,4 +1,5 @@
-package forwarder
+//Package vppagent provides sdk API for creating chaining vppagent forwarders
+package vppagent
 
 import (
 	"context"

--- a/forwarder/sdk/vppagent/chained_forwarder_server_test.go
+++ b/forwarder/sdk/vppagent/chained_forwarder_server_test.go
@@ -1,4 +1,4 @@
-package forwarder
+package vppagent
 
 import (
 	"context"

--- a/forwarder/sdk/vppagent/clear_mechanisms.go
+++ b/forwarder/sdk/vppagent/clear_mechanisms.go
@@ -1,4 +1,4 @@
-package forwarder
+package vppagent
 
 import (
 	"context"
@@ -40,17 +40,17 @@ func (c *clearMechanisms) Request(ctx context.Context, crossConnect *crossconnec
 		logrus.Infof("montir has not entry with id %v", crossConnect.GetId())
 		return nextRequest(ctx, crossConnect)
 	}
-	clearDataChange, cErr := converter.NewCrossConnectConverter(entity.(*crossconnect.CrossConnect), conversionParameters).MechanismsToDataRequest(nil, false)
-	if cErr == nil && clearDataChange != nil {
+	clearDataChange, err := converter.NewCrossConnectConverter(entity.(*crossconnect.CrossConnect), conversionParameters).MechanismsToDataRequest(nil, false)
+	if err == nil && clearDataChange != nil {
 		logrus.Infof("Sending clearing DataChange to vppagent: %v", proto.MarshalTextString(clearDataChange))
 		client := ConfiguratorClient(ctx)
 		if client == nil {
 			return nil, errors.New("configuration client is not passed for clear mechanism")
 		}
-		_, cErr = client.Delete(ctx, &configurator.DeleteRequest{Delete: clearDataChange})
+		_, err = client.Delete(ctx, &configurator.DeleteRequest{Delete: clearDataChange})
 	}
-	if cErr != nil {
-		logrus.Warnf("Connection Mechanism was not cleared properly before updating: %s", cErr.Error())
+	if err != nil {
+		logrus.Warnf("Connection Mechanism was not cleared properly before updating: %s", err.Error())
 	}
 	return nextRequest(ctx, crossConnect)
 }

--- a/forwarder/sdk/vppagent/commit.go
+++ b/forwarder/sdk/vppagent/commit.go
@@ -1,4 +1,4 @@
-package forwarder
+package vppagent
 
 import (
 	"context"
@@ -68,7 +68,7 @@ func getDataChangeAndClient(ctx context.Context) (*configurator.Config, configur
 	return dataChange, client, nil
 }
 
-// Commit commits changes
+// Commit creates handler for commits changes to vpp-agent
 func Commit(downstreamResync func()) forwarder.ForwarderServer {
 	return &commit{
 		downstreamResync: downstreamResync,

--- a/forwarder/sdk/vppagent/connect.go
+++ b/forwarder/sdk/vppagent/connect.go
@@ -1,4 +1,4 @@
-package forwarder
+package vppagent
 
 import (
 	"context"
@@ -9,7 +9,7 @@ import (
 	"github.com/networkservicemesh/networkservicemesh/forwarder/api/forwarder"
 )
 
-//Connect creates forwarder server handler with connection to vpp-agent confgirator server
+//Connect creates handler with connection to vpp-agent confgirator server
 func Connect(endpoint string) forwarder.ForwarderServer {
 	return &connect{endpoint: endpoint}
 }

--- a/forwarder/sdk/vppagent/context.go
+++ b/forwarder/sdk/vppagent/context.go
@@ -1,4 +1,4 @@
-package forwarder
+package vppagent
 
 import (
 	"context"

--- a/forwarder/sdk/vppagent/direct_memif_interfaces.go
+++ b/forwarder/sdk/vppagent/direct_memif_interfaces.go
@@ -1,4 +1,4 @@
-package forwarder
+package vppagent
 
 import (
 	"context"
@@ -12,18 +12,18 @@ import (
 	"github.com/networkservicemesh/networkservicemesh/forwarder/vppagent/pkg/memif"
 )
 
-//DirectMemifInterfaces creates forwarder server handler with direct memif connection/ disconnection
+//DirectMemifInterfaces creates forwarder server handler for direct memif connections
 func DirectMemifInterfaces(baseDir string) forwarder.ForwarderServer {
-	return &directMemifInterface{
+	return &directMemifInterfaces{
 		directMemifConnector: memif.NewDirectMemifConnector(baseDir),
 	}
 }
 
-type directMemifInterface struct {
+type directMemifInterfaces struct {
 	directMemifConnector *memif.DirectMemifConnector
 }
 
-func (c *directMemifInterface) Request(ctx context.Context, crossConnect *crossconnect.CrossConnect) (*crossconnect.CrossConnect, error) {
+func (c *directMemifInterfaces) Request(ctx context.Context, crossConnect *crossconnect.CrossConnect) (*crossconnect.CrossConnect, error) {
 	if isDirectMemif(crossConnect) {
 		return c.directMemifConnector.Connect(crossConnect)
 	}
@@ -34,7 +34,7 @@ func (c *directMemifInterface) Request(ctx context.Context, crossConnect *crossc
 	return next.Request(ctx, crossConnect)
 }
 
-func (c *directMemifInterface) Close(ctx context.Context, crossConnect *crossconnect.CrossConnect) (*empty.Empty, error) {
+func (c *directMemifInterfaces) Close(ctx context.Context, crossConnect *crossconnect.CrossConnect) (*empty.Empty, error) {
 	if isDirectMemif(crossConnect) {
 		c.directMemifConnector.Disconnect(crossConnect)
 		return new(empty.Empty), nil

--- a/forwarder/sdk/vppagent/kernel_interfaces.go
+++ b/forwarder/sdk/vppagent/kernel_interfaces.go
@@ -1,4 +1,4 @@
-package forwarder
+package vppagent
 
 import (
 	"context"
@@ -10,7 +10,7 @@ import (
 	"github.com/networkservicemesh/networkservicemesh/forwarder/vppagent/pkg/converter"
 )
 
-//KernelInterfaces creates dataplnae server handler with creation dataChange config for kernel and not direct memif connections
+//KernelInterfaces creates forwarder server handler with creation dataChange config for kernel and not direct memif connections
 func KernelInterfaces(baseDir string) forwarder.ForwarderServer {
 	return &kernelInterfaces{baseDir: baseDir}
 }
@@ -34,6 +34,7 @@ func (c *kernelInterfaces) Request(ctx context.Context, crossConnect *crossconne
 	}
 	return next.Request(nextCtx, crossConnect)
 }
+
 func (c *kernelInterfaces) Close(ctx context.Context, crossConnect *crossconnect.CrossConnect) (*empty.Empty, error) {
 	conversionParameters := &converter.CrossConnectConversionParameters{
 		BaseDir: c.baseDir,

--- a/forwarder/sdk/vppagent/next.go
+++ b/forwarder/sdk/vppagent/next.go
@@ -1,4 +1,4 @@
-package forwarder
+package vppagent
 
 import (
 	"context"

--- a/forwarder/sdk/vppagent/request_validator.go
+++ b/forwarder/sdk/vppagent/request_validator.go
@@ -1,4 +1,4 @@
-package forwarder
+package vppagent
 
 import (
 	"context"
@@ -9,15 +9,15 @@ import (
 	"github.com/networkservicemesh/networkservicemesh/forwarder/api/forwarder"
 )
 
-//ConnectionValidator returns Forwarder Server with validation for Request and Close
-func ConnectionValidator() forwarder.ForwarderServer {
-	return &validator{}
+//RequestValidator returns Forwarder Server with validation for Request and Close
+func RequestValidator() forwarder.ForwarderServer {
+	return &requestValidator{}
 }
 
-type validator struct {
+type requestValidator struct {
 }
 
-func (n *validator) Request(ctx context.Context, request *crossconnect.CrossConnect) (*crossconnect.CrossConnect, error) {
+func (n *requestValidator) Request(ctx context.Context, request *crossconnect.CrossConnect) (*crossconnect.CrossConnect, error) {
 	if err := request.IsValid(); err != nil {
 		Logger(ctx).Errorf("Reuqest: %v is not valid, reason: %v", request, err)
 		return nil, err
@@ -28,7 +28,7 @@ func (n *validator) Request(ctx context.Context, request *crossconnect.CrossConn
 	return request, nil
 }
 
-func (n *validator) Close(ctx context.Context, request *crossconnect.CrossConnect) (*empty.Empty, error) {
+func (n *requestValidator) Close(ctx context.Context, request *crossconnect.CrossConnect) (*empty.Empty, error) {
 	if err := request.IsValid(); err != nil {
 		Logger(ctx).Errorf("Close: %v is not valid, reason: %v", request, err)
 		return new(empty.Empty), err

--- a/forwarder/sdk/vppagent/use_crossconnect_monitor.go
+++ b/forwarder/sdk/vppagent/use_crossconnect_monitor.go
@@ -1,4 +1,4 @@
-package forwarder
+package vppagent
 
 import (
 	"context"
@@ -10,8 +10,8 @@ import (
 	monitor_crossconnect "github.com/networkservicemesh/networkservicemesh/sdk/monitor/crossconnect"
 )
 
-//UseMonitor creates forwarder server handler with updating crossconnect monitor server
-func UseMonitor(monitor monitor_crossconnect.MonitorServer) forwarder.ForwarderServer {
+//UseCrossConnectMonitor creates forwarder server handler with updating crossconnect monitor server
+func UseCrossConnectMonitor(monitor monitor_crossconnect.MonitorServer) forwarder.ForwarderServer {
 	return &useMonitor{
 		monitor: monitor,
 	}

--- a/forwarder/vppagent/pkg/vppagent/vppagent.go
+++ b/forwarder/vppagent/pkg/vppagent/vppagent.go
@@ -62,14 +62,14 @@ func CreateVPPAgent() *VPPAgent {
 //CreateForwarderServer creates ForwarderServer handler
 func (v *VPPAgent) CreateForwarderServer(config *common.ForwarderConfig) forwarder.ForwarderServer {
 	return sdk.ChainOf(
-		sdk.ConnectionValidator(),
-		sdk.UseMonitor(config.Monitor),
+		sdk.RequestValidator(),
+		sdk.UseCrossConnectMonitor(config.Monitor),
 		sdk.DirectMemifInterfaces(config.NSMBaseDir),
 		sdk.Connect(v.endpoint()),
 		sdk.KernelInterfaces(config.NSMBaseDir),
+		sdk.UseEthernetContext(),
 		sdk.ClearMechanisms(config.NSMBaseDir),
-		sdk.Commit(v.downstreamResync),
-		sdk.EthernetContextSetter())
+		sdk.Commit(v.downstreamResync))
 }
 
 // MonitorMechanisms sends mechanism updates


### PR DESCRIPTION
Signed-off-by: Denis Tingajkin <denis.tingajkin@xored.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
Sometimes vpn test not passing because ping is not a success with 1 attempt. By logs from https://circleci.com/gh/networkservicemesh/networkservicemesh/118345 I found that ARP entry was not set on NSC interface. Because at now [EthernetContext using only for remote cases](https://github.com/networkservicemesh/networkservicemesh/blob/master/controlplane/pkg/remote/forwarder_service.go#L314) (Before we did not face with ARP problem for local cases).


## Motivation and Context
1) https://circleci.com/gh/networkservicemesh/networkservicemesh/118345
2) https://github.com/networkservicemesh/networkservicemesh/issues/1774


## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [ ] Covered by existing integration testing
- [ ] Added integration testing to cover
- [X] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
