### PR TITLE
Trimming possible leading spaces from network service name

### DIFF
--- a/pkg/tools/tools.go
+++ b/pkg/tools/tools.go
@@ -177,7 +177,7 @@ type NSUrl struct {
 
 func parseNSUrl(urlString string) (*NSUrl, error) {
 	result := &NSUrl{}
-
+	// Remove possible leading spaces from network service name
 	urlString = strings.Trim(urlString, " ")
 	url, err := url.Parse(urlString)
 	if err != nil {
@@ -193,7 +193,6 @@ func parseNSUrl(urlString string) (*NSUrl, error) {
 		}
 		result.Intf = path[1]
 	}
-	// Remove possible leading spaces from network service name
 	result.NsName = path[0]
 	result.Params = url.Query()
 	return result, nil

--- a/pkg/tools/tools.go
+++ b/pkg/tools/tools.go
@@ -192,7 +192,8 @@ func parseNSUrl(urlString string) (*NSUrl, error) {
 		}
 		result.Intf = path[1]
 	}
-	result.NsName = path[0]
+	// Remove possible leading spaces from network service name
+	result.NsName = strings.Trim(path[0], " ")
 	result.Params = url.Query()
 	return result, nil
 }

--- a/pkg/tools/tools.go
+++ b/pkg/tools/tools.go
@@ -178,6 +178,7 @@ type NSUrl struct {
 func parseNSUrl(urlString string) (*NSUrl, error) {
 	result := &NSUrl{}
 
+	urlString = strings.Trim(urlString, " ")
 	url, err := url.Parse(urlString)
 	if err != nil {
 		return nil, err
@@ -193,7 +194,7 @@ func parseNSUrl(urlString string) (*NSUrl, error) {
 		result.Intf = path[1]
 	}
 	// Remove possible leading spaces from network service name
-	result.NsName = strings.Trim(path[0], " ")
+	result.NsName = path[0]
 	result.Params = url.Query()
 	return result, nil
 }


### PR DESCRIPTION
Signed-off-by: Serguei Bezverkhi <sbezverk@cisco.com>


## Description
In some cases for better readability requested network service annotations can be specified in this form:
```
ns.networkservicemesh.io: l3vpnnse/vrf_red?vpn=100:100, l3vpnnse/vrf_blue?vpn=101:101, l3vpnnse/vrf_green?vpn=105:105
``` 
Currently In this case leading space, is considered as a part of the name and as a result request to find such name fails. It is very difficult to spot in the error message because the output is not quoted.

```
time="2020-06-21T12:38:32Z" level=error msg="nsm client: Failed to connect rpc error: code = Unknown desc = NSM:(7.1.5) <nil>. Last NSE Error: rpc error: code = Unknown desc = no NetworkService with name:  l3vpnnse. Retry attempts: 9 Delaying: 5s" operation="nsmClient.Connect.attempt:1" span="{}"
```
## Motivation and Context

Adding Trim function for the network service names prevent this issue to occur.

## How Has This Been Tested?

- [X ] Covered by existing integration testing
- [ ] Added integration testing to cover
- [ X] Tested locally
- [ ] Have not tested

## Types of changes
- [ X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
