### PR TITLE
Fix GW address assignment for kernel-forwarded NSE

### DIFF
--- a/forwarder/vppagent/pkg/converter/kernel_connection_converter.go
+++ b/forwarder/vppagent/pkg/converter/kernel_connection_converter.go
@@ -161,11 +161,14 @@ func (c *KernelConnectionConverter) ToDataRequest(rv *configurator.Config, conne
 
 	// Process static routes
 	var routes []*connectioncontext.Route
+	var ipAddress string
 	switch c.conversionParameters.Side {
 	case SOURCE:
 		routes = c.Connection.GetContext().GetIpContext().GetDstRoutes()
+		ipAddress = extractCleanIPAddress(c.Connection.GetContext().GetIpContext().GetDstIpAddr())
 	case DESTINATION:
 		routes = c.Connection.GetContext().GetIpContext().GetSrcRoutes()
+		ipAddress = extractCleanIPAddress(c.Connection.GetContext().GetIpContext().GetSrcIpAddr())
 	}
 
 	duplicatedPrefixes := make(map[string]bool)
@@ -176,7 +179,7 @@ func (c *KernelConnectionConverter) ToDataRequest(rv *configurator.Config, conne
 				DstNetwork:        route.Prefix,
 				OutgoingInterface: c.conversionParameters.Name,
 				Scope:             linux_l3.Route_GLOBAL,
-				GwAddr:            extractCleanIPAddress(c.Connection.GetContext().GetIpContext().GetDstIpAddr()),
+				GwAddr:            ipAddress,
 			})
 		}
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This change fixes the gateway address assignment for kernel-forwarded NS Endpoint.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes https://github.com/networkservicemesh/networkservicemesh/issues/2179 .

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [x] Covered by existing integration testing
- [ ] Added integration testing to cover
- [x] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
