### PR TITLE
Put limits on containers created by admission-webhook

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -155,6 +155,7 @@ jobs:
             export CONTAINER_TAG="ci_${CIRCLE_WORKFLOW_ID}_${CIRCLE_SHA1:8:8}"
             export REPO="networkservicemeshci"
             export CONTAINER_REPO=${REPO}
+            export ENFORCE_LIMITS="true"
             echo "CONTAINER_REPO=${CONTAINER_REPO}"
             if [ "${CIRCLE_BRANCH}" == "master" ]; then
               export ARTIFACTS_SAVE_ALWAYS=true

--- a/.mk/helm.mk
+++ b/.mk/helm.mk
@@ -20,6 +20,7 @@ HELM_TIMEOUT?=300
 INSECURE?=false
 PROMETHEUS?=true
 METRICS_COLLECTOR_ENABLED?=true
+ENFORCE_LIMITS?=false
 
 TEST_OPTS:=--atomic \
   --set org='${CONTAINER_REPO}',tag='${CONTAINER_TAG}' \
@@ -31,7 +32,7 @@ TEST_OPTS:=--atomic \
   --set metricsCollectorEnabled='${METRICS_COLLECTOR_ENABLED}' \
   --set global.JaegerTracing='true' \
   --set spire.enabled='${SPIRE_ENABLED}',spire.org='${CONTAINER_REPO}',spire.tag='${CONTAINER_TAG}' \
-  --set admission-webhook.org='${CONTAINER_REPO}',admission-webhook.tag='${CONTAINER_TAG}' \
+  --set admission-webhook.org='${CONTAINER_REPO}',admission-webhook.tag='${CONTAINER_TAG}',admission-webhook.enforceLimits='${ENFORCE_LIMITS}' \
   --set prefix-service.org='${CONTAINER_REPO}',prefix-service.tag='${CONTAINER_TAG}' \
   --namespace '${NSM_NAMESPACE}'
 

--- a/deployments/helm/nsm/charts/admission-webhook/templates/admission-webhook-secret.tpl
+++ b/deployments/helm/nsm/charts/admission-webhook/templates/admission-webhook-secret.tpl
@@ -48,6 +48,8 @@ spec:
               value: jaeger.nsm-system
             - name: JAEGER_AGENT_PORT
               value: "6831"
+            - name: ENFORCE_LIMITS
+              value: {{ .Values.enforceLimits | quote }}
           volumeMounts:
             - name: webhook-certs
               mountPath: /etc/webhook/certs

--- a/deployments/helm/nsm/charts/admission-webhook/values.yaml
+++ b/deployments/helm/nsm/charts/admission-webhook/values.yaml
@@ -8,3 +8,4 @@ org: networkservicemesh
 tag: master
 pullPolicy: IfNotPresent
 clientNamespace: nsm-system
+enforceLimits: false

--- a/k8s/cmd/admission-webhook/const.go
+++ b/k8s/cmd/admission-webhook/const.go
@@ -18,6 +18,7 @@ const (
 	tracerEnabledEnv        = "TRACER_ENABLED"
 	jaegerHostEnv           = "JAEGER_AGENT_HOST"
 	jaegerPortEnv           = "JAEGER_AGENT_PORT"
+	enforceLimitsEnv        = "ENFORCE_LIMITS"
 	repoDefault             = "networkservicemesh"
 	initContainerDefault    = "nsm-init"
 	dnsInitContainerDefault = "nsm-dns-init"
@@ -32,4 +33,18 @@ const (
 	volumePath              = "/spec/volumes"
 	containersPath          = "/spec/containers"
 	defaultPort             = 443
+
+	// Keep in sync with ../../../test/kubetest/pods/limits.go.
+	// Limits for 'nsm-monitor' container.
+	nsmMonitorCPULimit    = "100m"
+	nsmMonitorMemoryLimit = "15Mi"
+	// Limits for 'coredns' container.
+	corednsCPULimit    = "100m"
+	corednsMemoryLimit = "15Mi"
+	// Limits for 'nsm-init' container.
+	nsmInitCPULimit    = "500m"
+	nsmInitMemoryLimit = "20Mi"
+	// Limits for 'nsm-dns-init' container.
+	nsmDNSInitCPULimit    = "500m"
+	nsmDNSInitMemoryLimit = "15Mi"
 )

--- a/k8s/cmd/admission-webhook/main.go
+++ b/k8s/cmd/admission-webhook/main.go
@@ -99,3 +99,7 @@ func getJaegerHost() string {
 func getJaegerPort() string {
 	return os.Getenv(jaegerPortEnv)
 }
+
+func getEnforceLimits() bool {
+	return utils.EnvVar(enforceLimitsEnv).GetBooleanOrDefault(false)
+}

--- a/k8s/cmd/admission-webhook/mutate.go
+++ b/k8s/cmd/admission-webhook/mutate.go
@@ -27,8 +27,9 @@ func (s *nsmAdmissionWebhook) mutate(request *v1beta1.AdmissionRequest) *v1beta1
 	if err = checkNsmInitContainerDuplication(metaAndSpec.spec); err != nil {
 		return errorReviewResponse(err)
 	}
-	patch := createNsmInitContainerPatch(metaAndSpec.spec.InitContainers, value)
-	patch = append(patch, createDNSPatch(metaAndSpec, value)...)
+	imposeLimits := needToImposeLimits(metaAndSpec)
+	patch := createNsmInitContainerPatch(metaAndSpec.spec.InitContainers, value, imposeLimits)
+	patch = append(patch, createDNSPatch(metaAndSpec, value, imposeLimits)...)
 	//append another patches
 	applyDeploymentKind(patch, request.Kind.Kind)
 	patchBytes, err := json.Marshal(patch)

--- a/test/kubetest/pods/common.go
+++ b/test/kubetest/pods/common.go
@@ -28,6 +28,20 @@ const (
 	NSMRSServiceAccount = "nsmrs-acc"
 	// ForwardPlaneServiceAccount service account for Forwarding Plane
 	ForwardPlaneServiceAccount = "forward-plane-acc"
+
+	// Keep in sync with ../../../k8s/cmd/admission-webhook/const.go.
+	// Limits for 'nsm-monitor' container.
+	nsmMonitorCPULimit    = "100m"
+	nsmMonitorMemoryLimit = "15Mi"
+	// Limits for 'coredns' container.
+	corednsCPULimit    = "100m"
+	corednsMemoryLimit = "15Mi"
+	// Limits for 'nsm-init' container.
+	nsmInitCPULimit    = "500m"
+	nsmInitMemoryLimit = "20Mi"
+	// Limits for 'nsm-dns-init' container.
+	nsmDNSInitCPULimit    = "500m"
+	nsmDNSInitMemoryLimit = "15Mi"
 )
 
 // ForwardingPlane - Wrapper for getting a forwarding plane pod

--- a/test/kubetest/pods/coredns_injection.go
+++ b/test/kubetest/pods/coredns_injection.go
@@ -17,6 +17,8 @@ func InjectCorednsWithSharedFolder(template *v1.Pod) {
 			Resources: v1.ResourceRequirements{
 				Limits: v1.ResourceList{
 					"networkservicemesh.io/socket": resource.NewQuantity(1, resource.DecimalSI).DeepCopy(),
+					v1.ResourceCPU:                 resource.MustParse(corednsCPULimit),
+					v1.ResourceMemory:              resource.MustParse(corednsMemoryLimit),
 				},
 			},
 			VolumeMounts: []v1.VolumeMount{{
@@ -58,6 +60,8 @@ func InjectCoredns(pod *v1.Pod, corednsConfigName string) *v1.Pod {
 			Resources: v1.ResourceRequirements{
 				Limits: v1.ResourceList{
 					"networkservicemesh.io/socket": resource.NewQuantity(1, resource.DecimalSI).DeepCopy(),
+					v1.ResourceCPU:                 resource.MustParse(corednsCPULimit),
+					v1.ResourceMemory:              resource.MustParse(corednsMemoryLimit),
 				},
 			},
 		})

--- a/test/kubetest/pods/nsc.go
+++ b/test/kubetest/pods/nsc.go
@@ -68,6 +68,12 @@ func WrongNSCPodWebhook(name string, node *v1.Node) *v1.Pod {
 					Name:            "nsm-init",
 					Image:           "nsm-init:latest",
 					ImagePullPolicy: v1.PullIfNotPresent,
+					Resources: v1.ResourceRequirements{
+						Limits: v1.ResourceList{
+							v1.ResourceCPU:    resource.MustParse(nsmInitCPULimit),
+							v1.ResourceMemory: resource.MustParse(nsmInitMemoryLimit),
+						},
+					},
 				},
 			},
 		},
@@ -138,6 +144,8 @@ func newDNSInitContainer(env map[string]string) v1.Container {
 		Resources: v1.ResourceRequirements{
 			Limits: v1.ResourceList{
 				"networkservicemesh.io/socket": resource.NewQuantity(1, resource.DecimalSI).DeepCopy(),
+				v1.ResourceCPU:                 resource.MustParse(nsmDNSInitCPULimit),
+				v1.ResourceMemory:              resource.MustParse(nsmDNSInitMemoryLimit),
 			},
 		},
 		VolumeMounts: []v1.VolumeMount{{
@@ -164,6 +172,8 @@ func newInitContainer(env map[string]string) v1.Container {
 		Resources: v1.ResourceRequirements{
 			Limits: v1.ResourceList{
 				"networkservicemesh.io/socket": resource.NewQuantity(1, resource.DecimalSI).DeepCopy(),
+				v1.ResourceCPU:                 resource.MustParse(nsmInitCPULimit),
+				v1.ResourceMemory:              resource.MustParse(nsmInitMemoryLimit),
 			},
 		},
 	})
@@ -184,6 +194,8 @@ func newMonitorContainer(env map[string]string) v1.Container {
 		Resources: v1.ResourceRequirements{
 			Limits: v1.ResourceList{
 				"networkservicemesh.io/socket": resource.NewQuantity(1, resource.DecimalSI).DeepCopy(),
+				v1.ResourceCPU:                 resource.MustParse(nsmMonitorCPULimit),
+				v1.ResourceMemory:              resource.MustParse(nsmMonitorMemoryLimit),
 			},
 		},
 	})


### PR DESCRIPTION
## Description

Make the Admission Webhook assign a hardcoded set of limits to the containers it creates if the original pod matches the requirements of the Guaranteed QoS class.

Use the following set of limits:
|Container image        | Memory|   CPU|
|-----------------|------:|-----:|
|`nsm-monitor`| `15Mi`|`100m`|
|`coredns`        |`15Mi`|`100m`|
|`nsm-init`       |`20Mi`|`500m`|
|`nsm-dns-init`   |`15Mi`|`500m`|

Also, to prove that these limits are sufficient, impose them on the CI tests unconditionally (including the containers created directly rather than by the Admission Webhook).

## Motivation and Context

Closes #2187.

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [x] Covered by existing integration testing
- [ ] Added integration testing to cover
- [ ] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
