### PR TITLE
fix: wireguard device logger prefix shouldn't confuse

### DIFF
--- a/forwarder/kernel-forwarder/pkg/kernelforwarder/remote/wireguard.go
+++ b/forwarder/kernel-forwarder/pkg/kernelforwarder/remote/wireguard.go
@@ -131,7 +131,7 @@ func createWireguardDevice(ifaceName string) (*device.Device, error) {
 		return nil, errors.Errorf("failed to create tun: %v", err)
 	}
 
-	logger := device.NewLogger(device.LogLevelDebug, fmt.Sprintf("Wireguard Error (%s): ", ifaceName))
+	logger := device.NewLogger(device.LogLevelDebug, fmt.Sprintf("Wireguard Device (%s): ", ifaceName))
 	return device.NewDevice(tunIface, logger), nil
 }
 


### PR DESCRIPTION
Signed-off-by: Denis Tingajkin <denis.tingajkin@xored.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
Currently, we are using the wrong prefix in wireguard device logger that can confuse the users/developers. For example, all wireguard device entries in logs start with string `Wireguard Error `

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [ ] Covered by existing integration testing
- [ ] Added integration testing to cover
- [ ] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
