### PR TITLE
Update Kind setup instructions

### DIFF
--- a/docs/guide-build.md
+++ b/docs/guide-build.md
@@ -32,7 +32,7 @@ And if you are using the Kind machinery to run your K8s cluster (described a bit
 make k8s-save
 ```
 
-because ```make k8s-save``` will build your containers and save them in `scripts/vagrant/images` where they can be loaded by the Kins K8s cluster.
+because ```make k8s-save``` will build your containers and save them in `scripts/vagrant/images` where they can be loaded by the Kind K8s cluster.
 
 You can also selectively rebuild any component, say the `nsmd`, with ```make k8s-nsmd-save```
 

--- a/scripts/kind.yaml
+++ b/scripts/kind.yaml
@@ -1,6 +1,6 @@
 ---
 kind: Cluster
-apiVersion: kind.sigs.k8s.io/v1alpha3
+apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
   - role: control-plane
   - role: worker


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
The instructions provided by [this guide](https://github.com/networkservicemesh/networkservicemesh/blob/master/docs/guide-build.md#install) seems to be out of dated.

## Description
- KinD has [dropped](https://github.com/kubernetes-sigs/kind/commit/3abbcbbb99cec020a052c97eeaf427229b7514ac) `v1alpha3`
- `SPIRE_ENABLED` and `--spire_enabled` aren't validated in the `helm-nsm-install.sh` script.
- `NSM_NAMESPACE` uses `nsm-system` as default value which is not created.
-  `SPIRE_ENABLED` is enabled by default

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
These changes allow the creation and installation of a KinD cluster.

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [ ] Covered by existing integration testing
- [ ] Added integration testing to cover
- [x] Tested locally
- [ ] Have not tested
<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
