### PR TITLE
Define variable PREFERRED_REMOTE_MECHANISM for nsmd container

### DIFF
--- a/deployments/helm/nsm/templates/nsmgr.tpl
+++ b/deployments/helm/nsm/templates/nsmgr.tpl
@@ -51,6 +51,8 @@ spec:
               value: jaeger.nsm-system
             - name: JAEGER_AGENT_PORT
               value: "6831"
+            - name: PREFERRED_REMOTE_MECHANISM
+              value: {{ .Values.preferredRemoteMechanism | quote }}
           volumeMounts:
             - name: nsm-socket
               mountPath: /var/lib/networkservicemesh


### PR DESCRIPTION
## Description

Define variable PREFERRED_REMOTE_MECHANISM for nsmd container (in addition to nsmdp)

## Motivation and Context

According to our tests, the variable `PREFERRED_REMOTE_MECHANISM` is also used by the `nsmd` container.

 Whether the `nsmdp` container actually uses the variable, has not been tested by us.

## How Has This Been Tested?

- [ ] Covered by existing integration testing
- [ ] Added integration testing to cover
- [x] Tested locally
- [ ] Have not tested


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
