### PR TITLE
Fix floating interdomain integration tests

### DIFF
--- a/k8s/pkg/registryserver/nse.go
+++ b/k8s/pkg/registryserver/nse.go
@@ -44,7 +44,7 @@ func newNseRegistryService(nsmName string, cache RegistryCache) *nseRegistryServ
 func (rs *nseRegistryService) RegisterNSE(ctx context.Context, request *registry.NSERegistration) (*registry.NSERegistration, error) {
 	st := time.Now()
 
-	span := spanhelper.FromContext(ctx, "ProxyNsmgr.RegisterNSE")
+	span := spanhelper.FromContext(ctx, "nsmgr.RegisterNSE")
 	defer span.Finish()
 	logger := span.Logger()
 

--- a/test/integration/interdomain_floating_interdomain_die_test.go
+++ b/test/integration/interdomain_floating_interdomain_die_test.go
@@ -115,7 +115,7 @@ func testFloatingInterdomainDie(t *testing.T, clustersCount int, killPod string)
 	}
 
 	icmpPod := kubetest.DeployICMP(k8ss[clustersCount-1].K8s, k8ss[clustersCount-1].NodesSetup[0].Node, "icmp-responder-nse-1", defaultTimeout)
-	k8ss[clustersCount-1].K8s.WaitLogsContains(nsmrsPod, "nsmrs", "Returned from RegisterNSE", defaultTimeout)
+	k8ss[clustersCount-1].K8s.WaitLogsContains(nsmrsPod, "nsmrs", "Registered NSE entry", defaultTimeout)
 
 	nscPodNode := kubetest.DeployNSCWithEnv(k8ss[0].K8s, k8ss[0].NodesSetup[0].Node, "nsc-1", defaultTimeout, map[string]string{
 		"CLIENT_LABELS":          "app=icmp",

--- a/test/integration/interdomain_floating_interdomain_monitor_test.go
+++ b/test/integration/interdomain_floating_interdomain_monitor_test.go
@@ -92,15 +92,15 @@ func testFloatingInterdomainMonitor(t *testing.T, killPod string) {
 	}, k8s.GetK8sNamespace())
 	g.Expect(err).To(BeNil())
 
+	serviceCleanup := kubetest.RunProxyNSMgrService(k8s)
+	defer serviceCleanup()
+
 	k8ss[0].NodesSetup = nodesSetup
 	pnsmdName := fmt.Sprintf("pnsmgr-%s", nodesSetup[0].Node.Name)
 	proxyNSMGRPod := startProxyNSMGRPod(g, pnsmdName, k8s, nodesSetup, nsmrsExternalIP)
 
-	serviceCleanup := kubetest.RunProxyNSMgrService(k8s)
-	defer serviceCleanup()
-
 	kubetest.DeployICMP(k8ss[0].K8s, k8ss[0].NodesSetup[0].Node, "icmp-responder-nse-1", defaultTimeout)
-	k8ss[1].K8s.WaitLogsContains(nsmrsPod, "nsmrs", "Returned from RegisterNSE", defaultTimeout)
+	k8ss[1].K8s.WaitLogsContains(nsmrsPod, "nsmrs", "Registered NSE entry", defaultTimeout)
 
 	switch killPod {
 	case "nsmrs":

--- a/test/integration/interdomain_floating_interdomain_test.go
+++ b/test/integration/interdomain_floating_interdomain_test.go
@@ -92,7 +92,7 @@ func testFloatingInterdomain(t *testing.T, clustersCount int) {
 	}
 
 	_ = kubetest.DeployICMP(k8ss[clustersCount-1].K8s, k8ss[clustersCount-1].NodesSetup[0].Node, "icmp-responder-nse-1", defaultTimeout)
-	k8ss[clustersCount-1].K8s.WaitLogsContains(nsmrsPod, "nsmrs", "Returned from RegisterNSE", defaultTimeout)
+	k8ss[clustersCount-1].K8s.WaitLogsContains(nsmrsPod, "nsmrs", "Registered NSE entry", defaultTimeout)
 
 	nscPodNode := kubetest.DeployNSCWithEnv(k8ss[0].K8s, k8ss[0].NodesSetup[0].Node, "nsc-1", defaultTimeout, map[string]string{
 		"CLIENT_LABELS":          "app=icmp",


### PR DESCRIPTION
Signed-off-by: Artem Belov <artem.belov@xored.com>

## Description
In integration tests proxy-nsmgr k8s service starting not instantly. So RegisterNSE request may be rejected. Added checking for BulkRegisterNSE request result to verify NSE registration.

## Motivation and Context
#2077 

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [x] Covered by existing integration testing
- [ ] Added integration testing to cover
- [ ] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
