### PR TITLE
fix: cluster initialization failure ignored

### DIFF
--- a/scripts/prepare-cluster.sh
+++ b/scripts/prepare-cluster.sh
@@ -1,15 +1,5 @@
 #!/bin/bash
 
-set -x
-
-function prepare() {
-  echo "Preparing cluster..."
-
-  make helm-init
-  make helm-install-config
-  make spire-install
-}
-
 # workaround for https://github.com/helm/helm/issues/6361:
 function delete_unavailable_apiservice() {
   for service in $(kubectl get apiservice | grep False | awk '{print $1}'); do
@@ -18,7 +8,21 @@ function delete_unavailable_apiservice() {
   done
 }
 
-if ! prepare; then
-  delete_unavailable_apiservice
-  prepare
+function has_unavailable_apiservice() {
+  kubectl get apiservice | grep False
+}
+
+if has_unavailable_apiservice; then
+  echo "Unavailable Kubernetes services detected, trying to wait when there are none..."
+  if timeout 180s bash -c "while kubectl get apiservice | grep -q False; do sleep 10; echo 'tick'; done"; then
+    echo "Success!"
+  else
+    echo "There still might be some services left:"
+    has_unavailable_apiservice
+    echo "Last resort: removing unavailable services.."
+    delete_unavailable_apiservice
+  fi
 fi
+
+echo "Preparing cluster..."
+make helm-init helm-install-config spire-install


### PR DESCRIPTION
fix for #2086 

Additionally, a waiting is added for unavailable services to become available, which prevents helm initialization errors on GKE, like here: 
https://120466-127937836-gh.circle-artifacts.com/0/home/circleci/project/.tests/cloud_test/gke-3/003-prepare.log

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [x] Covered by existing integration testing
- [ ] Added integration testing to cover
- [ ] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
