### PR TITLE
Fix: TestInterdomainVPNNSCRemote can fail because of some packets loss

### DIFF
--- a/test/integration/interdomain_vpn_test.go
+++ b/test/integration/interdomain_vpn_test.go
@@ -278,7 +278,7 @@ func testInterdomainVPN(t *testing.T, ptnum, clustersCount int, nodesCount int, 
 
 	g.Expect(err).To(BeNil())
 
-	g.Expect(pingResponse).Should(ContainSubstring("10 packets received"))
+	g.Expect(pingResponse).ShouldNot(ContainSubstring("100% packet loss"))
 	logrus.Printf("VPN NSC Ping succeeded:%s", pingResponse)
 
 	_, wgetResponse, err = k8s.Exec(nsc, nscContainerName, "wget", "-O", "/dev/null", "--timeout", "3", "http://"+dstIP+":80")


### PR DESCRIPTION
Signed-off-by: Denis Tingajkin <denis.tingajkin@xored.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
Sometimes VPN interdomain tests can have a packets loss for example:
https://circleci.com/gh/networkservicemesh/networkservicemesh/119534
```
Ping response: PING 172.16.1.2 (172.16.1.2): 56 data bytes\n64 bytes from 172.16.1.2: seq=1 ttl=255 time=35.549 ms\n64 bytes from 172.16.1.2: seq=2 ttl=255 time=34.186 ms\n64 bytes from 172.16.1.2: seq=3 ttl=255 time=33.041 ms\n64 bytes from 172.16.1.2: seq=4 ttl=255 time=37.760 ms\n64 bytes from 172.16.1.2: seq=5 ttl=255 time=36.520 ms\n64 bytes from 172.16.1.2: seq=7 ttl=255 time=36.853 ms\n64 bytes from 172.16.1.2: seq=8 ttl=255 time=36.373 ms\n64 bytes from 172.16.1.2: seq=9 ttl=255 time=36.848 ms\n\n--- 172.16.1.2 ping statistics ---\n11 packets transmitted, 8 packets received, 27% packet loss\nround-trip min/avg/max = 33.041/35.891/37.760 ms\n
```
Looks like we can use not a strict expectation for this case.

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [ ] Covered by existing integration testing
- [ ] Added integration testing to cover
- [ ] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
