### PR TITLE
fix: Increase connect time for TestInterdomainKernelForwarderWireguard

### DIFF
--- a/sdk/client/client.go
+++ b/sdk/client/client.go
@@ -40,7 +40,7 @@ import (
 
 const (
 	// ConnectTimeout - a default connection timeout
-	ConnectTimeout = 15 * time.Second
+	ConnectTimeout = time.Minute
 	// ConnectionRetry - A number of retries for establish a network service, default == 10
 	ConnectionRetry = 10
 	// RequestDelay - A delay between attempts, default = 5sec


### PR DESCRIPTION
Signed-off-by: Denis Tingajkin <denis.tingajkin@xored.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
It looks like creating of wireguard device can take time more than the client expected in case of interdomain
https://github.com/networkservicemesh/networkservicemesh/issues/2198

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [X] Covered by existing integration testing
- [ ] Added integration testing to cover
- [ ] Tested locally
- [X] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
