### PR TITLE
Fix aws cluster deleting

### DIFF
--- a/scripts/aws/destroy-kubernetes-cluster.go
+++ b/scripts/aws/destroy-kubernetes-cluster.go
@@ -145,11 +145,16 @@ func (ac *AWSCluster) deleteEksClusterVpc(cfClient *cloudformation.CloudFormatio
 	stackId := resp.Stacks[0].StackId
 
 	_, err = cfClient.DeleteStack(&cloudformation.DeleteStackInput{
-		StackName:       clusterStackName,
-		RetainResources: []*string{aws.String("Ipv6VPCCidrBlock")},
+		StackName: clusterStackName,
 	})
-	if ac.checkDeferError(err) {
-		return
+	if err != nil {
+		_, err = cfClient.DeleteStack(&cloudformation.DeleteStackInput{
+			StackName:       clusterStackName,
+			RetainResources: []*string{aws.String("Ipv6VPCCidrBlock")},
+		})
+		if ac.checkDeferError(err) {
+			return
+		}
 	}
 
 	for {


### PR DESCRIPTION
Signed-off-by: Artem Belov <artem.belov@xored.com>

## Description
First run `DeleteStack` attempt without `RetainResources` parameter  

## Motivation and Context
`RetainResources` parameter of `DeleteStack` request does not supported while cluster in `Failed` state

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [ ] Covered by existing integration testing
- [ ] Added integration testing to cover
- [x] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
