### PR TITLE
Modified title to show AWS instead of GCP

### DIFF
--- a/docs/guide-aws.md
+++ b/docs/guide-aws.md
@@ -1,4 +1,4 @@
-# Register inside Google Cloud Platform
+# Register inside AWS (Amazon Web Services)
 
 ## Create New Access Key
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The document title said to register inside GCP while we are in the AWS guide.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The document is about AWS and GCP is mentioned at its place.
It solves incoherence between title and real context

<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Select all that apply from the options below. -->
- [ ] Covered by existing integration testing
- [ ] Added integration testing to cover
- [ ] Tested locally
- [ X ] Have not tested
<!--- Add additional comments about testing if needed. -->
Test not really necessary. It is a small change in the documentation. All tests should pass as before.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ X ] My change requires a change to the documentation.
- [ X ] I have updated the documentation accordingly.
