### PR TITLE
Fix azure

### DIFF
--- a/.cloudtest/azure.yaml
+++ b/.cloudtest/azure.yaml
@@ -6,7 +6,7 @@ providers:
     instances: 6
     retry: 5
     node-count: 2
-    enabled: false
+    enabled: true
     timeout: 3600  # 30 minutes to start cluster
     env:
       - CLUSTER_RULES_PREFIX=azure


### PR DESCRIPTION
many Azure tests fail with error:
`Timeout during waiting for pod change status for pod icmp-responder-nse-1 [{PodScheduled False 0001-01-01 00:00:00 +0000 UTC 2020-02-11 09:01:36 +0000 UTC Unschedulable 0/2 nodes are available: 1 node(s) didn't match node selector, 2 Insufficient networkservicemesh.io/socket.}`

#2106 

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [ ] Covered by existing integration testing
- [ ] Added integration testing to cover
- [ ] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
