### PR TITLE
Revert "Temporarily disable testing on Azure (#2109)"

### DIFF
--- a/.cloudtest/azure.yaml
+++ b/.cloudtest/azure.yaml
@@ -6,7 +6,7 @@ providers:
     instances: 6
     retry: 5
     node-count: 2
-    enabled: false
+    enabled: true
     timeout: 3600  # 30 minutes to start cluster
     env:
       - CLUSTER_RULES_PREFIX=azure


### PR DESCRIPTION
This reverts commit 2810d98ce9b4c7ca82c937567b0818702dca6f52.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
Looks like the problem with device plugin on azure clusters is fixed and we can enable azure.
https://github.com/networkservicemesh/networkservicemesh/issues/2106

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [ ] Covered by existing integration testing
- [ ] Added integration testing to cover
- [ ] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
