### PR TITLE
Fix closing connection in healing state

### DIFF
--- a/forwarder/pkg/common/monitor_netnsinode_server.go
+++ b/forwarder/pkg/common/monitor_netnsinode_server.go
@@ -21,16 +21,21 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/networkservicemesh/networkservicemesh/controlplane/api/connection/mechanisms/kernel"
-	"github.com/networkservicemesh/networkservicemesh/controlplane/api/connection/mechanisms/memif"
-
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
 	"github.com/networkservicemesh/networkservicemesh/controlplane/api/connection"
+	"github.com/networkservicemesh/networkservicemesh/controlplane/api/connection/mechanisms/kernel"
+	"github.com/networkservicemesh/networkservicemesh/controlplane/api/connection/mechanisms/memif"
 	"github.com/networkservicemesh/networkservicemesh/controlplane/api/crossconnect"
 	monitor_crossconnect "github.com/networkservicemesh/networkservicemesh/sdk/monitor/crossconnect"
+	"github.com/networkservicemesh/networkservicemesh/utils"
 	"github.com/networkservicemesh/networkservicemesh/utils/fs"
+)
+
+const (
+	checkCCLivenessIntervalEnv     = utils.EnvVar("CROSS_CONNECT_LIVENESS_CHECK_INTERVAL")
+	checkCCLivenessIntervalDefault = 1 * time.Second
 )
 
 type MonitorNetNsInodeServer struct {
@@ -81,7 +86,7 @@ func copyEvent(event *crossconnect.CrossConnectEvent) *crossconnect.CrossConnect
 func (m *MonitorNetNsInodeServer) MonitorNetNsInode() {
 	for {
 		select {
-		case <-time.After(1 * time.Second):
+		case <-time.After(checkCCLivenessIntervalEnv.GetOrDefaultDuration(checkCCLivenessIntervalDefault)):
 			if err := m.checkCrossConnectLiveness(); err != nil {
 				logrus.Error(err)
 			}

--- a/forwarder/pkg/common/monitor_netnsinode_server.go
+++ b/forwarder/pkg/common/monitor_netnsinode_server.go
@@ -81,7 +81,7 @@ func copyEvent(event *crossconnect.CrossConnectEvent) *crossconnect.CrossConnect
 func (m *MonitorNetNsInodeServer) MonitorNetNsInode() {
 	for {
 		select {
-		case <-time.After(3 * time.Second):
+		case <-time.After(1 * time.Second):
 			if err := m.checkCrossConnectLiveness(); err != nil {
 				logrus.Error(err)
 			}

--- a/test/integration/recover_nse_heal_test.go
+++ b/test/integration/recover_nse_heal_test.go
@@ -166,3 +166,49 @@ func testNSEHeal(t *testing.T, nodesCount int, affinity map[string]int, fixture 
 
 	fixture.CheckNsc(k8s, nscPodNode)
 }
+
+func TestClosingNSEHealRemoteToLocal(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skip, please run without -short")
+		return
+	}
+
+	g := NewWithT(t)
+
+	affinity := map[string]int{
+		"icmp-responder-nse-1": 1,
+		"icmp-responder-nse-2": 0,
+	}
+	fixture := kubetest.DefaultTestingPodFixture(g)
+
+	k8s, err := kubetest.NewK8s(g, true)
+	g.Expect(err).To(BeNil())
+	defer k8s.Cleanup()
+
+	// Deploy open tracing to see what happening.
+	nodesSetup, err := kubetest.SetupNodes(k8s, 2, defaultTimeout)
+	g.Expect(err).To(BeNil())
+	defer kubetest.MakeLogsSnapshot(k8s, t)
+
+	// Run ICMP
+	node := affinity["icmp-responder-nse-1"]
+	nse1 := fixture.DeployNse(k8s, nodesSetup[node].Node, "icmp-responder-nse-1", defaultTimeout)
+
+	nscPodNode := fixture.DeployNsc(k8s, nodesSetup[0].Node, "nsc-1", defaultTimeout)
+	fixture.CheckNsc(k8s, nscPodNode)
+
+	// Delete NSE
+	k8s.DeletePods(nse1)
+	// Wait for DST Heal
+	logrus.Infof("Waiting for connection starts recovering...")
+	k8s.WaitLogsContains(nodesSetup[0].Nsmd, "nsmd", "Starting DST Heal...", defaultTimeout)
+	// Delete NSC
+	k8s.DeletePods(nscPodNode)
+
+	// Run NSE and NSC
+	node = affinity["icmp-responder-nse-2"]
+	nse1 = fixture.DeployNse(k8s, nodesSetup[node].Node, "icmp-responder-nse-1", defaultTimeout)
+	nscPodNode = fixture.DeployNsc(k8s, nodesSetup[0].Node, "nsc-1", defaultTimeout)
+
+	fixture.CheckNsc(k8s, nscPodNode)
+}


### PR DESCRIPTION
Signed-off-by: Artem Belov <artem.belov@xored.com>

## Description
Wait until healing state is done before closing connection.
Reduced interval between NetNsInode checks.
Canceling healing context is done in pull request #1932

## Motivation and Context
Healed connection creates duplicated interface: #2015 

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [ ] Covered by existing integration testing
- [x] Added integration testing to cover
- [ ] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
