### PR TITLE
 Fix: Crossconnect monitor example test doesn't wait for events

### DIFF
--- a/scripts/verify_crossconnect_monitor.sh
+++ b/scripts/verify_crossconnect_monitor.sh
@@ -18,7 +18,7 @@ for pod in $MONITORS; do
     echo "===== >>>>> PROCESSING ${pod}  <<<<< ==========="
     marker='src_ip_addr: "172.16.1.1/30"'
     echo -n "Checking that pod's log contains marker string '$marker' ... "
-    if timeout 2m ${kubectl} logs -f "$pod" | grep -q "$marker"; then
+    if timeout 2m kubectl -n "${NSM_NAMESPACE:-default}" logs -f "$pod" | grep -q "$marker"; then
       echo "OK"
     else
       echo "FAIL"

--- a/scripts/verify_crossconnect_monitor.sh
+++ b/scripts/verify_crossconnect_monitor.sh
@@ -18,7 +18,7 @@ for pod in $MONITORS; do
     echo "===== >>>>> PROCESSING ${pod}  <<<<< ==========="
     marker='src_ip_addr: "172.16.1.1/30"'
     echo -n "Checking that pod's log contains marker string '$marker' ... "
-    if ${kubectl} logs "$pod" | grep -q "$marker"; then
+    if timeout 2m ${kubectl} logs -f "$pod" | grep -q "$marker"; then
       echo "OK"
     else
       echo "FAIL"


### PR DESCRIPTION
Signed-off-by: denis-tingajkin <denis.tingajkin@xored.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
Added wait for events


## Motivation and Context
https://circleci.com/gh/networkservicemesh/networkservicemesh/119419
Sometimes Example-helm-crossconnect-monitor can fail.


Expected test behavior: the test waits for events some time.
Actual test behavior on the master branch:  the test doesn't wait for events.

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [ ] Covered by existing integration testing
- [ ] Added integration testing to cover
- [X] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
