### PR TITLE
Add retest pattern for docker.io request timeout

### DIFF
--- a/.cloudtest.yaml
+++ b/.cloudtest.yaml
@@ -25,6 +25,7 @@ retest:  # Allow to do test re-run if some kind of failures are detected, line C
     - "unable to establish connection to VPP (VPP API socket file /run/vpp/api.sock does not exist)"  # a VPP is not started, it will be re-started in general, but will cause test fail.
     # Sometimes (rarely) docker registry is unavailable for a moment
     - "Error response from daemon: Get https://.*docker.io/.*: dial tcp: lookup registry"
+    - "Error response from daemon: Get https://.*docker.io/.*: net/http: request canceled while waiting for connection"
 reporting:
   junit-report: "results/junit.xml"
 health-check:


### PR DESCRIPTION
Signed-off-by: Artem Belov <artem.belov@xored.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
Add cloudtest retest pattern
`Error response from daemon: Get https://.*docker.io/.*: net/http: request canceled while waiting for connection`

## Motivation and Context
#2068

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [ ] Covered by existing integration testing
- [ ] Added integration testing to cover
- [ ] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
