### PR TITLE
2 clients and 1 endpoint in vpp-icmp-responder, icmp-responder Helm charts

### DIFF
--- a/deployments/helm/client/templates/nsc.tpl
+++ b/deployments/helm/client/templates/nsc.tpl
@@ -5,13 +5,23 @@ spec:
   selector:
     matchLabels:
       networkservicemesh.io/app: "icmp-responder-nsc"
-  replicas: 4
+  replicas: 2
   template:
     metadata:
       labels:
         networkservicemesh.io/app: "icmp-responder-nsc"
     spec:
       serviceAccount: nsc-acc
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: networkservicemesh.io/app
+                    operator: In
+                    values:
+                      - icmp-responder-nsc
+              topologyKey: "kubernetes.io/hostname"
       containers:
         - name: alpine-img
           image: alpine:latest

--- a/deployments/helm/endpoint/templates/icmp-responder-nse.tpl
+++ b/deployments/helm/endpoint/templates/icmp-responder-nse.tpl
@@ -6,7 +6,7 @@ spec:
     matchLabels:
       networkservicemesh.io/app: "icmp-responder"
       networkservicemesh.io/impl: "icmp-responder"
-  replicas: 2
+  replicas: 1
   template:
     metadata:
       labels:
@@ -14,20 +14,6 @@ spec:
         networkservicemesh.io/impl: "icmp-responder"
     spec:
       serviceAccount: nse-acc
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            - labelSelector:
-                matchExpressions:
-                  - key: networkservicemesh.io/app
-                    operator: In
-                    values:
-                      - icmp-responder
-                  - key: networkservicemesh.io/impl
-                    operator: In
-                    values:
-                      - icmp-responder
-              topologyKey: "kubernetes.io/hostname"
       containers:
         - name: icmp-responder-nse
           image: {{ .Values.registry }}/{{ .Values.org }}/test-common:{{ .Values.tag}}

--- a/deployments/helm/vpp-icmp-responder/templates/vpp-icmp-responder-nsc.tpl
+++ b/deployments/helm/vpp-icmp-responder/templates/vpp-icmp-responder-nsc.tpl
@@ -15,6 +15,16 @@ spec:
     spec:
       hostPID: true
       serviceAccount: nsc-acc
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: networkservicemesh.io/app
+                    operator: In
+                    values:
+                      - vppagent-nsc
+              topologyKey: "kubernetes.io/hostname"
       containers:
         - name: vppagent-nsc
           image: {{ .Values.registry }}/{{ .Values.org }}/vpp-test-common:{{ .Values.tag }}

--- a/deployments/helm/vpp-icmp-responder/templates/vpp-icmp-responder-nse.tpl
+++ b/deployments/helm/vpp-icmp-responder/templates/vpp-icmp-responder-nse.tpl
@@ -6,7 +6,7 @@ spec:
     matchLabels:
       networkservicemesh.io/app: "icmp-responder"
       networkservicemesh.io/impl: "vppagent-icmp-responder"
-  replicas: 2
+  replicas: 1
   template:
     metadata:
       labels:
@@ -14,20 +14,6 @@ spec:
         networkservicemesh.io/impl: "vppagent-icmp-responder"
     spec:
       serviceAccount: nse-acc
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            - labelSelector:
-                matchExpressions:
-                  - key: networkservicemesh.io/app
-                    operator: In
-                    values:
-                      - icmp-responder
-                  - key: networkservicemesh.io/impl
-                    operator: In
-                    values:
-                      - vppagent-icmp-responder
-              topologyKey: "kubernetes.io/hostname"
       containers:
         - name: icmp-responder-nse
           image: {{ .Values.registry }}/{{ .Values.org }}/vpp-test-common:{{ .Values.tag }}


### PR DESCRIPTION
Clients are deployed into different nodes using anti-affinity to ensure
both remote and local connection cases are covered.

see  #2056 for details.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [x] Covered by existing integration testing
- [ ] Added integration testing to cover
- [ ] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
