### PR TITLE
Update SPIRE to version 0.11.3

### DIFF
--- a/deployments/helm/nsm/charts/spire/Chart.yaml
+++ b/deployments/helm/nsm/charts/spire/Chart.yaml
@@ -3,4 +3,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Kubernetes
 name: spire
-version: 0.1.0
+version: 0.11.3

--- a/deployments/helm/nsm/charts/spire/templates/server-statefulset.tpl
+++ b/deployments/helm/nsm/charts/spire/templates/server-statefulset.tpl
@@ -33,7 +33,7 @@ spec:
               readOnly: true
 
         - name: spire-server
-          image: gcr.io/spiffe-io/spire-server:0.11.0
+          image: gcr.io/spiffe-io/spire-server:0.11.3
           args:
             - -config
             - /run/spire/config/server.conf


### PR DESCRIPTION
SPIRE 0.11.0 has two new CVEs, discovered during a CNCF security audit. While I believe neither of them affects NSM's use case, it should still be fixed. 

SPIRE 0.11.3 should be API-identical to SPIRE 0.11.0.

Links to security advisories:
https://github.com/spiffe/spire/security/advisories/GHSA-q7gm-mjrg-44h9
https://github.com/spiffe/spire/security/advisories/GHSA-h746-rm5q-8mgq

Signed-off-by: Daniel Feldman <daniel@scytale.io>
