### PR TITLE
Fix #2245 Create NSM_NAMESPACE if missing on helm-install-nsm

### DIFF
--- a/scripts/helm-nsm-install.sh
+++ b/scripts/helm-nsm-install.sh
@@ -152,7 +152,7 @@ fi
 
 if (! kubectl get namespace | grep -q "$NSM_NAMESPACE" ); then
   echo "Creating namespace: $NSM_NAMESPACE"
-  kubectl create namespace $NSM_NAMESPACE
+  kubectl create namespace "$NSM_NAMESPACE"
 fi
 
 set -o xtrace

--- a/scripts/helm-nsm-install.sh
+++ b/scripts/helm-nsm-install.sh
@@ -150,6 +150,11 @@ else
   exit 1
 fi
 
+if (! kubectl get namespace | grep -q "$NSM_NAMESPACE" ); then
+  echo "Creating namespace: $NSM_NAMESPACE"
+  kubectl create namespace $NSM_NAMESPACE
+fi
+
 set -o xtrace
 # shellcheck disable=SC2086
 $HELM install $VERSION_SPECIFIC_OPTS \


### PR DESCRIPTION
## Description

This change fixes issue #2245 . It updates the helm-nsm-install script to create the NSM_NAMESPACE if it does not already exist. Helm no longer will create namespaces if they don't exist, and so this is required so that the install that happens later in the script does not fail.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

See issue #2245 . This fixes an error that can be encountered when running `make helm-install-nsm`

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [ ] Covered by existing integration testing
- [ ] Added integration testing to cover
- [x] Tested locally
- [ ] Have not tested

Tested locally by deleting the `nsm-system` namespace, then by running `make helm-install-nsm`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

Unless there are docs I didn't see for this script, I think this is fine?