### PR TITLE
Fix liveness/readiness probe host

### DIFF
--- a/deployments/helm/nsm/templates/nsmgr.tpl
+++ b/deployments/helm/nsm/templates/nsmgr.tpl
@@ -68,6 +68,7 @@ spec:
               mountPath: /var/lib/networkservicemesh/config
           livenessProbe:
             httpGet:
+              host: "127.0.0.1"
               path: /liveness
               port: 5555
             initialDelaySeconds: 10
@@ -75,6 +76,7 @@ spec:
             timeoutSeconds: 3
           readinessProbe:
             httpGet:
+              host: "127.0.0.1"
               path: /readiness
               port: 5555
             initialDelaySeconds: 10


### PR DESCRIPTION
Fix liveness/readiness probe host in helm based deployment

## Motivation and Context
Liveness/readiness probes are executed by default against PodIP, while with current helm installation nsmd is listening for them on localhost:
```
time="2020-01-10T11:24:58Z" level=info msg="Waiting for liveness probe: tcp:127.0.0.1:5000"
```
... what leads to loop like:
```
  Normal   Started    24m (x2 over 25m)    kubelet, node5     Started container nsmd
  Warning  Unhealthy  23m (x4 over 24m)    kubelet, node5     Liveness probe failed: Get http://10.233.70.17:5555/liveness: dial tcp 10.233.70.17:5555: connect: connection refused
  Warning  BackOff    5m6s (x49 over 18m)  kubelet, node5     Back-off restarting failed container
  Warning  Unhealthy  3s (x56 over 25m)    kubelet, node5     Readiness probe failed: Get http://10.233.70.17:5555/readiness: dial tcp 10.233.70.17:5555: connect: connection refused
```

## How Has This Been Tested?
- [ ] Covered by existing integration testing
- [ ] Added integration testing to cover
- [x] Tested locally
- [ ] Have not tested

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
