### PR TITLE
Fix cross-connect metrics mapping

### DIFF
--- a/controlplane/pkg/metrics/helpers.go
+++ b/controlplane/pkg/metrics/helpers.go
@@ -25,10 +25,10 @@ import (
 
 // GetMetricsIdentifiers returns source and destination
 // of the metrics specified with `pod` name and `namespace`
-func GetMetricsIdentifiers(crossConnect *crossconnect.CrossConnect) (map[string]string, error) {
+func GetMetricsIdentifiers(crossConnect *crossconnect.CrossConnect) (string, map[string]string, error) {
 	srcPod, srcNamespace, dstPod, dstNamespace := "", "", "", ""
 	if crossConnect.GetSource() == nil {
-		return nil, errors.Errorf("error: crossConnect should have at least one source, %v", crossConnect)
+		return "", nil, errors.Errorf("error: crossConnect should have at least one source, %v", crossConnect)
 	}
 
 	ccSrcLabels := crossConnect.GetSource().GetLabels()
@@ -36,7 +36,7 @@ func GetMetricsIdentifiers(crossConnect *crossconnect.CrossConnect) (map[string]
 	srcNamespace = ccSrcLabels[connection.NamespaceKey]
 
 	if crossConnect.GetDestination() == nil {
-		return nil, errors.Errorf("error: crossConnect should have at least one destination, %v", crossConnect)
+		return "", nil, errors.Errorf("error: crossConnect should have at least one destination, %v", crossConnect)
 	}
 
 	ccDstLabels := crossConnect.GetDestination().GetLabels()
@@ -50,5 +50,5 @@ func GetMetricsIdentifiers(crossConnect *crossconnect.CrossConnect) (map[string]
 		DstNamespaceKey: dstNamespace,
 	}
 
-	return res, nil
+	return crossConnect.Id, res, nil
 }

--- a/controlplane/pkg/metrics/prometheus.go
+++ b/controlplane/pkg/metrics/prometheus.go
@@ -61,13 +61,13 @@ const (
 	TxErrorPackets = "tx_error_packets"
 
 	// SrcPodKey is vector label for source pod
-	SrcPodKey = "src_pod"
+	SrcPodKey = "src_pod_name"
 	// SrcNamespaceKey is vector label for source pod namespace
-	SrcNamespaceKey = "src_namespace"
+	SrcNamespaceKey = "src_pod_namespace"
 	// DstPodKey is vector label for dest pod
-	DstPodKey = "dst_pod"
+	DstPodKey = "dst_pod_name"
 	// DstNamespaceKey is vector label for dest pod namespace
-	DstNamespaceKey = "dst_namespace"
+	DstNamespaceKey = "dst_pod_namespace"
 )
 
 // PrometheusMetricsContext is metrics context,
@@ -138,12 +138,9 @@ func buildPrometheusMetric(metricType string) PrometheusMetric {
 	if err := prometheus.Register(metricGaugeVec); err != nil {
 		if are, ok := err.(prometheus.AlreadyRegisteredError); ok {
 			metricGaugeVec = are.ExistingCollector.(*prometheus.GaugeVec)
-			logrus.Infof("using already registered vector %v", metricGaugeVec)
 		} else {
 			logrus.Infof("failed to register vector %v, err: %v", metricGaugeVec, err)
 		}
-	} else {
-		logrus.Infof("successfully registered vector %v", metricGaugeVec)
 	}
 
 	res := PrometheusMetric{

--- a/deployments/helm/nsm/charts/admission-webhook/templates/admission-webhook-secret.tpl
+++ b/deployments/helm/nsm/charts/admission-webhook/templates/admission-webhook-secret.tpl
@@ -41,7 +41,7 @@ spec:
             - name: TAG
               value: "{{ .Values.tag }}"
             - name: NSM_NAMESPACE
-              value: "nsm-system"
+              value: "{{ .Values.clientNamespace }}"
             - name: TRACER_ENABLED
               value: {{ .Values.global.JaegerTracing | default false | quote }}
             - name: JAEGER_AGENT_HOST

--- a/deployments/helm/nsm/charts/admission-webhook/values.yaml
+++ b/deployments/helm/nsm/charts/admission-webhook/values.yaml
@@ -7,3 +7,4 @@ registry: docker.io
 org: networkservicemesh
 tag: master
 pullPolicy: IfNotPresent
+clientNamespace: nsm-system

--- a/docs/spec/metrics.md
+++ b/docs/spec/metrics.md
@@ -31,6 +31,15 @@ If you want to track the metrics in Prometheus, you need to apply analogically
 PROMETHEUS=true
 ```
 
+For custom implemented endpoints, you need to wrap the endpoint with pod name mutator in order to make the endpoint pod name visible for the cross-connect monitor, which is responsible for exposing the metrics to Prometheus:
+```
+podName := endpoint.CreatePodNameMutator()
+composite := endpoint.NewCompositeEndpoint(
+	...,
+	endpoint.NewCustomFuncEndpoint("podName", podName),
+)
+```
+
 Port-forward the prometheus-server pod to observe metrics for pod to pod connection:
 ```
 export POD_NAME=$(kubectl get pods --namespace nsm-system -l "app=prometheus-server" -o jsonpath="{.items[0].metadata.name}")

--- a/test/integration/basic_monitor_crossconnect_metrics_test.go
+++ b/test/integration/basic_monitor_crossconnect_metrics_test.go
@@ -220,21 +220,21 @@ func TestGetMetricsIdentifiers(t *testing.T) {
 		},
 	}
 
-	metricsIdentifiers, err := metricspkg.GetMetricsIdentifiers(cc)
+	ccID, metricsIdentifiers, err := metricspkg.GetMetricsIdentifiers(cc)
 	if err != nil {
 		t.Fatalf("failed to get metrics identifier from crossconnect: %v", err)
 	}
 	expectedMetricsIdentifiers := map[string]string{
-		"src_pod":       "icmp-responder-nsc-6475749466-qbcq5",
-		"src_namespace": "nsm-system",
-		"dst_pod":       "icmp-responder-nse-59c456b6d8-c7nc5",
-		"dst_namespace": "nsm-system",
+		"src_pod_name":      "icmp-responder-nsc-6475749466-qbcq5",
+		"src_pod_namespace": "nsm-system",
+		"dst_pod_name":      "icmp-responder-nse-59c456b6d8-c7nc5",
+		"dst_pod_namespace": "nsm-system",
 	}
 
-	if metricsIdentifiers["src_pod"] != expectedMetricsIdentifiers["src_pod"] ||
-		metricsIdentifiers["dst_pod"] != expectedMetricsIdentifiers["dst_pod"] ||
-		metricsIdentifiers["src_namespace"] != expectedMetricsIdentifiers["src_namespace"] ||
-		metricsIdentifiers["dst_namespace"] != expectedMetricsIdentifiers["dst_namespace"] {
+	if metricsIdentifiers["src_pod_name"] != expectedMetricsIdentifiers["src_pod_name"] ||
+		metricsIdentifiers["dst_pod_name"] != expectedMetricsIdentifiers["dst_pod_name"] ||
+		metricsIdentifiers["src_pod_namespace"] != expectedMetricsIdentifiers["src_pod_namespace"] ||
+		metricsIdentifiers["dst_pod_namespace"] != expectedMetricsIdentifiers["dst_pod_namespace"] || ccID != cc.Id {
 		t.Fatalf("failed to correct metrics identifier from crossconnect: want: %v, got: %v",
 			expectedMetricsIdentifiers, metricsIdentifiers)
 	}


### PR DESCRIPTION
A bug was reproduced after testing metrics with the 4g-network example:
cross-connect id did not always map event metrics properly. This change
provides a fix. It also updates the documentatation with more details
how to use metrics observability features

Signed-off-by: Ivana Yovcheva <iyovcheva@vmware.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [x] Covered by existing integration testing
- [ ] Added integration testing to cover
- [x] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
