### PR TITLE
CloudTest: re-run test if docker registry was unavailable

### DIFF
--- a/.cloudtest.yaml
+++ b/.cloudtest.yaml
@@ -22,6 +22,8 @@ retest:  # Allow to do test re-run if some kind of failures are detected, line C
     - "NetworkPlugin cni failed to set up pod"    # Error in AWS dur to leak of IPs or not ability to assign them.
     - "etcdserver: request timed out"  # Error in any could, reason unknown.
     - "unable to establish connection to VPP (VPP API socket file /run/vpp/api.sock does not exist)"  # a VPP is not started, it will be re-started in general, but will cause test fail.
+    # Sometimes (rarely) docker registry is unavailable for a moment
+    - "Error response from daemon: Get https://.*docker.io/.*: dial tcp: lookup registry"
 reporting:
   junit-report: "results/junit.xml"
 health-check:


### PR DESCRIPTION
Sometimes, the whole CI run fails because of a single docker registry glitch:

`message\":\"Failed to pull image \\\"networkservicemeshci/nsmd:ci_772866e5-22ed-4ed5-a4d3-ced57a16ee40_c5613003\\\": rpc error: code = Unknown desc = Error response from daemon: Get https://registry-1.docker.io/v2/networkservicemeshci/nsmd/manifests/ci_772866e5-22ed-4ed5-a4d3-ced57a16ee40_c5613003: dial tcp: lookup registry-1.docker.io on 147.75.207.208:53: read udp 139.178.88.101:58317-\\u003e147.75.207.208:53: i/o timeout\"
`

In such situations seems reasonable to make another try, so the PR adds a re-test pattern.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://circleci.com/gh/networkservicemesh/networkservicemesh/118570?utm_campaign=workflow-failed&utm_medium=email&utm_source=notification

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [x] Covered by existing integration testing
- [ ] Added integration testing to cover
- [x] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
