### PR TITLE
fix: Use a concrete version of cloud testing tool to avoid problems with updating

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -160,7 +160,7 @@ jobs:
               export ARTIFACTS_SAVE_ALWAYS=true
             fi
             pushd test
-            go get github.com/networkservicemesh/cloudtest
+            go get github.com/networkservicemesh/cloudtest@v0.2.0
             popd
             cloudtest || ERR=$?
             [ "${CIRCLE_BRANCH}" == "master" ] && [ "$ERR" == "" ] && exit 0


### PR DESCRIPTION
Signed-off-by: Denis Tingajkin <denis.tingajkin@xored.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description

## Motivation and Context
We are planning to update cloudtest with these issues:
https://github.com/networkservicemesh/cloudtest/issues/34
https://github.com/networkservicemesh/cloudtest/issues/35
https://github.com/networkservicemesh/cloudtest/issues/33

So it looks like we need at first fix up version of cloudtest on ci to avoid potential new problems.
## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [ ] Covered by existing integration testing
- [ ] Added integration testing to cover
- [ ] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
